### PR TITLE
[codex] Harden authentication and repository operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,18 @@
 # GitHub OAuth Configuration
 # Register a new OAuth App at https://github.com/settings/applications/new
 # Homepage URL: http://localhost:8080
-# Authorization callback URL: http://localhost:8080/auth/callback
+# Authorization callback URL: http://localhost:8080/admin/auth/callback
 
 GITHUB_CLIENT_ID=your_client_id_here
 GITHUB_CLIENT_SECRET=your_client_secret_here
-SESSION_SECRET=random_string_for_cookie_encryption
+SESSION_SECRET=replace_with_at_least_32_random_characters
 
 # Security Settings
 # Comma-separated list of GitHub usernames allowed to access the CMS
-# Leave empty to allow all authenticated GitHub users
-ALLOWED_GITHUB_USERS=
-# CSRF secret for token generation (optional, will be auto-generated if not set)
-CSRF_SECRET=
+# Required by default in every environment
+ALLOWED_GITHUB_USERS=your_github_username
+# Explicit development-only override. Never enable this in production.
+ALLOW_ALL_GITHUB_USERS=false
 # GitHub OAuth scopes (comma-separated)
 # Options: public_repo (public repos only), repo (public + private repos)
 # Default: public_repo

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ cp .env.example .env
 ```env
 GITHUB_CLIENT_ID=your_client_id
 GITHUB_CLIENT_SECRET=your_client_secret
-SESSION_SECRET=ランダムな文字列
+SESSION_SECRET=32文字以上のランダムな文字列
+ALLOWED_GITHUB_USERS=your-github-username
 ```
 
 ### 4. Hugoサイトの準備
@@ -95,7 +96,8 @@ mise run dev
 | `GITHUB_CLIENT_ID` | GitHub OAuth Client ID | (必須) |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth Client Secret | (必須) |
 | `SESSION_SECRET` | セッション暗号化キー | (自動生成・非推奨) |
-| `ALLOWED_GITHUB_USERS` | 許可するGitHubユーザー名(カンマ区切り) | (空=全員許可) |
+| `ALLOWED_GITHUB_USERS` | 許可するGitHubユーザー名(カンマ区切り) | (必須) |
+| `ALLOW_ALL_GITHUB_USERS` | 全GitHubユーザーを許可する開発用設定 | `false` |
 | `GITHUB_OAUTH_SCOPES` | OAuthスコープ | `public_repo` |
 | `PORT` | サーバーポート | `8080` |
 | `APP_URL` | アプリケーションURL | `http://localhost:8080` |

--- a/docs/audits/security-and-quality-audit.md
+++ b/docs/audits/security-and-quality-audit.md
@@ -1,18 +1,18 @@
 # セキュリティ・品質監査
 
-最終確認日: 2026-07-05
+最終確認日: 2026-07-06
 
 ## 概要
 
 Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレビュー、および開発・デプロイ手順を確認した結果をまとめる。
 
-現時点では、特に認可、SSHリモート利用時のGit認証、メディアパス検証に本番運用前の対応が必要である。
+初回監査では、特に認可、SSHリモート利用時のGit認証、メディアパス検証を本番運用前の必須対応として確認した。各項目の現在の対応状態は以下に記録する。
 
 ## 優先度: 重大
 
 ### 1. 許可リスト未設定時にすべてのGitHubユーザーを許可する
 
-- 状態: 未対応
+- 状態: 対応済み
 - 該当箇所:
   - `pkg/config/config.go` の `AllowedGitHubUsers`
   - `pkg/config/config.go` の `IsUserAllowed`
@@ -29,7 +29,7 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 
 ### 2. SSHリモートではログインユーザーのOAuth権限で公開されない
 
-- 状態: 未対応
+- 状態: 対応済み
 - 該当箇所: `pkg/services/git.go` の `ExecuteGitWithToken`
 - 影響:
   - OAuthトークンを使う処理はHTTPSリモートを前提としている。
@@ -40,10 +40,12 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
   - ユーザーのOAuth権限で公開する場合はHTTPSリモートのみを許可し、起動時に検証する。
   - SSH鍵で公開する設計にする場合は、その事実を明示し、OAuthログインとは別に厳格なCMS認可を行う。
   - リモート名のハードコードを廃止し、すべて`config.GitRemote`を使用する。
+  - 実装では`github.com`のHTTPSリモートだけを許可し、credential helperを無効化してログインユーザーのOAuthトークンを使用する。
+  - 既存のSSH形式リモートはHTTPS形式へ移行する必要がある。
 
 ### 3. メディアアップロード先がリポジトリ外へ脱出できる
 
-- 状態: 未対応
+- 状態: 対応済み
 - 該当箇所:
   - `pkg/handlers/media.go`
   - `pkg/services/media.go` の `ListMediaFiles`
@@ -60,7 +62,7 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 
 ### 4. GitHubアクセストークンがCookie内で暗号化されていない
 
-- 状態: 未対応
+- 状態: 対応済み（暗号化Cookie。サーバー側セッションストアへの移行は将来改善）
 - 該当箇所:
   - `main.go` のCookie Store初期化
   - `pkg/handlers/auth.go` の`access_token`保存
@@ -115,7 +117,7 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 
 ### 8. Hugoプレビューと管理画面が同一オリジンである
 
-- 状態: 未対応
+- 状態: 対応済み（別オリジンへの分離は将来改善）
 - 該当箇所:
   - `main.go` のHugoリバースプロキシ
   - `templates/index.html` のプレビューiframe
@@ -125,6 +127,8 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 - 推奨対応:
   - プレビューを管理画面とは異なるオリジンへ分離する。
   - 分離できない場合はiframeの`sandbox`と厳格なContent Security Policyを導入する。ただし、必要なプレビュー機能との互換性を検証する。
+  - 現在はiframeを`sandbox="allow-forms allow-scripts"`でopaque originとして扱い、`allow-same-origin`、トップレベル遷移、ポップアップを許可していない。
+  - プレビューへの直接アクセスにも管理画面と同じ認証・トークン再検証を適用している。
 
 ## 優先度: 中
 
@@ -142,7 +146,7 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 
 ### 10. `CACHE_CONCURRENCY`の値によって停止またはpanicする
 
-- 状態: 未対応
+- 状態: 対応済み
 - 該当箇所:
   - `pkg/config/config.go`
   - `pkg/services/cache.go`
@@ -183,16 +187,9 @@ Hugo CMSの認証、記事編集、メディア管理、Git連携、Hugoプレ�
 
 ## その他の改善点
 
-- `http.Server`に`ReadHeaderTimeout`、`ReadTimeout`、`WriteTimeout`、`IdleTimeout`が設定されていない。
-- メディアアップロードは解析前のリクエストボディ上限がなく、認証済みユーザーによるディスク・メモリ消費を十分に防げない。
-- `GET /ready`がリポジトリの実パス、メモリ使用量、goroutine数を公開している。
 - 記事取得APIのパスをフロントエンド側でURLエンコードしていないため、`&`、`#`、`?`などを含むファイル名を正しく扱えない。
 - Git statusのporcelain出力を文字列操作で解析しており、リネームや引用された日本語ファイル名のdirty判定を誤る可能性がある。
-- `SafeJoin`は字句上の親ディレクトリ参照を防ぐが、シンボリックリンク後の実パスまでは検証しない。
 - 複数タブや並行リクエスト間の更新競合を検出するバージョン番号・ETag・排他制御がなく、後勝ちで記事を上書きする。
-- `CSRF_SECRET`は設定として読み込まれるが、トークン生成には使用されていない。
-- `.env.example`のOAuth callback URLコメントが実際の`/admin/auth/callback`と一致していない。
-- `hugo-cms.exe`が`.gitignore`対象外で、未追跡の大容量バイナリとして残っている。
 - 複数のGoファイルが`gofmt`未適用である。
 
 ## 検証結果

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -18,14 +18,14 @@ GitHub OAuth Appの認証情報です。
 
 #### `SESSION_SECRET`
 
-セッションCookieの暗号化に使用するキーです。
+セッションCookieの署名鍵と暗号化鍵の導出に使用する、32文字以上の秘密値です。
 
 ```bash
 # 生成例
 openssl rand -base64 32
 ```
 
-**注意**: 設定しない場合、起動時にランダムなキーが生成されますが、サーバー再起動でセッションが無効になります。
+**注意**: `GIN_MODE=release`では必須です。開発モードで設定しない場合は起動時にランダムなキーを生成するため、サーバー再起動でセッションが無効になります。
 
 ### 認証・セキュリティ
 
@@ -37,9 +37,17 @@ CMSへのアクセスを許可するGitHubユーザー名のリスト(カンマ�
 # 特定のユーザーのみ許可
 ALLOWED_GITHUB_USERS=user1,user2,user3
 
-# 空の場合は全認証ユーザーを許可 (非推奨)
-ALLOWED_GITHUB_USERS=
+# 1人以上のユーザー指定が必須
+ALLOWED_GITHUB_USERS=user1
 ```
+
+未設定または空の場合、CMSは安全のため起動を拒否します。ローカル開発で全GitHubユーザーを明示的に許可する場合だけ、次を設定できます。
+
+```env
+ALLOW_ALL_GITHUB_USERS=true
+```
+
+この設定を本番環境で使用してはいけません。
 
 #### `GITHUB_OAUTH_SCOPES`
 
@@ -56,10 +64,6 @@ GITHUB_OAUTH_SCOPES=repo
 ```
 
 **重要**: スコープを変更した場合、既存ユーザーは再ログインが必要です。
-
-#### `CSRF_SECRET`
-
-CSRFトークン生成用のシークレット。設定しない場合は自動生成されます。
 
 ### アプリケーション設定
 
@@ -180,6 +184,8 @@ GIT_USER_EMAIL="bot@hugo-cms.local"
 
 リモートリポジトリ名。デフォルト: `origin`
 
+指定したリモートのURLは`https://github.com/owner/repository.git`形式である必要があります。SSH形式や認証情報を埋め込んだURLは、ログインユーザー以外の認証情報利用やトークン送信先のすり替えを防ぐため拒否されます。
+
 ## タイムアウト設定
 
 以下のタイムアウトはソースコード内で定義されています:
@@ -200,6 +206,7 @@ GIT_USER_EMAIL="bot@hugo-cms.local"
 GITHUB_CLIENT_ID=Iv1.xxxxxxxx
 GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxx
 SESSION_SECRET=dev-secret-key-change-in-production
+ALLOWED_GITHUB_USERS=your-username
 
 PORT=8080
 APP_URL=http://localhost:8080
@@ -213,10 +220,9 @@ HUGO_SERVER_PORT=1314
 ```env
 GITHUB_CLIENT_ID=Iv1.xxxxxxxx
 GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxx
-SESSION_SECRET=長くてランダムな文字列
+SESSION_SECRET=32文字以上のランダムな文字列
 
 ALLOWED_GITHUB_USERS=your-username
-CSRF_SECRET=別のランダム文字列
 
 PORT=8080
 APP_URL=https://cms.example.com
@@ -236,7 +242,8 @@ GIT_BRANCH=main
 ```env
 GITHUB_CLIENT_ID=Iv1.xxxxxxxx
 GITHUB_CLIENT_SECRET=xxxxxxxxxxxxxxxx
-SESSION_SECRET=docker-secret
+SESSION_SECRET=replace-with-at-least-32-random-characters
+ALLOWED_GITHUB_USERS=your-username
 
 PORT=8080
 APP_URL=http://localhost:8080

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -42,7 +42,7 @@ vim .env
 
 3. Hugoリポジトリを準備:
 ```bash
-git clone git@github.com:username/hugo-site.git /opt/hugo-cms/repo
+git clone https://github.com/username/hugo-site.git /opt/hugo-cms/repo
 ```
 
 4. systemdサービスを作成:
@@ -192,11 +192,11 @@ cms.example.com {
 # 必須
 GITHUB_CLIENT_ID=本番用のClient ID
 GITHUB_CLIENT_SECRET=本番用のClient Secret
-SESSION_SECRET=長くてランダムな文字列
+SESSION_SECRET=32文字以上のランダムな文字列
 
 # セキュリティ
 ALLOWED_GITHUB_USERS=your-username
-CSRF_SECRET=別のランダム文字列
+ALLOW_ALL_GITHUB_USERS=false
 
 # アプリケーション
 PORT=8080
@@ -217,19 +217,19 @@ GIN_MODE=release
    - **Homepage URL**: `https://cms.example.com`
    - **Authorization callback URL**: `https://cms.example.com/admin/auth/callback`
 
-### SSH鍵の設定
+### Gitリモートの設定
 
-Gitのpush/pullにはGitHub OAuth トークンを使用しますが、
-初回クローンにはSSH鍵またはHTTPS認証が必要です:
+Gitのpush/pullは、ログインユーザーのGitHub OAuthトークンを使用します。認証主体がサーバーのSSH鍵へ切り替わることを防ぐため、リモートURLには`https://github.com/`形式だけを使用してください。
 
 ```bash
-# SSHの場合
-ssh-keygen -t ed25519 -C "hugo-cms@server"
-cat ~/.ssh/id_ed25519.pub
-# GitHubのDeploy Keysに追加
-
-# HTTPS の場合
 git clone https://github.com/username/hugo-site.git repo
+git -C repo remote get-url origin
+```
+
+SSH、scp形式、GitHub以外のHTTPSホスト、認証情報を埋め込んだURLはCMSからの同期・公開時に拒否されます。既存リポジトリがSSH形式の場合は次のように変更します。
+
+```bash
+git -C repo remote set-url origin https://github.com/username/hugo-site.git
 ```
 
 ## 監視とログ
@@ -344,9 +344,9 @@ LOG_LEVEL=debug
 ## セキュリティチェックリスト
 
 - [ ] HTTPS (SSL/TLS) が有効
-- [ ] `SESSION_SECRET` がランダムな値
-- [ ] `CSRF_SECRET` がランダムな値
+- [ ] `SESSION_SECRET` が32文字以上のランダムな値
 - [ ] `ALLOWED_GITHUB_USERS` で許可ユーザーを制限
+- [ ] `ALLOW_ALL_GITHUB_USERS=false` を設定
 - [ ] `GIN_MODE=release` を設定
 - [ ] ファイアウォールで不要なポートを閉じる
 - [ ] 定期的なセキュリティアップデート

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -309,7 +309,7 @@ Hugoサーバーを再起動します。
 ]
 ```
 
-### POST /admin/api/media/upload
+### POST /admin/api/media
 
 メディアファイルをアップロードします。
 
@@ -322,7 +322,8 @@ Hugoサーバーを再起動します。
 
 **制限**:
 - 最大サイズ: `MAX_UPLOAD_SIZE_MB` (デフォルト10MB)
-- 許可される拡張子: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.svg`, `.mp4`, `.webm`, `.pdf`
+- 許可される拡張子: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.mp4`, `.webm`, `.pdf`
+- 拡張子と実際のContent-Typeが一致しないファイル、および実行可能コンテンツを含められるSVGは拒否
 
 **レスポンス**:
 ```json
@@ -344,7 +345,7 @@ Hugoサーバーを再起動します。
 }
 ```
 
-### DELETE /admin/api/media
+### POST /admin/api/media/delete
 
 メディアファイルを削除します。
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
+	"fmt"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/handlers"
 	"hugo-cms/pkg/services"
@@ -22,7 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func SetupRouter() *gin.Engine {
+func SetupRouter() (*gin.Engine, error) {
 	appURL := config.GetAppURL()
 	r := gin.Default()
 
@@ -32,6 +35,9 @@ func SetupRouter() *gin.Engine {
 	// Session Setup
 	secret := os.Getenv("SESSION_SECRET")
 	if secret == "" {
+		if gin.Mode() == gin.ReleaseMode {
+			return nil, fmt.Errorf("SESSION_SECRET is required in release mode")
+		}
 		slog.Warn("SESSION_SECRET is not set, using temporary random secret",
 			"warning", "insecure for production")
 		b := make([]byte, 32)
@@ -40,7 +46,12 @@ func SetupRouter() *gin.Engine {
 		}
 		secret = base64.StdEncoding.EncodeToString(b)
 	}
-	store := cookie.NewStore([]byte(secret))
+	if len(secret) < 32 {
+		return nil, fmt.Errorf("SESSION_SECRET must be at least 32 characters")
+	}
+	authKey := sha512.Sum512([]byte("hugo-cms/session-auth/" + secret))
+	encryptionKey := sha256.Sum256([]byte("hugo-cms/session-encryption/" + secret))
+	store := cookie.NewStore(authKey[:], encryptionKey[:])
 	store.Options(sessions.Options{
 		Path:     "/", // Cookie valid for whole domain
 		MaxAge:   86400 * 7,
@@ -59,6 +70,12 @@ func SetupRouter() *gin.Engine {
 
 	// --- Admin Routes ---
 	admin := r.Group("/admin")
+	admin.Use(func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "SAMEORIGIN")
+		c.Header("Referrer-Policy", "no-referrer")
+		c.Next()
+	})
 	{
 		// Public Auth
 		admin.GET("/login", handlers.LoginPage)
@@ -77,6 +94,7 @@ func SetupRouter() *gin.Engine {
 			authorized.GET("/", func(c *gin.Context) { c.HTML(http.StatusOK, "index.html", nil) })
 
 			api := authorized.Group("/api")
+			api.Use(handlers.RequestBodyLimit(config.MaxUploadSize + (1 << 20)))
 			api.Use(handlers.CSRFProtection) // Apply CSRF protection to all API routes
 			{
 				api.GET("/csrf-token", handlers.GetCSRFToken) // Endpoint to get CSRF token
@@ -104,25 +122,24 @@ func SetupRouter() *gin.Engine {
 	previewProxyURL, _ := url.Parse("http://" + config.HugoServerBind + ":" + config.HugoServerPort)
 	proxy := httputil.NewSingleHostReverseProxy(previewProxyURL)
 
-	r.NoRoute(func(c *gin.Context) {
-		// Protect Proxy
-		session := sessions.Default(c)
-		if session.Get("access_token") == nil {
-			// If not authenticated, redirect to admin login
-			c.Redirect(http.StatusFound, "/admin/login")
-			return
-		}
-
-		// Proxy to Hugo
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		slog.Warn("Hugo preview proxy failed", "error", err)
+		http.Error(w, "Preview unavailable", http.StatusBadGateway)
+	}
+	r.NoRoute(handlers.AuthRequired, handlers.TokenValidation, func(c *gin.Context) {
 		proxy.ServeHTTP(c.Writer, c.Request)
 	})
 
-	return r
+	return r, nil
 }
 
 func main() {
 	// Initialize config
 	config.Init()
+	if err := config.ValidateSecurityConfig(); err != nil {
+		slog.Error("Invalid security configuration", "error", err)
+		os.Exit(1)
+	}
 
 	appURL := config.GetAppURL()
 	slog.Info("Starting server",
@@ -130,16 +147,25 @@ func main() {
 		"redirect_url", config.OauthConf.RedirectURL,
 		"port", config.ServerPort)
 
+	r, err := SetupRouter()
+	if err != nil {
+		slog.Error("Failed to configure HTTP router", "error", err)
+		os.Exit(1)
+	}
+
 	// Start Hugo Server
 	if err := services.StartHugoServer(); err != nil {
 		slog.Error("Failed to start Hugo Server", "error", err)
 	}
 
-	r := SetupRouter()
-
 	srv := &http.Server{
-		Addr:    ":" + config.ServerPort,
-		Handler: r,
+		Addr:              ":" + config.ServerPort,
+		Handler:           r,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      6 * time.Minute,
+		IdleTimeout:       2 * time.Minute,
+		MaxHeaderBytes:    1 << 20,
 	}
 
 	go func() {

--- a/main.go
+++ b/main.go
@@ -133,6 +133,19 @@ func SetupRouter() (*gin.Engine, error) {
 	return r, nil
 }
 
+func newHTTPServer(handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              ":" + config.ServerPort,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		// Request bodies are size-limited by middleware. Global read and
+		// write deadlines would make valid large uploads depend on connection
+		// speed and can prevent the final response from being written.
+		IdleTimeout:    2 * time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+}
+
 func main() {
 	// Initialize config
 	config.Init()
@@ -158,15 +171,7 @@ func main() {
 		slog.Error("Failed to start Hugo Server", "error", err)
 	}
 
-	srv := &http.Server{
-		Addr:              ":" + config.ServerPort,
-		Handler:           r,
-		ReadHeaderTimeout: 10 * time.Second,
-		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      6 * time.Minute,
-		IdleTimeout:       2 * time.Minute,
-		MaxHeaderBytes:    1 << 20,
-	}
+	srv := newHTTPServer(r)
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,26 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func configureGinMode() error {
+	mode := strings.TrimSpace(os.Getenv("GIN_MODE"))
+	if mode == "" {
+		return nil
+	}
+
+	switch mode {
+	case gin.DebugMode, gin.ReleaseMode, gin.TestMode:
+		gin.SetMode(mode)
+		return nil
+	default:
+		return fmt.Errorf("invalid GIN_MODE %q", mode)
+	}
+}
+
 func SetupRouter() (*gin.Engine, error) {
+	if err := configureGinMode(); err != nil {
+		return nil, err
+	}
+
 	appURL := config.GetAppURL()
 	r := gin.Default()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestSetupRouterRejectsShortSessionSecret(t *testing.T) {
+	originalMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("SESSION_SECRET", "too-short")
+
+	_, err := SetupRouter()
+	if err == nil || !strings.Contains(err.Error(), "at least 32") {
+		t.Fatalf("SetupRouter() error = %v, want minimum-length error", err)
+	}
+}
+
+func TestSetupRouterRequiresSessionSecretInReleaseMode(t *testing.T) {
+	originalMode := gin.Mode()
+	gin.SetMode(gin.ReleaseMode)
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("SESSION_SECRET", "")
+
+	_, err := SetupRouter()
+	if err == nil || !strings.Contains(err.Error(), "required in release mode") {
+		t.Fatalf("SetupRouter() error = %v, want required-secret error", err)
+	}
+}
+
+func TestSetupRouterAcceptsStrongSessionSecret(t *testing.T) {
+	originalMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("SESSION_SECRET", strings.Repeat("s", 32))
+
+	router, err := SetupRouter()
+	if err != nil {
+		t.Fatalf("SetupRouter() unexpected error: %v", err)
+	}
+	if router == nil {
+		t.Fatal("SetupRouter() returned a nil router")
+	}
+}
+
+func TestAdminSecurityHeadersAndPreviewAuthentication(t *testing.T) {
+	originalMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("SESSION_SECRET", strings.Repeat("s", 32))
+
+	router, err := SetupRouter()
+	if err != nil {
+		t.Fatalf("SetupRouter() unexpected error: %v", err)
+	}
+
+	loginRecorder := httptest.NewRecorder()
+	router.ServeHTTP(loginRecorder, httptest.NewRequest(http.MethodGet, "/admin/login", nil))
+	if loginRecorder.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("admin response is missing X-Content-Type-Options")
+	}
+	if loginRecorder.Header().Get("X-Frame-Options") != "SAMEORIGIN" {
+		t.Error("admin response is missing X-Frame-Options")
+	}
+
+	previewRecorder := httptest.NewRecorder()
+	router.ServeHTTP(previewRecorder, httptest.NewRequest(http.MethodGet, "/preview-path", nil))
+	if previewRecorder.Code != http.StatusFound {
+		t.Fatalf("unauthenticated preview status = %d, want %d", previewRecorder.Code, http.StatusFound)
+	}
+	if location := previewRecorder.Header().Get("Location"); location != "/admin/login" {
+		t.Fatalf("unauthenticated preview redirect = %q, want %q", location, "/admin/login")
+	}
+}
+
+func TestPreviewFrameIsSandboxedWithoutSameOrigin(t *testing.T) {
+	content, err := os.ReadFile("templates/index.html")
+	if err != nil {
+		t.Fatalf("read admin template: %v", err)
+	}
+	template := string(content)
+	if !strings.Contains(template, `sandbox="allow-forms allow-scripts"`) {
+		t.Fatal("preview iframe is missing the expected sandbox")
+	}
+	if strings.Contains(template, "allow-same-origin") {
+		t.Fatal("preview iframe must not use allow-same-origin")
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ func TestSetupRouterRejectsShortSessionSecret(t *testing.T) {
 	originalMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
 	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", "")
 	t.Setenv("SESSION_SECRET", "too-short")
 
 	_, err := SetupRouter()
@@ -27,6 +28,7 @@ func TestSetupRouterRequiresSessionSecretInReleaseMode(t *testing.T) {
 	originalMode := gin.Mode()
 	gin.SetMode(gin.ReleaseMode)
 	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", "")
 	t.Setenv("SESSION_SECRET", "")
 
 	_, err := SetupRouter()
@@ -39,6 +41,7 @@ func TestSetupRouterAcceptsStrongSessionSecret(t *testing.T) {
 	originalMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
 	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", "")
 	t.Setenv("SESSION_SECRET", strings.Repeat("s", 32))
 
 	router, err := SetupRouter()
@@ -54,6 +57,7 @@ func TestAdminSecurityHeadersAndPreviewAuthentication(t *testing.T) {
 	originalMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
 	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", "")
 	t.Setenv("SESSION_SECRET", strings.Repeat("s", 32))
 
 	router, err := SetupRouter()
@@ -105,5 +109,33 @@ func TestHTTPServerDoesNotCapRequestBodyDuration(t *testing.T) {
 	}
 	if server.WriteTimeout != 0 {
 		t.Fatalf("WriteTimeout = %v, want no global deadline that expires during uploads", server.WriteTimeout)
+	}
+}
+
+func TestSetupRouterHonorsReleaseModeFromEnvironment(t *testing.T) {
+	originalMode := gin.Mode()
+	gin.SetMode(gin.DebugMode)
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", gin.ReleaseMode)
+	t.Setenv("SESSION_SECRET", "")
+
+	_, err := SetupRouter()
+	if err == nil || !strings.Contains(err.Error(), "required in release mode") {
+		t.Fatalf("SetupRouter() error = %v, want required-secret error", err)
+	}
+	if gin.Mode() != gin.ReleaseMode {
+		t.Fatalf("gin.Mode() = %q, want %q", gin.Mode(), gin.ReleaseMode)
+	}
+}
+
+func TestSetupRouterRejectsInvalidGinMode(t *testing.T) {
+	originalMode := gin.Mode()
+	t.Cleanup(func() { gin.SetMode(originalMode) })
+	t.Setenv("GIN_MODE", "production")
+	t.Setenv("SESSION_SECRET", strings.Repeat("s", 32))
+
+	_, err := SetupRouter()
+	if err == nil || !strings.Contains(err.Error(), "invalid GIN_MODE") {
+		t.Fatalf("SetupRouter() error = %v, want invalid-mode error", err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -90,5 +91,19 @@ func TestPreviewFrameIsSandboxedWithoutSameOrigin(t *testing.T) {
 	}
 	if strings.Contains(template, "allow-same-origin") {
 		t.Fatal("preview iframe must not use allow-same-origin")
+	}
+}
+
+func TestHTTPServerDoesNotCapRequestBodyDuration(t *testing.T) {
+	server := newHTTPServer(http.NotFoundHandler())
+
+	if server.ReadHeaderTimeout != 10*time.Second {
+		t.Fatalf("ReadHeaderTimeout = %v, want %v", server.ReadHeaderTimeout, 10*time.Second)
+	}
+	if server.ReadTimeout != 0 {
+		t.Fatalf("ReadTimeout = %v, want no global request body deadline", server.ReadTimeout)
+	}
+	if server.WriteTimeout != 0 {
+		t.Fatalf("WriteTimeout = %v, want no global deadline that expires during uploads", server.WriteTimeout)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -140,7 +140,7 @@ func Init() {
 
 // ValidateSecurityConfig rejects insecure authorization defaults.
 func ValidateSecurityConfig() error {
-	if AllowAllGitHubUsers && strings.EqualFold(os.Getenv("GIN_MODE"), "release") {
+	if AllowAllGitHubUsers && strings.EqualFold(strings.TrimSpace(os.Getenv("GIN_MODE")), "release") {
 		return fmt.Errorf("ALLOW_ALL_GITHUB_USERS cannot be enabled when GIN_MODE=release")
 	}
 	if len(AllowedGitHubUsers) == 0 && !AllowAllGitHubUsers {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
@@ -43,9 +44,9 @@ var (
 	GitNetworkTimeout = 5 * time.Minute  // Network operations (push, pull)
 
 	// Security settings
-	AllowedGitHubUsers = []string{} // Empty means allow all authenticated users
-	CSRFSecret         = ""
-	GitHubOAuthScopes  = []string{"public_repo"} // Default to public_repo only
+	AllowedGitHubUsers  = []string{}
+	AllowAllGitHubUsers = false
+	GitHubOAuthScopes   = []string{"public_repo"} // Default to public_repo only
 
 	// Snippet settings
 	SnippetPaths = []string{"repo/.vscode/md.code-snippets"}
@@ -83,8 +84,10 @@ func Init() {
 
 	// Max upload size (default 10MB)
 	if maxSize := os.Getenv("MAX_UPLOAD_SIZE_MB"); maxSize != "" {
-		if val, err := strconv.ParseInt(maxSize, 10, 64); err == nil && val > 0 {
+		if val, err := strconv.ParseInt(maxSize, 10, 64); err == nil && val > 0 && val <= 1024 {
 			MaxUploadSize = val * 1024 * 1024
+		} else {
+			slog.Warn("Invalid MAX_UPLOAD_SIZE_MB value; using existing default", "value", maxSize)
 		}
 	}
 
@@ -94,14 +97,24 @@ func Init() {
 	GitRemote = getEnv("GIT_REMOTE", "origin")
 
 	// Security settings
+	AllowedGitHubUsers = nil
+	AllowAllGitHubUsers = false
 	if users := os.Getenv("ALLOWED_GITHUB_USERS"); users != "" {
 		AllowedGitHubUsers = splitAndTrim(users, ",")
 	}
-	CSRFSecret = getEnv("CSRF_SECRET", "")
-
+	if allowAll := os.Getenv("ALLOW_ALL_GITHUB_USERS"); allowAll != "" {
+		val, err := strconv.ParseBool(allowAll)
+		if err != nil {
+			slog.Warn("Invalid ALLOW_ALL_GITHUB_USERS value; defaulting to false", "value", allowAll)
+		} else {
+			AllowAllGitHubUsers = val
+		}
+	}
 	if cc := os.Getenv("CACHE_CONCURRENCY"); cc != "" {
-		if val, err := strconv.Atoi(cc); err == nil {
+		if val, err := strconv.Atoi(cc); err == nil && val >= 1 && val <= 256 {
 			CacheConcurrency = val
+		} else {
+			slog.Warn("Invalid CACHE_CONCURRENCY value; using existing default", "value", cc)
 		}
 	}
 
@@ -123,6 +136,17 @@ func Init() {
 		Endpoint:     github.Endpoint,
 		RedirectURL:  redirectURL,
 	}
+}
+
+// ValidateSecurityConfig rejects insecure authorization defaults.
+func ValidateSecurityConfig() error {
+	if AllowAllGitHubUsers && strings.EqualFold(os.Getenv("GIN_MODE"), "release") {
+		return fmt.Errorf("ALLOW_ALL_GITHUB_USERS cannot be enabled when GIN_MODE=release")
+	}
+	if len(AllowedGitHubUsers) == 0 && !AllowAllGitHubUsers {
+		return fmt.Errorf("ALLOWED_GITHUB_USERS must contain at least one user; set ALLOW_ALL_GITHUB_USERS=true only for explicit development use")
+	}
+	return nil
 }
 
 func GetAppURL() string {
@@ -149,7 +173,7 @@ func splitAndTrim(s, sep string) []string {
 // IsUserAllowed checks if a GitHub username is in the allowed list
 func IsUserAllowed(username string) bool {
 	if len(AllowedGitHubUsers) == 0 {
-		return true // No restriction if list is empty
+		return AllowAllGitHubUsers
 	}
 	for _, u := range AllowedGitHubUsers {
 		if strings.EqualFold(u, username) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,6 +32,12 @@ func TestValidateSecurityConfig(t *testing.T) {
 			wantErr:  true,
 		},
 		{
+			name:     "rejects allow-all when release mode has whitespace",
+			allowAll: true,
+			ginMode:  " release ",
+			wantErr:  true,
+		},
+		{
 			name:  "allows a configured user",
 			users: []string{"octocat"},
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import "testing"
+
+func TestValidateSecurityConfig(t *testing.T) {
+	originalUsers := AllowedGitHubUsers
+	originalAllowAll := AllowAllGitHubUsers
+	t.Cleanup(func() {
+		AllowedGitHubUsers = originalUsers
+		AllowAllGitHubUsers = originalAllowAll
+	})
+
+	tests := []struct {
+		name     string
+		users    []string
+		allowAll bool
+		ginMode  string
+		wantErr  bool
+	}{
+		{
+			name:    "rejects an empty allowlist by default",
+			wantErr: true,
+		},
+		{
+			name:     "allows an explicit development override",
+			allowAll: true,
+		},
+		{
+			name:     "rejects the allow-all override in release mode",
+			allowAll: true,
+			ginMode:  "release",
+			wantErr:  true,
+		},
+		{
+			name:  "allows a configured user",
+			users: []string{"octocat"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AllowedGitHubUsers = tt.users
+			AllowAllGitHubUsers = tt.allowAll
+			t.Setenv("GIN_MODE", tt.ginMode)
+
+			err := ValidateSecurityConfig()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateSecurityConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsUserAllowed(t *testing.T) {
+	originalUsers := AllowedGitHubUsers
+	originalAllowAll := AllowAllGitHubUsers
+	t.Cleanup(func() {
+		AllowedGitHubUsers = originalUsers
+		AllowAllGitHubUsers = originalAllowAll
+	})
+
+	AllowedGitHubUsers = nil
+	AllowAllGitHubUsers = false
+	if IsUserAllowed("octocat") {
+		t.Fatal("IsUserAllowed() should fail closed when no users are configured")
+	}
+
+	AllowAllGitHubUsers = true
+	if !IsUserAllowed("octocat") {
+		t.Fatal("IsUserAllowed() should honor the explicit allow-all override")
+	}
+
+	AllowedGitHubUsers = []string{"OctoCat"}
+	AllowAllGitHubUsers = false
+	if !IsUserAllowed("octocat") {
+		t.Fatal("IsUserAllowed() should compare usernames case-insensitively")
+	}
+}

--- a/pkg/handlers/auth.go
+++ b/pkg/handlers/auth.go
@@ -3,10 +3,11 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"math/big"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -27,8 +28,15 @@ type GitHubUser struct {
 
 func AuthRequired(c *gin.Context) {
 	session := sessions.Default(c)
-	token := session.Get("access_token")
-	if token == nil {
+	token, tokenOK := session.Get("access_token").(string)
+	username, userOK := session.Get("github_user").(string)
+	if !tokenOK || token == "" || !userOK || username == "" || !config.IsUserAllowed(username) {
+		if tokenOK || userOK {
+			session.Clear()
+			if err := session.Save(); err != nil {
+				slog.Error("Failed to clear unauthorized session", "error", err)
+			}
+		}
 		if strings.HasPrefix(c.Request.URL.Path, "/admin/api/") {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		} else {
@@ -44,20 +52,26 @@ func LoginPage(c *gin.Context) {
 	c.HTML(http.StatusOK, "login.html", nil)
 }
 
-func generateStateOauth() string {
+func generateStateOauth() (string, error) {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
-		// Fallback to time-based state (less secure but functional)
-		return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%d", time.Now().UnixNano())))
+		return "", fmt.Errorf("generate OAuth state: %w", err)
 	}
-	return base64.URLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 func GithubLogin(c *gin.Context) {
-	state := generateStateOauth()
+	state, err := generateStateOauth()
+	if err != nil {
+		ErrorInternal(c, "Failed to start OAuth login")
+		return
+	}
 	session := sessions.Default(c)
 	session.Set("oauth_state", state)
-	session.Save()
+	if err := session.Save(); err != nil {
+		ErrorInternal(c, "Failed to persist OAuth session")
+		return
+	}
 
 	url := config.OauthConf.AuthCodeURL(state, oauth2.AccessTypeOffline)
 	c.Redirect(http.StatusTemporaryRedirect, url)
@@ -65,21 +79,30 @@ func GithubLogin(c *gin.Context) {
 
 func AuthCallback(c *gin.Context) {
 	session := sessions.Default(c)
-	retrievedState := session.Get("oauth_state")
+	retrievedState, ok := session.Get("oauth_state").(string)
 	queryState := c.Query("state")
 
-	if retrievedState != queryState {
+	if !ok || retrievedState == "" || queryState == "" ||
+		subtle.ConstantTimeCompare([]byte(retrievedState), []byte(queryState)) != 1 {
 		c.String(http.StatusBadRequest, "Invalid OAuth State")
 		return
 	}
 
 	// Remove state from session
 	session.Delete("oauth_state")
+	if err := session.Save(); err != nil {
+		ErrorInternal(c, "Failed to update OAuth session")
+		return
+	}
 
 	// Use request context for proper cancellation propagation
 	ctx := c.Request.Context()
 
 	code := c.Query("code")
+	if code == "" {
+		c.String(http.StatusBadRequest, "Missing OAuth Code")
+		return
+	}
 	token, err := config.OauthConf.Exchange(ctx, code)
 	if err != nil {
 		c.String(http.StatusInternalServerError, "OAuth Exchange Failed")
@@ -103,7 +126,11 @@ func AuthCallback(c *gin.Context) {
 
 	session.Set("access_token", token.AccessToken)
 	session.Set("github_user", user.Login)
-	session.Save()
+	session.Set("token_validated_at", time.Now().Unix())
+	if err := session.Save(); err != nil {
+		ErrorInternal(c, "Failed to persist login session")
+		return
+	}
 
 	c.Redirect(http.StatusFound, "/admin/")
 }
@@ -190,7 +217,9 @@ func TokenValidation(c *gin.Context) {
 		if !validateGitHubToken(ctx, token) {
 			// Token is invalid, clear session
 			session.Clear()
-			session.Save()
+			if err := session.Save(); err != nil {
+				slog.Error("Failed to clear expired session", "error", err)
+			}
 
 			if strings.HasPrefix(c.Request.URL.Path, "/admin/api/") {
 				ErrorUnauthorized(c, "Session expired. Please login again.")
@@ -204,7 +233,9 @@ func TokenValidation(c *gin.Context) {
 
 		// Update validation timestamp
 		session.Set("token_validated_at", now)
-		session.Save()
+		if err := session.Save(); err != nil {
+			slog.Error("Failed to persist token validation time", "error", err)
+		}
 	}
 
 	c.Next()
@@ -213,20 +244,40 @@ func TokenValidation(c *gin.Context) {
 func Logout(c *gin.Context) {
 	session := sessions.Default(c)
 	session.Clear()
-	session.Save()
+	if err := session.Save(); err != nil {
+		ErrorInternal(c, "Failed to clear session")
+		return
+	}
 	c.Redirect(http.StatusFound, "/admin/login")
 }
 
 // GetCSRFToken returns the CSRF token for the current session
 func GetCSRFToken(c *gin.Context) {
 	session := sessions.Default(c)
-	token := session.Get("csrf_token")
-	if token == nil {
-		token = generateCSRFToken()
+	token, ok := session.Get("csrf_token").(string)
+	if !ok || token == "" {
+		var err error
+		token, err = generateCSRFToken()
+		if err != nil {
+			ErrorInternal(c, "Failed to generate CSRF token")
+			return
+		}
 		session.Set("csrf_token", token)
-		session.Save()
+		if err := session.Save(); err != nil {
+			ErrorInternal(c, "Failed to persist CSRF token")
+			return
+		}
 	}
 	c.JSON(http.StatusOK, gin.H{"csrf_token": token})
+}
+
+func RequestBodyLimit(maxBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Body != nil {
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		}
+		c.Next()
+	}
 }
 
 // CSRFProtection middleware validates CSRF tokens on POST/PUT/DELETE requests
@@ -238,8 +289,8 @@ func CSRFProtection(c *gin.Context) {
 	}
 
 	session := sessions.Default(c)
-	sessionToken := session.Get("csrf_token")
-	if sessionToken == nil {
+	sessionToken, ok := session.Get("csrf_token").(string)
+	if !ok || sessionToken == "" {
 		// Generate a new token if none exists (for better UX)
 		// Client should retry after getting new token
 		ErrorForbidden(c, "CSRF token expired. Please refresh and try again.")
@@ -247,11 +298,9 @@ func CSRFProtection(c *gin.Context) {
 		return
 	}
 
-	// Check header first, then form
+	// Require the header so multipart bodies are not parsed before the upload
+	// handler has applied its request-size limit.
 	requestToken := c.GetHeader("X-CSRF-Token")
-	if requestToken == "" {
-		requestToken = c.PostForm("csrf_token")
-	}
 
 	if requestToken == "" {
 		ErrorForbidden(c, "CSRF token missing from request")
@@ -259,7 +308,7 @@ func CSRFProtection(c *gin.Context) {
 		return
 	}
 
-	if requestToken != sessionToken.(string) {
+	if subtle.ConstantTimeCompare([]byte(requestToken), []byte(sessionToken)) != 1 {
 		ErrorForbidden(c, "CSRF token mismatch. Please refresh and try again.")
 		c.Abort()
 		return
@@ -268,12 +317,10 @@ func CSRFProtection(c *gin.Context) {
 	c.Next()
 }
 
-func generateCSRFToken() string {
+func generateCSRFToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		// Fallback to time-based token with random component
-		n, _ := rand.Int(rand.Reader, big.NewInt(1000000))
-		return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%d-%d", time.Now().UnixNano(), n)))
+		return "", fmt.Errorf("generate CSRF token: %w", err)
 	}
-	return base64.URLEncoding.EncodeToString(b)
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/pkg/handlers/auth_test.go
+++ b/pkg/handlers/auth_test.go
@@ -1,0 +1,167 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"hugo-cms/pkg/config"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+)
+
+func newSessionTestRouter() *gin.Engine {
+	router := gin.New()
+	store := cookie.NewStore(
+		[]byte(strings.Repeat("a", 64)),
+		[]byte(strings.Repeat("b", 32)),
+	)
+	router.Use(sessions.Sessions("test-session", store))
+	return router
+}
+
+func sessionCookie(t *testing.T, router *gin.Engine, values map[string]interface{}) *http.Cookie {
+	t.Helper()
+
+	router.GET("/seed-session", func(c *gin.Context) {
+		session := sessions.Default(c)
+		for key, value := range values {
+			session.Set(key, value)
+		}
+		if err := session.Save(); err != nil {
+			t.Fatalf("save test session: %v", err)
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/seed-session", nil))
+	result := recorder.Result()
+	defer result.Body.Close()
+	cookies := result.Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("session seed did not return a cookie")
+	}
+	return cookies[0]
+}
+
+func TestAuthRequiredFailsClosedWithoutAllowlist(t *testing.T) {
+	originalUsers := config.AllowedGitHubUsers
+	originalAllowAll := config.AllowAllGitHubUsers
+	t.Cleanup(func() {
+		config.AllowedGitHubUsers = originalUsers
+		config.AllowAllGitHubUsers = originalAllowAll
+	})
+	config.AllowedGitHubUsers = nil
+	config.AllowAllGitHubUsers = false
+
+	router := newSessionTestRouter()
+	cookie := sessionCookie(t, router, map[string]interface{}{
+		"access_token": "token",
+		"github_user":  "octocat",
+	})
+	router.GET("/protected", AuthRequired, func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	request.AddCookie(cookie)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusFound {
+		t.Fatalf("AuthRequired status = %d, want %d", recorder.Code, http.StatusFound)
+	}
+}
+
+func TestAuthRequiredAllowsConfiguredUser(t *testing.T) {
+	originalUsers := config.AllowedGitHubUsers
+	originalAllowAll := config.AllowAllGitHubUsers
+	t.Cleanup(func() {
+		config.AllowedGitHubUsers = originalUsers
+		config.AllowAllGitHubUsers = originalAllowAll
+	})
+	config.AllowedGitHubUsers = []string{"octocat"}
+	config.AllowAllGitHubUsers = false
+
+	router := newSessionTestRouter()
+	cookie := sessionCookie(t, router, map[string]interface{}{
+		"access_token": "token",
+		"github_user":  "OctoCat",
+	})
+	router.GET("/protected", AuthRequired, func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	request.AddCookie(cookie)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("AuthRequired status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+}
+
+func TestCSRFProtectionRejectsInvalidSessionTokenType(t *testing.T) {
+	router := newSessionTestRouter()
+	cookie := sessionCookie(t, router, map[string]interface{}{
+		"csrf_token": 42,
+	})
+	router.POST("/protected", CSRFProtection, func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/protected", nil)
+	request.Header.Set("X-CSRF-Token", "token")
+	request.AddCookie(cookie)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("CSRFProtection status = %d, want %d", recorder.Code, http.StatusForbidden)
+	}
+}
+
+func TestGetCSRFTokenReplacesInvalidSessionToken(t *testing.T) {
+	router := newSessionTestRouter()
+	cookie := sessionCookie(t, router, map[string]interface{}{
+		"csrf_token": 42,
+	})
+	router.GET("/csrf", GetCSRFToken)
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/csrf", nil)
+	request.AddCookie(cookie)
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("GetCSRFToken status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if strings.Contains(recorder.Body.String(), `"csrf_token":42`) {
+		t.Fatal("GetCSRFToken returned an invalid token from the session")
+	}
+}
+
+func TestRequestBodyLimit(t *testing.T) {
+	router := gin.New()
+	router.POST("/limited", RequestBodyLimit(4), func(c *gin.Context) {
+		if _, err := io.ReadAll(c.Request.Body); err != nil {
+			c.Status(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	})
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/limited", strings.NewReader("12345"))
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("RequestBodyLimit status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+}

--- a/pkg/handlers/health.go
+++ b/pkg/handlers/health.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"os"
-	"runtime"
 	"time"
 
 	"hugo-cms/pkg/config"
@@ -46,7 +45,6 @@ func ReadinessCheck(c *gin.Context) {
 	contentAccessible := isDirAccessible(contentDir)
 	checks["content_dir"] = gin.H{
 		"healthy": contentAccessible,
-		"path":    contentDir,
 	}
 	if !contentAccessible {
 		allHealthy = false
@@ -61,19 +59,11 @@ func ReadinessCheck(c *gin.Context) {
 		allHealthy = false
 	}
 
-	// System info
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
-
 	response := gin.H{
 		"status":    getOverallStatus(allHealthy),
 		"timestamp": time.Now().UTC().Format(time.RFC3339),
 		"uptime":    time.Since(startTime).String(),
 		"checks":    checks,
-		"system": gin.H{
-			"goroutines":   runtime.NumGoroutine(),
-			"memory_alloc": memStats.Alloc / 1024 / 1024, // MB
-		},
 	}
 
 	if allHealthy {

--- a/pkg/handlers/media.go
+++ b/pkg/handlers/media.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
+	"errors"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/services"
 	"net/http"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -16,6 +16,10 @@ func ListMedia(c *gin.Context) {
 	articlePath := c.Query("path")
 	files, err := services.ListMediaFiles(mode, articlePath)
 	if err != nil {
+		if errors.Is(err, services.ErrInvalidMedia) {
+			ErrorBadRequest(c, "Invalid media request")
+			return
+		}
 		ErrorInternal(c, "Failed to list media: "+err.Error())
 		return
 	}
@@ -27,6 +31,10 @@ func UploadMedia(c *gin.Context) {
 	articlePath := c.PostForm("path")
 	file, err := c.FormFile("file")
 	if err != nil {
+		if c.Request.Body != nil && strings.Contains(err.Error(), "request body too large") {
+			RespondError(c, http.StatusRequestEntityTooLarge, ErrCodeBadRequest, "Upload request is too large")
+			return
+		}
 		ErrorBadRequest(c, "No file uploaded")
 		return
 	}
@@ -40,6 +48,10 @@ func UploadMedia(c *gin.Context) {
 
 	info, err := services.SaveMediaFile(file, mode, articlePath)
 	if err != nil {
+		if errors.Is(err, services.ErrInvalidMedia) {
+			ErrorBadRequest(c, err.Error())
+			return
+		}
 		ErrorInternal(c, "Failed to save file: "+err.Error())
 		return
 	}
@@ -62,10 +74,8 @@ func DeleteMedia(c *gin.Context) {
 		return
 	}
 
-	// Additional validation: must be within allowed directories (static or content)
-	normalizedPath := filepath.ToSlash(filepath.Clean(req.RepoPath))
-	if !strings.HasPrefix(normalizedPath, "static/") && !strings.HasPrefix(normalizedPath, "content/") {
-		ErrorBadRequest(c, "Invalid media path: must be in static/ or content/")
+	if !services.ValidateMediaRepoPath(req.RepoPath) {
+		ErrorBadRequest(c, "Invalid media path")
 		return
 	}
 
@@ -82,6 +92,10 @@ func ServeMediaRaw(c *gin.Context) {
 		ErrorBadRequest(c, "Path parameter required")
 		return
 	}
+	if !services.ValidateMediaRepoPath(targetPath) {
+		ErrorNotFound(c, "Invalid media path")
+		return
+	}
 
 	fullPath := services.SafeJoin(config.RepoPath, "", targetPath)
 	if fullPath == "" {
@@ -89,5 +103,7 @@ func ServeMediaRaw(c *gin.Context) {
 		return
 	}
 
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Header("Cache-Control", "private, max-age=300")
 	c.File(fullPath)
 }

--- a/pkg/handlers/media_test.go
+++ b/pkg/handlers/media_test.go
@@ -3,8 +3,11 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"hugo-cms/pkg/config"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -164,6 +167,11 @@ func TestServeMediaRaw_PathValidation(t *testing.T) {
 			path:           "../../../etc/passwd",
 			expectedStatus: http.StatusNotFound,
 		},
+		{
+			name:           "Repository metadata",
+			path:           ".git/config",
+			expectedStatus: http.StatusNotFound,
+		},
 	}
 
 	for _, tt := range tests {
@@ -180,6 +188,35 @@ func TestServeMediaRaw_PathValidation(t *testing.T) {
 				t.Errorf("ServeMediaRaw() status = %d, want %d", w.Code, tt.expectedStatus)
 			}
 		})
+	}
+}
+
+func TestServeMediaRaw_AllowedMedia(t *testing.T) {
+	originalRepoPath := config.RepoPath
+	t.Cleanup(func() { config.RepoPath = originalRepoPath })
+
+	config.RepoPath = t.TempDir()
+	mediaPath := filepath.Join(config.RepoPath, "static", "images", "photo.png")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0755); err != nil {
+		t.Fatalf("create media directory: %v", err)
+	}
+	if err := os.WriteFile(mediaPath, []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	}, 0644); err != nil {
+		t.Fatalf("write media file: %v", err)
+	}
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest("GET", "/api/media/raw?path=static/images/photo.png", nil)
+
+	ServeMediaRaw(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("ServeMediaRaw() status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
 	}
 }
 

--- a/pkg/services/file.go
+++ b/pkg/services/file.go
@@ -14,26 +14,86 @@ import (
 )
 
 func SafeJoin(root, sub, target string) string {
-	// Prevent absolute paths from bypassing the root
-	if filepath.IsAbs(target) {
+	if root == "" || filepath.IsAbs(sub) || filepath.IsAbs(target) {
 		return ""
 	}
 
-	intendedRoot := filepath.Join(root, sub)
-	finalPath := filepath.Join(intendedRoot, target)
-
-	// Verify that finalPath is inside intendedRoot using filepath.Rel
-	rel, err := filepath.Rel(intendedRoot, finalPath)
+	rootAbs, err := filepath.Abs(root)
 	if err != nil {
 		return ""
 	}
-
-	// Check if the relative path indicates traversal (starts with "..")
-	if strings.HasPrefix(rel, "..") || rel == ".." {
+	intendedRoot := filepath.Join(rootAbs, sub)
+	if !isPathWithin(rootAbs, intendedRoot) {
 		return ""
 	}
 
-	return finalPath
+	finalPath := filepath.Join(intendedRoot, target)
+	if !isPathWithin(intendedRoot, finalPath) {
+		return ""
+	}
+
+	if !isResolvedPathWithin(rootAbs, finalPath) {
+		return ""
+	}
+	return filepath.Join(root, sub, target)
+}
+
+func isPathWithin(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
+}
+
+// isResolvedPathWithin prevents existing symlinks below a target root from
+// escaping it. Missing suffixes are allowed for new files.
+func isResolvedPathWithin(root, target string) bool {
+	rootInfo, err := os.Lstat(root)
+	if err != nil {
+		return os.IsNotExist(err)
+	}
+
+	rootBoundary := root
+	if rootInfo.Mode()&os.ModeSymlink != 0 {
+		rootBoundary, err = filepath.EvalSymlinks(root)
+		if err != nil {
+			return false
+		}
+	}
+
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	current := root
+	for _, component := range strings.Split(rel, string(os.PathSeparator)) {
+		if component == "" || component == "." {
+			continue
+		}
+		current = filepath.Join(current, component)
+		info, statErr := os.Lstat(current)
+		if os.IsNotExist(statErr) {
+			return true
+		}
+		if statErr != nil {
+			return false
+		}
+
+		if info.Mode()&os.ModeSymlink != 0 {
+			if rootBoundary == root {
+				rootBoundary, err = filepath.EvalSymlinks(root)
+				if err != nil {
+					return false
+				}
+			}
+			current, err = filepath.EvalSymlinks(current)
+			if err != nil || !isPathWithin(rootBoundary, current) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func DeleteFile(targetPath string) error {

--- a/pkg/services/file_test.go
+++ b/pkg/services/file_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -8,7 +9,7 @@ import (
 
 func TestSafeJoin(t *testing.T) {
 	root := "/tmp/repo"
-	
+
 	absTarget := "/etc/passwd"
 	if runtime.GOOS == "windows" {
 		absTarget = "C:\\Windows\\System32\\drivers\\etc\\hosts"
@@ -39,9 +40,9 @@ func TestSafeJoin(t *testing.T) {
 			wantPath: "",
 		},
 		{
-			name:     "Valid Nested Traversal",
-			sub:      "content",
-			target:   "posts/../about.md",
+			name:   "Valid Nested Traversal",
+			sub:    "content",
+			target: "posts/../about.md",
 			// Resolves to content/about.md which is inside content
 			wantPath: filepath.Join(root, "content", "about.md"),
 		},
@@ -58,7 +59,7 @@ func TestSafeJoin(t *testing.T) {
 			got := SafeJoin(root, tt.sub, tt.target)
 			// Normalize paths for comparison (Windows/Unix separators)
 			// But SafeJoin returns empty on error, so literal comparison is mostly fine except separators
-			
+
 			// If wantPath is empty, we expect empty
 			if tt.wantPath == "" {
 				if got != "" {
@@ -70,5 +71,27 @@ func TestSafeJoin(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSafeJoinRejectsSymlinkEscape(t *testing.T) {
+	baseDir := t.TempDir()
+	root := filepath.Join(baseDir, "repo")
+	contentDir := filepath.Join(root, "content")
+	outsideDir := filepath.Join(baseDir, "outside")
+	if err := os.MkdirAll(contentDir, 0755); err != nil {
+		t.Fatalf("create content directory: %v", err)
+	}
+	if err := os.MkdirAll(outsideDir, 0755); err != nil {
+		t.Fatalf("create outside directory: %v", err)
+	}
+
+	linkPath := filepath.Join(contentDir, "linked")
+	if err := os.Symlink(outsideDir, linkPath); err != nil {
+		t.Skipf("symlinks are not available in this environment: %v", err)
+	}
+
+	if got := SafeJoin(root, "content", "linked/secret.md"); got != "" {
+		t.Fatalf("SafeJoin() followed a symlink outside the root: %q", got)
 	}
 }

--- a/pkg/services/git.go
+++ b/pkg/services/git.go
@@ -47,6 +47,9 @@ func CheckSemanticDiff(relPath string) (bool, error) {
 }
 
 func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
+	if token == "" {
+		return "GitHub token is required", fmt.Errorf("empty GitHub token")
+	}
 	start := time.Now()
 	defer func() {
 		slog.Debug("Git command executed", "args", args, "duration", time.Since(start))
@@ -61,27 +64,23 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	// We need to ensure the remote URL in the command triggers ASKPASS.
 	// Typically, https://username@host/repo... works, asking for password.
 
-	cmdGetUrl := exec.CommandContext(ctx, "git", "remote", "get-url", "origin")
+	cmdGetUrl := exec.CommandContext(ctx, "git", "remote", "get-url", config.GitRemote)
 	cmdGetUrl.Dir = dir
 	outUrl, err := cmdGetUrl.Output()
 	if err != nil {
 		return "Failed to get remote url", err
 	}
 	remoteUrl := strings.TrimSpace(string(outUrl))
-	u, err := url.Parse(remoteUrl)
+	authenticatedUrl, err := authenticatedGitHubURL(remoteUrl)
 	if err != nil {
-		return "Invalid remote url", err
+		return "Remote URL must use HTTPS on github.com", err
 	}
-
-	// Set generic username "oauth2" and remove password to force prompt
-	u.User = url.User("oauth2")
-	authenticatedUrl := u.String()
 
 	// 2. Prepare Arguments
 	newArgs := make([]string, len(args))
 	copy(newArgs, args)
 	for i, v := range newArgs {
-		if v == "origin" {
+		if v == config.GitRemote {
 			newArgs[i] = authenticatedUrl
 		}
 	}
@@ -97,12 +96,7 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	cmd.Dir = dir
 
 	// 4. Set Environment
-	env := os.Environ()
-	env = append(env,
-		"GIT_ASKPASS="+scriptPath,
-		"GIT_TOKEN="+token,
-		"GIT_TERMINAL_PROMPT=0", // Disable interactive prompt fallback
-	)
+	env := gitAuthEnvironment(os.Environ(), scriptPath, token)
 	cmd.Env = env
 
 	output, err := cmd.CombinedOutput()
@@ -114,6 +108,51 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	safeLog = strings.ReplaceAll(safeLog, authenticatedUrl, remoteUrl)
 
 	return safeLog, err
+}
+
+func gitAuthEnvironment(base []string, scriptPath, token string) []string {
+	env := make([]string, 0, len(base)+6)
+	for _, entry := range base {
+		key, _, _ := strings.Cut(entry, "=")
+		upperKey := strings.ToUpper(key)
+		if upperKey == "GIT_ASKPASS" ||
+			upperKey == "GIT_TOKEN" ||
+			upperKey == "GIT_TERMINAL_PROMPT" ||
+			upperKey == "GIT_CONFIG_COUNT" ||
+			strings.HasPrefix(upperKey, "GIT_CONFIG_KEY_") ||
+			strings.HasPrefix(upperKey, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		env = append(env, entry)
+	}
+
+	return append(env,
+		"GIT_ASKPASS="+scriptPath,
+		"GIT_TOKEN="+token,
+		"GIT_TERMINAL_PROMPT=0", // Disable interactive prompt fallback
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=credential.helper",
+		"GIT_CONFIG_VALUE_0=",
+	)
+}
+
+func authenticatedGitHubURL(remoteURL string) (string, error) {
+	u, err := url.Parse(remoteURL)
+	if err != nil {
+		return "", fmt.Errorf("parse remote URL: %w", err)
+	}
+	if !strings.EqualFold(u.Scheme, "https") || !strings.EqualFold(u.Hostname(), "github.com") {
+		return "", fmt.Errorf("unsupported Git remote %q", remoteURL)
+	}
+	if u.User != nil {
+		return "", fmt.Errorf("Git remote must not contain embedded credentials")
+	}
+	if u.Path == "" || u.Path == "/" {
+		return "", fmt.Errorf("Git remote repository path is missing")
+	}
+
+	u.User = url.User("oauth2")
+	return u.String(), nil
 }
 
 func createAskPassScript() (string, error) {

--- a/pkg/services/git.go
+++ b/pkg/services/git.go
@@ -64,13 +64,10 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	// We need to ensure the remote URL in the command triggers ASKPASS.
 	// Typically, https://username@host/repo... works, asking for password.
 
-	cmdGetUrl := exec.CommandContext(ctx, "git", "remote", "get-url", config.GitRemote)
-	cmdGetUrl.Dir = dir
-	outUrl, err := cmdGetUrl.Output()
+	remoteUrl, err := readRawRemoteURL(ctx, dir, config.GitRemote)
 	if err != nil {
 		return "Failed to get remote url", err
 	}
-	remoteUrl := strings.TrimSpace(string(outUrl))
 	authenticatedUrl, err := authenticatedGitHubURL(remoteUrl)
 	if err != nil {
 		return "Remote URL must use HTTPS on github.com", err
@@ -96,7 +93,7 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	cmd.Dir = dir
 
 	// 4. Set Environment
-	env := gitAuthEnvironment(os.Environ(), scriptPath, token)
+	env := gitAuthEnvironment(os.Environ(), scriptPath, token, authenticatedUrl)
 	cmd.Env = env
 
 	output, err := cmd.CombinedOutput()
@@ -110,8 +107,23 @@ func ExecuteGitWithToken(dir, token string, args ...string) (string, error) {
 	return safeLog, err
 }
 
-func gitAuthEnvironment(base []string, scriptPath, token string) []string {
-	env := make([]string, 0, len(base)+6)
+func readRawRemoteURL(ctx context.Context, dir, remote string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--local", "--get", "remote."+remote+".url")
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("read configured remote URL: %w", err)
+	}
+
+	remoteURL := strings.TrimSpace(string(output))
+	if remoteURL == "" {
+		return "", fmt.Errorf("configured remote URL is empty")
+	}
+	return remoteURL, nil
+}
+
+func gitAuthEnvironment(base []string, scriptPath, token, authenticatedURL string) []string {
+	env := make([]string, 0, len(base)+9)
 	for _, entry := range base {
 		key, _, _ := strings.Cut(entry, "=")
 		upperKey := strings.ToUpper(key)
@@ -130,9 +142,13 @@ func gitAuthEnvironment(base []string, scriptPath, token string) []string {
 		"GIT_ASKPASS="+scriptPath,
 		"GIT_TOKEN="+token,
 		"GIT_TERMINAL_PROMPT=0", // Disable interactive prompt fallback
-		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_COUNT=2",
 		"GIT_CONFIG_KEY_0=credential.helper",
 		"GIT_CONFIG_VALUE_0=",
+		// An exact self-rewrite wins over broader global insteadOf rules and
+		// keeps the validated GitHub HTTPS URL as the actual network target.
+		"GIT_CONFIG_KEY_1=url."+authenticatedURL+".insteadOf",
+		"GIT_CONFIG_VALUE_1="+authenticatedURL,
 	)
 }
 

--- a/pkg/services/git_test.go
+++ b/pkg/services/git_test.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestAuthenticatedGitHubURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		remote  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "HTTPS GitHub remote",
+			remote: "https://github.com/example/site.git",
+			want:   "https://oauth2@github.com/example/site.git",
+		},
+		{
+			name:    "SSH URL",
+			remote:  "ssh://git@github.com/example/site.git",
+			wantErr: true,
+		},
+		{
+			name:    "scp-like SSH URL",
+			remote:  "git@github.com:example/site.git",
+			wantErr: true,
+		},
+		{
+			name:    "custom SSH alias",
+			remote:  "github:example/site.git",
+			wantErr: true,
+		},
+		{
+			name:    "non-GitHub host",
+			remote:  "https://example.com/example/site.git",
+			wantErr: true,
+		},
+		{
+			name:    "embedded credentials",
+			remote:  "https://user:password@github.com/example/site.git",
+			wantErr: true,
+		},
+		{
+			name:    "missing repository path",
+			remote:  "https://github.com/",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := authenticatedGitHubURL(tt.remote)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("authenticatedGitHubURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("authenticatedGitHubURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitAuthEnvironmentRemovesInheritedGitAuthentication(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"GIT_ASKPASS=attacker",
+		"git_token=old-token",
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=credential.helper",
+		"GIT_CONFIG_VALUE_0=malicious-helper",
+		"GIT_CONFIG_KEY_1=http.extraHeader",
+		"GIT_CONFIG_VALUE_1=Authorization: secret",
+	}
+
+	got := gitAuthEnvironment(base, "/safe/askpass", "new-token")
+
+	wantPresent := []string{
+		"PATH=/usr/bin",
+		"GIT_ASKPASS=/safe/askpass",
+		"GIT_TOKEN=new-token",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=credential.helper",
+		"GIT_CONFIG_VALUE_0=",
+	}
+	for _, entry := range wantPresent {
+		if !slices.Contains(got, entry) {
+			t.Errorf("gitAuthEnvironment() missing %q: %v", entry, got)
+		}
+	}
+	for _, entry := range got {
+		if entry == "GIT_ASKPASS=attacker" ||
+			entry == "git_token=old-token" ||
+			entry == "GIT_CONFIG_VALUE_0=malicious-helper" ||
+			entry == "GIT_CONFIG_KEY_1=http.extraHeader" ||
+			entry == "GIT_CONFIG_VALUE_1=Authorization: secret" {
+			t.Errorf("gitAuthEnvironment() preserved inherited authentication setting %q", entry)
+		}
+	}
+}

--- a/pkg/services/git_test.go
+++ b/pkg/services/git_test.go
@@ -1,7 +1,12 @@
 package services
 
 import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -74,16 +79,19 @@ func TestGitAuthEnvironmentRemovesInheritedGitAuthentication(t *testing.T) {
 		"GIT_CONFIG_VALUE_1=Authorization: secret",
 	}
 
-	got := gitAuthEnvironment(base, "/safe/askpass", "new-token")
+	authenticatedURL := "https://oauth2@github.com/example/site.git"
+	got := gitAuthEnvironment(base, "/safe/askpass", "new-token", authenticatedURL)
 
 	wantPresent := []string{
 		"PATH=/usr/bin",
 		"GIT_ASKPASS=/safe/askpass",
 		"GIT_TOKEN=new-token",
 		"GIT_TERMINAL_PROMPT=0",
-		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_COUNT=2",
 		"GIT_CONFIG_KEY_0=credential.helper",
 		"GIT_CONFIG_VALUE_0=",
+		"GIT_CONFIG_KEY_1=url." + authenticatedURL + ".insteadOf",
+		"GIT_CONFIG_VALUE_1=" + authenticatedURL,
 	}
 	for _, entry := range wantPresent {
 		if !slices.Contains(got, entry) {
@@ -98,5 +106,53 @@ func TestGitAuthEnvironmentRemovesInheritedGitAuthentication(t *testing.T) {
 			entry == "GIT_CONFIG_VALUE_1=Authorization: secret" {
 			t.Errorf("gitAuthEnvironment() preserved inherited authentication setting %q", entry)
 		}
+	}
+}
+
+func TestReadRawRemoteURLIgnoresInsteadOfRewrite(t *testing.T) {
+	repoPath := t.TempDir()
+	runGitForTest(t, repoPath, "init")
+	runGitForTest(t, repoPath, "remote", "add", "origin", "https://github.com/example/site.git")
+
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "url.git@github.com:.insteadOf")
+	t.Setenv("GIT_CONFIG_VALUE_0", "https://github.com/")
+
+	got, err := readRawRemoteURL(context.Background(), repoPath, "origin")
+	if err != nil {
+		t.Fatalf("readRawRemoteURL() unexpected error: %v", err)
+	}
+	if got != "https://github.com/example/site.git" {
+		t.Fatalf("readRawRemoteURL() = %q, want raw configured URL", got)
+	}
+}
+
+func TestGitAuthEnvironmentPreventsURLRewrite(t *testing.T) {
+	authenticatedURL := "https://oauth2@github.com/example/site.git"
+	globalConfig := filepath.Join(t.TempDir(), "gitconfig")
+	configContent := "[url \"ssh://attacker.invalid/\"]\n\tinsteadOf = https://\n"
+	if err := os.WriteFile(globalConfig, []byte(configContent), 0600); err != nil {
+		t.Fatalf("write global Git config: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", globalConfig)
+
+	cmd := exec.Command("git", "ls-remote", "--get-url", authenticatedURL)
+	cmd.Env = gitAuthEnvironment(os.Environ(), filepath.Join(t.TempDir(), "askpass"), "token", authenticatedURL)
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git URL expansion failed: %v", err)
+	}
+	if got := strings.TrimSpace(string(output)); got != authenticatedURL {
+		t.Fatalf("expanded URL = %q, want %q", got, authenticatedURL)
+	}
+}
+
+func runGitForTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
 	}
 }

--- a/pkg/services/media.go
+++ b/pkg/services/media.go
@@ -43,6 +43,11 @@ func isAllowedMediaExtension(path string) bool {
 	return ok
 }
 
+func isAllowedImageExtension(path string) bool {
+	mediaType, ok := allowedMediaTypes[strings.ToLower(filepath.Ext(path))]
+	return ok && strings.HasPrefix(mediaType, "image/")
+}
+
 func ValidateMediaRepoPath(repoPath string) bool {
 	if repoPath == "" || !isAllowedMediaExtension(repoPath) {
 		return false
@@ -99,8 +104,9 @@ func ListMediaFiles(mode, articlePath string) ([]MediaFile, error) {
 			if d.IsDir() {
 				return nil
 			}
-			// Only expose explicitly allowed media files.
-			if isAllowedMediaExtension(path) {
+			// The current media picker renders thumbnails with <img> and
+			// inserts image Markdown, so only expose image files here.
+			if isAllowedImageExtension(path) {
 				// Found image
 				relPath, relErr := filepath.Rel(config.RepoPath, path)
 				if relErr != nil {

--- a/pkg/services/media.go
+++ b/pkg/services/media.go
@@ -1,12 +1,15 @@
 package services
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"hugo-cms/pkg/config"
 	"io"
 	"io/fs"
 	"log/slog"
 	"mime/multipart"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,13 +25,49 @@ type MediaFile struct {
 	RepoPath string `json:"repo_path"`
 }
 
+var ErrInvalidMedia = errors.New("invalid media")
+
+var allowedMediaTypes = map[string]string{
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png":  "image/png",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".mp4":  "video/mp4",
+	".webm": "video/webm",
+	".pdf":  "application/pdf",
+}
+
+func isAllowedMediaExtension(path string) bool {
+	_, ok := allowedMediaTypes[strings.ToLower(filepath.Ext(path))]
+	return ok
+}
+
+func ValidateMediaRepoPath(repoPath string) bool {
+	if repoPath == "" || !isAllowedMediaExtension(repoPath) {
+		return false
+	}
+	normalized := filepath.ToSlash(filepath.Clean(repoPath))
+	if normalized == "." ||
+		(!strings.HasPrefix(normalized, "static/") && !strings.HasPrefix(normalized, "content/")) {
+		return false
+	}
+	return SafeJoin(config.RepoPath, "", normalized) != ""
+}
+
 func ListMediaFiles(mode, articlePath string) ([]MediaFile, error) {
 	var searchDirs []string
+	if mode == "" {
+		mode = "static"
+	}
 
 	// Determine search roots based on mode
 	if mode == "static" {
 		// List all files in repo/static/{StaticMediaDir}
-		staticDir := filepath.Join(config.RepoPath, "static", config.StaticMediaDir)
+		staticDir := SafeJoin(config.RepoPath, "static", config.StaticMediaDir)
+		if staticDir == "" {
+			return nil, fmt.Errorf("%w: invalid static media directory", ErrInvalidMedia)
+		}
 		if _, err := os.Stat(staticDir); err == nil {
 			searchDirs = append(searchDirs, staticDir)
 		}
@@ -36,19 +75,18 @@ func ListMediaFiles(mode, articlePath string) ([]MediaFile, error) {
 		if articlePath == "" {
 			return nil, nil // No article context, return empty
 		}
+		fullArticlePath := SafeJoin(config.RepoPath, "content", articlePath)
+		if fullArticlePath == "" || strings.ToLower(filepath.Ext(fullArticlePath)) != ".md" {
+			return nil, fmt.Errorf("%w: invalid article path", ErrInvalidMedia)
+		}
 		// Assuming articlePath is "posts/2024/slug/index.md" (relative to content)
 		// We want to list files in "repo/content/posts/2024/slug"
-		bundleDir := filepath.Dir(articlePath)
-		fullBundlePath := filepath.Join(config.RepoPath, "content", bundleDir)
+		fullBundlePath := filepath.Dir(fullArticlePath)
 		if _, err := os.Stat(fullBundlePath); err == nil {
 			searchDirs = append(searchDirs, fullBundlePath)
 		}
 	} else {
-		// Default/Fallback: maybe show static?
-		staticDir := filepath.Join(config.RepoPath, "static", config.StaticMediaDir)
-		if _, err := os.Stat(staticDir); err == nil {
-			searchDirs = append(searchDirs, staticDir)
-		}
+		return nil, fmt.Errorf("%w: invalid media mode", ErrInvalidMedia)
 	}
 
 	var files []MediaFile
@@ -61,13 +99,17 @@ func ListMediaFiles(mode, articlePath string) ([]MediaFile, error) {
 			if d.IsDir() {
 				return nil
 			}
-			// Simple filter for images
-			ext := strings.ToLower(filepath.Ext(path))
-			switch ext {
-			case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg":
+			// Only expose explicitly allowed media files.
+			if isAllowedMediaExtension(path) {
 				// Found image
-				relPath, _ := filepath.Rel(config.RepoPath, path)
+				relPath, relErr := filepath.Rel(config.RepoPath, path)
+				if relErr != nil {
+					return relErr
+				}
 				relPath = filepath.ToSlash(relPath)
+				if !ValidateMediaRepoPath(relPath) {
+					return nil
+				}
 
 				// Determine Usage Path
 				usagePath := ""
@@ -76,19 +118,29 @@ func ListMediaFiles(mode, articlePath string) ([]MediaFile, error) {
 					// BUT usually Hugo static files are served at root.
 					// So if StaticMediaDir is "uploads", path is repo/static/uploads/img.png
 					// Usage path: /uploads/img.png
-					staticRel, _ := filepath.Rel(filepath.Join(config.RepoPath, "static"), path)
+					staticRel, relErr := filepath.Rel(filepath.Join(config.RepoPath, "static"), path)
+					if relErr != nil {
+						return relErr
+					}
 					usagePath = "/" + filepath.ToSlash(staticRel)
 				} else {
 					// content/posts/slug/img.png -> img.png (Page Bundle)
 					// Or if in subfolder src/img.png -> src/img.png
-					bundleRel, _ := filepath.Rel(root, path)
+					bundleRel, relErr := filepath.Rel(root, path)
+					if relErr != nil {
+						return relErr
+					}
 					usagePath = filepath.ToSlash(bundleRel)
 				}
 
+				info, infoErr := d.Info()
+				if infoErr != nil {
+					return infoErr
+				}
 				files = append(files, MediaFile{
 					Name:     d.Name(), // Or relative path from root?
 					Path:     usagePath,
-					Size:     0, // d.Info() needed
+					Size:     info.Size(),
 					URL:      "/admin/api/media/raw?path=" + url.QueryEscape(relPath),
 					RepoPath: relPath,
 				})
@@ -109,36 +161,42 @@ func SaveMediaFile(header *multipart.FileHeader, mode, articlePath string) (*Med
 	}
 	defer src.Close()
 
+	if header.Size <= 0 || header.Size > config.MaxUploadSize {
+		return nil, fmt.Errorf("%w: invalid file size", ErrInvalidMedia)
+	}
+
 	filename := filepath.Base(header.Filename)
 	filename = strings.ReplaceAll(filename, " ", "_")
 
 	ext := strings.ToLower(filepath.Ext(filename))
-
-	// Validate Extension
-	allowedExts := map[string]bool{
-		".jpg": true, ".jpeg": true, ".png": true, ".gif": true,
-		".webp": true, ".svg": true, ".mp4": true, ".webm": true, ".pdf": true,
-	}
-	if !allowedExts[ext] {
-		return nil, fmt.Errorf("file type not allowed: %s", ext)
+	expectedContentType, ok := allowedMediaTypes[ext]
+	if !ok {
+		return nil, fmt.Errorf("%w: file type not allowed: %s", ErrInvalidMedia, ext)
 	}
 
 	name := strings.TrimSuffix(filename, ext)
-	filename = fmt.Sprintf("%s_%d%s", name, time.Now().Unix(), ext)
+	filename = fmt.Sprintf("%s_%d%s", name, time.Now().UnixNano(), ext)
 
 	var targetDir string
 
 	if mode == "static" {
-		targetDir = filepath.Join(config.RepoPath, "static", config.StaticMediaDir)
-	} else {
+		targetDir = SafeJoin(config.RepoPath, "static", config.StaticMediaDir)
+	} else if mode == "content" {
 		// Content mode
 		if articlePath == "" {
-			return nil, fmt.Errorf("article path required for content upload")
+			return nil, fmt.Errorf("%w: article path required for content upload", ErrInvalidMedia)
 		}
-		bundleDir := filepath.Dir(articlePath)
-		// Use ARTICLE_MEDIA_DIR config
-		subDir := config.ArticleMediaDir
-		targetDir = filepath.Join(config.RepoPath, "content", bundleDir, subDir)
+		fullArticlePath := SafeJoin(config.RepoPath, "content", articlePath)
+		if fullArticlePath == "" || strings.ToLower(filepath.Ext(fullArticlePath)) != ".md" {
+			return nil, fmt.Errorf("%w: invalid article path", ErrInvalidMedia)
+		}
+		// Use ARTICLE_MEDIA_DIR config, constrained to the article bundle.
+		targetDir = SafeJoin(filepath.Dir(fullArticlePath), "", config.ArticleMediaDir)
+	} else {
+		return nil, fmt.Errorf("%w: invalid media mode", ErrInvalidMedia)
+	}
+	if targetDir == "" {
+		return nil, fmt.Errorf("%w: invalid media target directory", ErrInvalidMedia)
 	}
 
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
@@ -146,23 +204,57 @@ func SaveMediaFile(header *multipart.FileHeader, mode, articlePath string) (*Med
 	}
 
 	fullMediaPath := filepath.Join(targetDir, filename)
-	dst, err := os.Create(fullMediaPath)
+	dst, err := os.CreateTemp(targetDir, ".upload-*")
 	if err != nil {
 		return nil, err
 	}
-	defer dst.Close()
+	tempPath := dst.Name()
+	defer os.Remove(tempPath)
 
-	if _, err := io.Copy(dst, src); err != nil {
+	head := make([]byte, 512)
+	n, readErr := io.ReadFull(src, head)
+	if readErr != nil && readErr != io.ErrUnexpectedEOF {
+		dst.Close()
+		return nil, fmt.Errorf("read upload: %w", readErr)
+	}
+	if detected := http.DetectContentType(head[:n]); detected != expectedContentType {
+		dst.Close()
+		return nil, fmt.Errorf("%w: file content does not match extension: got %s", ErrInvalidMedia, detected)
+	}
+
+	reader := io.MultiReader(bytes.NewReader(head[:n]), src)
+	written, copyErr := io.Copy(dst, io.LimitReader(reader, config.MaxUploadSize+1))
+	if copyErr != nil {
+		dst.Close()
+		return nil, copyErr
+	}
+	if written > config.MaxUploadSize {
+		dst.Close()
+		return nil, fmt.Errorf("%w: file exceeds maximum upload size", ErrInvalidMedia)
+	}
+	if err := dst.Close(); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(tempPath, fullMediaPath); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(fullMediaPath, 0644); err != nil {
 		return nil, err
 	}
 
 	// Calculate Result
-	relPath, _ := filepath.Rel(config.RepoPath, fullMediaPath)
+	relPath, err := filepath.Rel(config.RepoPath, fullMediaPath)
+	if err != nil {
+		return nil, err
+	}
 	relPath = filepath.ToSlash(relPath)
 
 	usagePath := ""
 	if mode == "static" {
-		staticRel, _ := filepath.Rel(filepath.Join(config.RepoPath, "static"), fullMediaPath)
+		staticRel, relErr := filepath.Rel(filepath.Join(config.RepoPath, "static"), fullMediaPath)
+		if relErr != nil {
+			return nil, relErr
+		}
 		usagePath = "/" + filepath.ToSlash(staticRel)
 	} else {
 		// Relative to bundle root
@@ -170,8 +262,11 @@ func SaveMediaFile(header *multipart.FileHeader, mode, articlePath string) (*Med
 		// We need path relative to bundle root.
 		// Bundle root is targetDir without subDir (if subDir is relative)
 		// Actually simpler:
-		bundleRoot := filepath.Join(config.RepoPath, "content", filepath.Dir(articlePath))
-		bundleRel, _ := filepath.Rel(bundleRoot, fullMediaPath)
+		bundleRoot := filepath.Dir(SafeJoin(config.RepoPath, "content", articlePath))
+		bundleRel, relErr := filepath.Rel(bundleRoot, fullMediaPath)
+		if relErr != nil {
+			return nil, relErr
+		}
 		usagePath = filepath.ToSlash(bundleRel)
 	}
 
@@ -185,9 +280,12 @@ func SaveMediaFile(header *multipart.FileHeader, mode, articlePath string) (*Med
 }
 
 func DeleteMediaFile(repoPath string) error {
+	if !ValidateMediaRepoPath(repoPath) {
+		return fmt.Errorf("%w: invalid media path", ErrInvalidMedia)
+	}
 	fullMediaPath := SafeJoin(config.RepoPath, "", repoPath)
 	if fullMediaPath == "" {
-		return fmt.Errorf("invalid media path")
+		return fmt.Errorf("%w: invalid media path", ErrInvalidMedia)
 	}
 	return os.Remove(fullMediaPath)
 }

--- a/pkg/services/media_test.go
+++ b/pkg/services/media_test.go
@@ -55,32 +55,27 @@ func withMediaConfig(t *testing.T, repoPath string) {
 }
 
 func TestListMediaFiles(t *testing.T) {
-	// Create temp directory structure
-	tmpDir, err := os.MkdirTemp("", "media_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	repoPath := t.TempDir()
+	withMediaConfig(t, repoPath)
 
-	// Create static/images directory
-	staticDir := filepath.Join(tmpDir, "static", "images")
+	staticDir := filepath.Join(repoPath, "static", "images")
 	if err := os.MkdirAll(staticDir, 0755); err != nil {
-		t.Fatalf("Failed to create static dir: %v", err)
+		t.Fatalf("create static directory: %v", err)
 	}
 
-	// Create test image file
-	testFile := filepath.Join(staticDir, "test.jpg")
-	if err := os.WriteFile(testFile, []byte("fake image data"), 0644); err != nil {
-		t.Fatalf("Failed to create test file: %v", err)
+	for _, name := range []string{"photo.jpg", "clip.mp4", "document.pdf", "script.svg"} {
+		if err := os.WriteFile(filepath.Join(staticDir, name), []byte("test"), 0644); err != nil {
+			t.Fatalf("create test media %q: %v", name, err)
+		}
 	}
 
-	// Note: ListMediaFiles uses config.RepoPath which makes it hard to test in isolation.
-	// This test documents the expected behavior but may need config injection for proper unit testing.
-	t.Run("Static mode requires valid config", func(t *testing.T) {
-		// This would require setting up config.RepoPath, config.StaticMediaDir
-		// For now, we test the function exists and returns without panic
-		_, _ = ListMediaFiles("static", "")
-	})
+	files, err := ListMediaFiles("static", "")
+	if err != nil {
+		t.Fatalf("ListMediaFiles() unexpected error: %v", err)
+	}
+	if len(files) != 1 || files[0].Name != "photo.jpg" {
+		t.Fatalf("ListMediaFiles() = %#v, want only photo.jpg", files)
+	}
 
 	t.Run("Content mode requires article path", func(t *testing.T) {
 		files, err := ListMediaFiles("content", "")
@@ -238,6 +233,8 @@ func TestValidateMediaRepoPath(t *testing.T) {
 		want bool
 	}{
 		{path: "static/images/photo.jpg", want: true},
+		{path: "static/images/clip.mp4", want: true},
+		{path: "static/images/document.pdf", want: true},
 		{path: "content/posts/photo.png", want: true},
 		{path: ".git/config", want: false},
 		{path: "static/../.git/config.jpg", want: false},

--- a/pkg/services/media_test.go
+++ b/pkg/services/media_test.go
@@ -1,10 +1,58 @@
 package services
 
 import (
+	"bytes"
+	"hugo-cms/pkg/config"
+	"mime/multipart"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func testFileHeader(t *testing.T, filename string, content []byte) *multipart.FileHeader {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("CreateFormFile() error: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		t.Fatalf("write multipart content: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	request := httptest.NewRequest("POST", "/", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	if err := request.ParseMultipartForm(int64(body.Len())); err != nil {
+		t.Fatalf("ParseMultipartForm() error: %v", err)
+	}
+	return request.MultipartForm.File["file"][0]
+}
+
+func withMediaConfig(t *testing.T, repoPath string) {
+	t.Helper()
+
+	originalRepoPath := config.RepoPath
+	originalStaticDir := config.StaticMediaDir
+	originalArticleDir := config.ArticleMediaDir
+	originalMaxSize := config.MaxUploadSize
+	t.Cleanup(func() {
+		config.RepoPath = originalRepoPath
+		config.StaticMediaDir = originalStaticDir
+		config.ArticleMediaDir = originalArticleDir
+		config.MaxUploadSize = originalMaxSize
+	})
+
+	config.RepoPath = repoPath
+	config.StaticMediaDir = "images"
+	config.ArticleMediaDir = "images"
+	config.MaxUploadSize = 1024 * 1024
+}
 
 func TestListMediaFiles(t *testing.T) {
 	// Create temp directory structure
@@ -67,9 +115,9 @@ func TestSaveMediaFile_InvalidExtension(t *testing.T) {
 	// Create a mock file header - this is tricky without a full request
 	// Document expected behavior: should reject files with disallowed extensions
 	t.Run("Extension validation", func(t *testing.T) {
-		// Allowed extensions are: .jpg, .jpeg, .png, .gif, .webp, .svg, .mp4, .webm, .pdf
-		allowedExts := []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".mp4", ".webm", ".pdf"}
-		disallowedExts := []string{".exe", ".sh", ".bat", ".php", ".html", ".js"}
+		// SVG is intentionally rejected because it can contain executable content.
+		allowedExts := []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".mp4", ".webm", ".pdf"}
+		disallowedExts := []string{".svg", ".exe", ".sh", ".bat", ".php", ".html", ".js"}
 
 		for _, ext := range allowedExts {
 			t.Logf("Allowed extension: %s", ext)
@@ -120,5 +168,86 @@ func TestDeleteMediaFile_InvalidPath(t *testing.T) {
 	err = DeleteMediaFile("../../../etc/passwd")
 	if err == nil {
 		t.Error("DeleteMediaFile should return error for path traversal attempt")
+	}
+}
+
+func TestSaveMediaFileRejectsArticlePathTraversal(t *testing.T) {
+	baseDir := t.TempDir()
+	repoPath := filepath.Join(baseDir, "repo")
+	if err := os.MkdirAll(filepath.Join(repoPath, "content"), 0755); err != nil {
+		t.Fatalf("create content directory: %v", err)
+	}
+	withMediaConfig(t, repoPath)
+
+	header := testFileHeader(t, "image.png", []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	})
+	if _, err := SaveMediaFile(header, "content", "../../outside/index.md"); err == nil {
+		t.Fatal("SaveMediaFile() should reject an article path outside content")
+	}
+
+	if _, err := os.Stat(filepath.Join(baseDir, "outside")); !os.IsNotExist(err) {
+		t.Fatalf("outside directory should not be created, stat error = %v", err)
+	}
+}
+
+func TestSaveMediaFileRejectsMismatchedContent(t *testing.T) {
+	repoPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoPath, "static", "images"), 0755); err != nil {
+		t.Fatalf("create static directory: %v", err)
+	}
+	withMediaConfig(t, repoPath)
+
+	header := testFileHeader(t, "not-an-image.jpg", []byte("%PDF-1.7\n"))
+	if _, err := SaveMediaFile(header, "static", ""); err == nil {
+		t.Fatal("SaveMediaFile() should reject content that does not match its extension")
+	}
+}
+
+func TestSaveMediaFileWritesValidatedImage(t *testing.T) {
+	repoPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoPath, "static", "images"), 0755); err != nil {
+		t.Fatalf("create static directory: %v", err)
+	}
+	withMediaConfig(t, repoPath)
+
+	header := testFileHeader(t, "image.png", []byte{
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	})
+	media, err := SaveMediaFile(header, "static", "")
+	if err != nil {
+		t.Fatalf("SaveMediaFile() unexpected error: %v", err)
+	}
+	if !ValidateMediaRepoPath(media.RepoPath) {
+		t.Fatalf("SaveMediaFile() returned invalid repository path %q", media.RepoPath)
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, filepath.FromSlash(media.RepoPath))); err != nil {
+		t.Fatalf("saved media file not found: %v", err)
+	}
+}
+
+func TestValidateMediaRepoPath(t *testing.T) {
+	repoPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoPath, "static", "images"), 0755); err != nil {
+		t.Fatalf("create static directory: %v", err)
+	}
+	withMediaConfig(t, repoPath)
+
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "static/images/photo.jpg", want: true},
+		{path: "content/posts/photo.png", want: true},
+		{path: ".git/config", want: false},
+		{path: "static/../.git/config.jpg", want: false},
+		{path: "static/images/script.svg", want: false},
+		{path: "../../outside/photo.jpg", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := ValidateMediaRepoPath(tt.path); got != tt.want {
+			t.Errorf("ValidateMediaRepoPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
 	}
 }

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -181,7 +181,6 @@ export async function uploadMedia(file, mode, path) {
     formData.append('file', file);
     if (mode) formData.append('mode', mode);
     if (path) formData.append('path', path);
-    formData.append('csrf_token', csrfToken); // CSRF token in form data for multipart
     const res = await fetch('/admin/api/media', {
         method: 'POST',
         headers: getCSRFHeaders(),

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,7 +77,13 @@
             </div>
 
             <div id="preview-view">
-                <iframe id="preview-frame" src=""></iframe>
+                <iframe
+                    id="preview-frame"
+                    src=""
+                    sandbox="allow-forms allow-scripts"
+                    referrerpolicy="no-referrer"
+                    title="Site preview"
+                ></iframe>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary

- make GitHub user authorization fail closed and re-check authorization on every protected request
- encrypt session cookies, strengthen OAuth/CSRF token handling, and add HTTP limits and security headers
- constrain media paths to the repository, reject symlink escapes, validate upload MIME types and sizes, and reject SVG uploads
- restrict authenticated Git operations to credential-free `https://github.com` remotes and isolate Git credential configuration
- sandbox Hugo previews and require authentication for proxied preview routes
- update security documentation, deployment guidance, API documentation, and regression tests

## Why

The security audit identified permissive authorization defaults, plaintext OAuth tokens inside signed cookies, repository path traversal, unsafe Git authentication fallback, and same-origin preview execution. These issues could allow unauthorized CMS access, token exposure, writes outside the repository, use of server-side credentials, or preview content interacting with the CMS origin.

## Operational impact

- `ALLOWED_GITHUB_USERS` must contain at least one user. `ALLOW_ALL_GITHUB_USERS=true` is only accepted outside release mode.
- `SESSION_SECRET` must be at least 32 characters and is required in release mode.
- CMS sync/publish now requires a credential-free `https://github.com/owner/repository.git` remote. Existing SSH remotes must be migrated.
- SVG uploads are no longer accepted because SVG can contain executable content.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `node --check static/js/api.js`
- `git diff --check`