### PR TITLE
feat: add site-aware preview routing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Hugo CMSの利用方法、仕様、設計、および監査結果を目的別に
 
 - [設定ガイド](guides/configuration.md) - 環境変数と実行設定
 - [デプロイガイド](guides/deployment.md) - サーバー、Docker、リバースプロキシ
+- [Smoke Test Checklist](guides/smoke-tests.md) - 変更後の最低限確認項目
 
 ## リファレンス
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -179,10 +179,11 @@ type GeneratorAdapter interface {
 - shutdown時の全preview停止
 - `/admin/preview/{siteID}/...` 経由の認証付きproxy
 - selected siteのiframe preview
+- 初回proxy前のpreview port readiness wait
 - preview内のroot-relative URLを同じsiteのpreview routeへ戻すredirect
 - `hugo_server_bind` + `hugo_server_port` の重複設定の拒否
 
-現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。同じbind/portを複数siteへ割り当てると、preview processの起動直後に既存プロセスへ誤proxyする可能性があるため、設定読み込み時に拒否する。今後の改善候補として、動的な空きポート割り当て、readiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
+現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。同じbind/portを複数siteへ割り当てると、preview processの起動直後に既存プロセスへ誤proxyする可能性があるため、設定読み込み時に拒否する。初回preview requestでは、process起動後にTCP接続できるまで短時間待ってからproxyする。今後の改善候補として、動的な空きポート割り当て、HTTPレベルのreadiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -204,6 +204,7 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 - preview process管理はサイト設定を明示的に受け取り、site IDごとにadapterを保持する。
 - 記事キャッシュは`repo_path + content_dir`でkey分割する。
 - process-wide runtimeを読むscope外処理はruntime lockで保護する。
+- preview adapter mapのlockはmapアクセス中だけ保持し、preview process操作やruntime bridge呼び出し中には保持しない。`/ready`などがruntime lockを先に取るため、lock順序の反転を避ける。
 
 今後の最終形は、記事・メディア・Git・generatorサービスへ`SiteConfig`または`SiteRuntime`を明示的に渡し、process-wide runtime mutationを削減することである。
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -1,10 +1,10 @@
 # マルチサイト・マルチジェネレーター設計
 
-最終更新日: 2026-07-06
+最終更新日: 2026-07-10
 
 ## ステータス
 
-提案段階。現在のHugo向け動作を維持しながら段階的に移行する。
+段階実装中。現在のHugo向け動作を維持しながら、Site Registry、site-aware API、site別preview processへ移行している。
 
 ## 背景
 
@@ -172,14 +172,37 @@ type GeneratorAdapter interface {
 
 ### Preview Process Supervisor
 
-現在の単一グローバルなHugoプロセスを、サイトIDをキーにしたプロセス管理へ変更する。
+単一グローバルなHugoプロセスではなく、サイトIDをキーにしたプロセス管理を行う。
 
-- 動的な空きポート割り当て
 - サイト単位の起動・停止・再起動
 - 多重起動防止
-- readiness確認
-- アイドル時の自動停止
-- 同時起動数、CPU、メモリ、実行時間の制限
+- shutdown時の全preview停止
+- `/admin/preview/{siteID}/...` 経由の認証付きproxy
+- selected siteのiframe preview
+
+現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。今後の改善候補として、動的な空きポート割り当て、readiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
+
+```mermaid
+flowchart LR
+    UI["Editor iframe"] --> Proxy["/admin/preview/{siteID}/..."]
+    Proxy --> Registry["Site Registry"]
+    Registry --> Manager["Preview Manager"]
+    Manager --> HugoProc["Hugo server (site A)"]
+    Manager --> EleventyProc["Eleventy --serve (site B)"]
+```
+
+preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:<preview-port>`をブラウザへ露出しないことで、previewプロセスのbind先をローカルに閉じ込めやすくする。
+
+### Site Runtime Bridge
+
+既存サービスの多くは`config.RepoPath`などのprocess-wide runtime値を参照している。現在は互換性を保つため、HTTP handler層で選択サイトを解決し、短時間だけruntime値を適用するbridgeを使っている。
+
+- site-scoped APIは`?site=`または`X-CMS-Site`で対象サイトを指定する。
+- preview process管理はサイト設定を明示的に受け取り、site IDごとにadapterを保持する。
+- 記事キャッシュは`repo_path + content_dir`でkey分割する。
+- process-wide runtimeを読むscope外処理はruntime lockで保護する。
+
+今後の最終形は、記事・メディア・Git・generatorサービスへ`SiteConfig`または`SiteRuntime`を明示的に渡し、process-wide runtime mutationを削減することである。
 
 ## ジェネレーターごとの差異
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -179,8 +179,10 @@ type GeneratorAdapter interface {
 - shutdown時の全preview停止
 - `/admin/preview/{siteID}/...` 経由の認証付きproxy
 - selected siteのiframe preview
+- preview内のroot-relative URLを同じsiteのpreview routeへ戻すredirect
+- `hugo_server_bind` + `hugo_server_port` の重複設定の拒否
 
-現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。今後の改善候補として、動的な空きポート割り当て、readiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
+現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。同じbind/portを複数siteへ割り当てると、preview processの起動直後に既存プロセスへ誤proxyする可能性があるため、設定読み込み時に拒否する。今後の改善候補として、動的な空きポート割り当て、readiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -182,8 +182,9 @@ type GeneratorAdapter interface {
 - 初回proxy前のpreview port readiness wait
 - preview内のroot-relative URLを同じsiteのpreview routeへ戻すredirect
 - `hugo_server_bind` + `hugo_server_port` の重複設定の拒否
+- `0.0.0.0`や`::`のwildcard bindは同じport上の任意bindと衝突扱いにする
 
-現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。同じbind/portを複数siteへ割り当てると、preview processの起動直後に既存プロセスへ誤proxyする可能性があるため、設定読み込み時に拒否する。初回preview requestでは、process起動後にTCP接続できるまで短時間待ってからproxyする。今後の改善候補として、動的な空きポート割り当て、HTTPレベルのreadiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
+現在の実装では、ポートはSite Registryの`hugo_server_port`で明示する。同じbind/portを複数siteへ割り当てると、preview processの起動直後に既存プロセスへ誤proxyする可能性があるため、設定読み込み時に拒否する。wildcard bindは同じportの具体bindも占有し得るため、同じportの任意bindと衝突扱いにする。初回preview requestでは、process起動後にTCP接続できるまで短時間待ってからproxyする。今後の改善候補として、動的な空きポート割り当て、HTTPレベルのreadiness確認、アイドル時の自動停止、同時起動数やCPU/メモリ制限がある。
 
 ```mermaid
 flowchart LR

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -178,6 +178,8 @@ HTTP APIでは、`?site=<site_id>`または`X-CMS-Site: <site_id>`で対象サ�
 
 サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
 
+初回preview requestで対象サイトのpreview processを起動した場合、CMSはproxyする前にpreview portが実際に接続可能になるまで短時間待機します。これにより、process起動直後にiframeが`502 Preview unavailable`になる揺らぎを抑えます。
+
 preview iframe内のページ・画像・CSSなどが`/images/foo.png`のようなroot-relative URLを要求した場合も、直前のpreview URLから選択サイトを判定し、同じ`/admin/preview/<site_id>/...`配下へリダイレクトします。これにより非defaultサイトのpreviewがdefaultサイトのroot proxyへ落ちることを避けます。
 
 ### site registry項目

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -176,7 +176,9 @@ HTTP APIでは、`?site=<site_id>`または`X-CMS-Site: <site_id>`で対象サ�
 /admin/preview/<site_id>/<page-path>
 ```
 
-サイトごとに`hugo_server_port`を重複しない値にしてください。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
+サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
+
+preview iframe内のページ・画像・CSSなどが`/images/foo.png`のようなroot-relative URLを要求した場合も、直前のpreview URLから選択サイトを判定し、同じ`/admin/preview/<site_id>/...`配下へリダイレクトします。これにより非defaultサイトのpreviewがdefaultサイトのroot proxyへ落ちることを避けます。
 
 ### site registry項目
 
@@ -189,7 +191,7 @@ HTTP APIでは、`?site=<site_id>`または`X-CMS-Site: <site_id>`で対象サ�
 | `content_dir` | いいえ | Markdown記事のルート。デフォルト`content` |
 | `static_dir` | いいえ | 静的ファイルのルート。デフォルト`static` |
 | `public_dir` | いいえ | build出力先。デフォルト`public` |
-| `hugo_server_port` | いいえ | previewプロセスのポート。サイト間で重複不可 |
+| `hugo_server_port` | いいえ | previewプロセスのポート。`hugo_server_bind`との組み合わせはサイト間で重複不可 |
 | `hugo_server_bind` | いいえ | preview bind address。デフォルト`127.0.0.1` |
 | `snippet_paths` | いいえ | スニペットファイル。相対パスは`repo_path`基準 |
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -149,6 +149,8 @@ sites:
     static_dir: static
     public_dir: public
     hugo_server_port: "1314"
+    snippet_paths:
+      - .vscode/md.code-snippets
 
   - id: notes
     name: Notes
@@ -158,9 +160,38 @@ sites:
     static_dir: public-assets
     public_dir: _site
     hugo_server_port: "1315"
+    snippet_paths:
+      - .vscode/md.code-snippets
 ```
 
-現時点ではdefault siteを既存APIへ適用し、`GET /admin/api/sites`で読み込まれたSite Registryを確認できます。UI上のサイト切替とsiteId付きAPIは次段階で追加します。
+Site Registryを設定すると、管理画面のサイドバーにサイトセレクタが表示されます。記事、CMS設定、メディア、スニペット、Git操作、プレビューは選択中サイトを対象にします。
+
+HTTP APIでは、`?site=<site_id>`または`X-CMS-Site: <site_id>`で対象サイトを指定できます。未指定の場合は`default_site`が使われます。
+
+### Preview
+
+プレビューはサイトごとに独立したプロセスとして管理されます。選択中サイトのiframeは次の内部proxyを参照します。
+
+```text
+/admin/preview/<site_id>/<page-path>
+```
+
+サイトごとに`hugo_server_port`を重複しない値にしてください。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
+
+### site registry項目
+
+| 項目 | 必須 | 説明 |
+|---|---:|---|
+| `id` | はい | サイトID。UI、API、preview routeで使用 |
+| `name` | いいえ | UI表示名。未指定時は`id` |
+| `repo_path` | はい | 対象リポジトリ |
+| `generator` | いいえ | `hugo`または`eleventy` |
+| `content_dir` | いいえ | Markdown記事のルート。デフォルト`content` |
+| `static_dir` | いいえ | 静的ファイルのルート。デフォルト`static` |
+| `public_dir` | いいえ | build出力先。デフォルト`public` |
+| `hugo_server_port` | いいえ | previewプロセスのポート。サイト間で重複不可 |
+| `hugo_server_bind` | いいえ | preview bind address。デフォルト`127.0.0.1` |
+| `snippet_paths` | いいえ | スニペットファイル。相対パスは`repo_path`基準 |
 
 ### スニペット設定
 
@@ -170,11 +201,24 @@ Markdown編集時に使用するスニペットファイルのパス。カンマ
 ファイル形式は VS Code のスニペット形式 (`.code-snippets` または `.json`) に準拠します。
 `scope` プロパティに `markdown` が含まれるか、`scope` が未指定（グローバル）のスニペットのみが読み込まれます。
 
-デフォルト: `repo/.vscode/md.code-snippets`
+単一サイト構成のデフォルト: `<REPO_PATH>/.vscode/md.code-snippets`
+
+Site Registry利用時は、サイトごとに`snippet_paths`を指定できます。未指定の場合は各サイトの`<repo_path>/.vscode/md.code-snippets`を読み込みます。
 
 ```env
 # 複数ファイルを指定
 SNIPPET_PATHS=repo/.vscode/global.code-snippets,repo/.vscode/md.code-snippets
+```
+
+Site Registryでの例:
+
+```yaml
+sites:
+  - id: techblog
+    repo_path: D:/sites/techblog
+    snippet_paths:
+      - .vscode/global.code-snippets
+      - .vscode/md.code-snippets
 ```
 
 ### メディア設定

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -176,7 +176,7 @@ HTTP APIでは、`?site=<site_id>`または`X-CMS-Site: <site_id>`で対象サ�
 /admin/preview/<site_id>/<page-path>
 ```
 
-サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
+サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。`0.0.0.0`や`::`のようなwildcard bindは同じportの任意bindと衝突扱いになります。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
 
 初回preview requestで対象サイトのpreview processを起動した場合、CMSはproxyする前にpreview portが実際に接続可能になるまで短時間待機します。これにより、process起動直後にiframeが`502 Preview unavailable`になる揺らぎを抑えます。
 
@@ -194,7 +194,7 @@ preview iframe内のページ・画像・CSSなどが`/images/foo.png`のよう�
 | `static_dir` | いいえ | 静的ファイルのルート。デフォルト`static` |
 | `public_dir` | いいえ | build出力先。デフォルト`public` |
 | `hugo_server_port` | いいえ | previewプロセスのポート。`hugo_server_bind`との組み合わせはサイト間で重複不可 |
-| `hugo_server_bind` | いいえ | preview bind address。デフォルト`127.0.0.1` |
+| `hugo_server_bind` | いいえ | preview bind address。デフォルト`127.0.0.1`。`0.0.0.0`や`::`は同じportの全bindと衝突扱い |
 | `snippet_paths` | いいえ | スニペットファイル。相対パスは`repo_path`基準 |
 
 ### スニペット設定

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -68,6 +68,7 @@ sites:
 - `/admin/api/config?site=<id>` の `_cms.site_id` が対象サイトになる
 - スニペットが選択サイトの`snippet_paths`または`<repo_path>/.vscode/md.code-snippets`から読み込まれる
 - Preview iframe が `/admin/preview/<site_id>/...` を参照する
+- 初回previewでも、preview process起動直後のport未listenによる一時的な`502`にならない
 - preview内のroot-relative URL (`/images/foo.png`, `/about/`など) が同じsiteの`/admin/preview/<site_id>/...`へリダイレクトされる
 - サイトごとに別のpreview processが起動する
 - Restart Previewが選択サイトのpreviewだけを再起動する

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -1,0 +1,101 @@
+# Smoke Test Checklist
+
+最終更新日: 2026-07-10
+
+大きめの変更やSite Registry変更後に、最低限確認する項目です。
+
+## 1. 共通
+
+```powershell
+go test ./...
+go vet ./...
+go build -buildvcs=false ./...
+git diff --check
+```
+
+ブラウザでは以下を確認します。
+
+- `/admin/login` からログインできる
+- `/health` が `200`
+- `/ready` がdefault siteの状態を返す
+- `/admin/api/sites` がSite Registryを返す
+
+## 2. 単一Hugoサイト
+
+`SITES_CONFIG_PATH`を未設定にして確認します。
+
+- 記事一覧が表示される
+- 記事を開ける
+- front matter formが表示される
+- 保存できる
+- Diffが表示される
+- 画像メディア一覧が表示される
+- スニペットが `<REPO_PATH>/.vscode/md.code-snippets` から読み込まれる
+- Preview iframe が `/admin/preview/default/...` で表示される
+- Restart Previewが成功する
+
+## 3. 複数サイト
+
+例:
+
+```yaml
+default_site: techblog
+sites:
+  - id: techblog
+    name: Tech Blog
+    repo_path: D:/sites/techblog
+    generator: hugo
+    content_dir: content
+    static_dir: static
+    public_dir: public
+    hugo_server_port: "1314"
+
+  - id: notes
+    name: Notes
+    repo_path: D:/sites/notes
+    generator: eleventy
+    content_dir: src
+    static_dir: public-assets
+    public_dir: _site
+    hugo_server_port: "1315"
+```
+
+確認項目:
+
+- サイドバーのSite selectorで切り替えられる
+- 切り替え後、記事一覧が選択サイトの内容になる
+- `/admin/api/articles?site=<id>` が対象サイトの内容を返す
+- `/admin/api/config?site=<id>` の `_cms.site_id` が対象サイトになる
+- スニペットが選択サイトの`snippet_paths`または`<repo_path>/.vscode/md.code-snippets`から読み込まれる
+- Preview iframe が `/admin/preview/<site_id>/...` を参照する
+- サイトごとに別のpreview processが起動する
+- Restart Previewが選択サイトのpreviewだけを再起動する
+
+## 4. Eleventy
+
+対象リポジトリには以下が必要です。
+
+- `package.json`
+- `@11ty/eleventy` dependency
+- lockfile (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lock`, `bun.lockb`)
+- `content_dir` と `public_dir` の明示
+
+確認項目:
+
+- 記事一覧が`content_dir`配下から取得される
+- 記事を保存できる
+- Previewが`eleventy --serve`で起動する
+- Buildがlockfileに対応するpackage manager経由で実行される
+
+## 5. Git操作
+
+- Syncが対象サイトのrepoで実行される
+- 単一記事publishが対象サイトのcontent pathをcommit対象にする
+- static directoryが未作成でも単一記事publishが失敗しない
+- push失敗後の再publishで、既存commitがremoteへpushされる
+
+## 6. 注意点
+
+- preview portはサイト間で重複させないでください。
+- preview processはCMSサーバー上でサイトのコードを実行します。Site Registryには信頼済みリポジトリだけを登録してください。
+- 現在は互換性維持のため、内部サービスの一部がprocess-wide runtime bridgeを使います。scope外のruntime readsはlockで保護し、今後は明示的な`SiteRuntime`引数へ段階移行します。

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -68,8 +68,10 @@ sites:
 - `/admin/api/config?site=<id>` の `_cms.site_id` が対象サイトになる
 - スニペットが選択サイトの`snippet_paths`または`<repo_path>/.vscode/md.code-snippets`から読み込まれる
 - Preview iframe が `/admin/preview/<site_id>/...` を参照する
+- preview内のroot-relative URL (`/images/foo.png`, `/about/`など) が同じsiteの`/admin/preview/<site_id>/...`へリダイレクトされる
 - サイトごとに別のpreview processが起動する
 - Restart Previewが選択サイトのpreviewだけを再起動する
+- `hugo_server_bind` + `hugo_server_port` が重複しているSite Registryは起動時に拒否される
 
 ## 4. Eleventy
 
@@ -96,6 +98,6 @@ sites:
 
 ## 6. 注意点
 
-- preview portはサイト間で重複させないでください。
+- preview bind/portはサイト間で重複させないでください。重複したSite Registryは起動時に拒否されます。
 - preview processはCMSサーバー上でサイトのコードを実行します。Site Registryには信頼済みリポジトリだけを登録してください。
 - 現在は互換性維持のため、内部サービスの一部がprocess-wide runtime bridgeを使います。scope外のruntime readsはlockで保護し、今後は明示的な`SiteRuntime`引数へ段階移行します。

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -73,6 +73,7 @@ sites:
 - サイトごとに別のpreview processが起動する
 - Restart Previewが選択サイトのpreviewだけを再起動する
 - `hugo_server_bind` + `hugo_server_port` が重複しているSite Registryは起動時に拒否される
+- `0.0.0.0`や`::`のwildcard bindは、同じportの具体bindとも衝突として拒否される
 
 ## 4. Eleventy
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -5,6 +5,7 @@ Hugo CMSのREST API仕様です。
 ## 認証
 
 すべての `/admin/api/*` エンドポイントは認証が必要です。
+`/admin/preview/*` も認証済みadmin route配下で提供されます。
 
 ### セッション認証
 
@@ -29,6 +30,36 @@ fetch('/admin/api/article', {
     body: JSON.stringify(data)
 });
 ```
+
+---
+
+## サイト指定
+
+Site Registryを使う場合、site-aware APIはクエリパラメータまたはヘッダーで対象サイトを指定できます。
+
+```http
+GET /admin/api/articles?site=techblog
+X-CMS-Site: techblog
+```
+
+両方が指定された場合はクエリパラメータが優先されます。未指定の場合は`default_site`が使われます。
+
+対象API:
+
+- `/admin/api/articles`
+- `/admin/api/article`
+- `/admin/api/create`
+- `/admin/api/delete`
+- `/admin/api/diff`
+- `/admin/api/config`
+- `/admin/api/snippets`
+- `/admin/api/sync`
+- `/admin/api/publish`
+- `/admin/api/media`
+- `/admin/api/media/delete`
+- `/admin/api/media/raw`
+- `/admin/api/build`
+- `/admin/api/build/restart`
 
 ---
 
@@ -221,6 +252,52 @@ CSRFトークンを取得します。
     "type": "git"  // "git", "unsaved", or "none"
 }
 ```
+
+---
+
+## サイトAPI
+
+### GET /admin/api/sites
+
+読み込まれたSite Registryを取得します。
+
+**レスポンス**:
+
+```json
+{
+  "default_site": "techblog",
+  "selected_site": "techblog",
+  "sites": [
+    {
+      "id": "techblog",
+      "name": "Tech Blog",
+      "repo_path": "D:/sites/techblog",
+      "generator": "hugo",
+      "content_dir": "content",
+      "static_dir": "static",
+      "public_dir": "public",
+      "hugo_server_port": "1314",
+      "snippet_paths": ["D:/sites/techblog/.vscode/md.code-snippets"]
+    }
+  ]
+}
+```
+
+---
+
+## Preview
+
+### GET /admin/preview/:site/*
+
+選択サイトのpreview processへproxyします。管理画面のiframeが使用する内部routeです。
+
+例:
+
+```text
+/admin/preview/techblog/posts/hello/
+```
+
+このrouteは必要に応じて対象サイトのpreview processを起動し、Site Registryの`hugo_server_bind`と`hugo_server_port`へproxyします。サイトIDが存在しない場合は`400`、preview processを起動できない場合は`502`を返します。
 
 ---
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -297,7 +297,7 @@ CSRFトークンを取得します。
 /admin/preview/techblog/posts/hello/
 ```
 
-このrouteは必要に応じて対象サイトのpreview processを起動し、Site Registryの`hugo_server_bind`と`hugo_server_port`へproxyします。サイトIDが存在しない場合は`400`、preview processを起動できない場合は`502`を返します。
+このrouteは必要に応じて対象サイトのpreview processを起動し、Site Registryの`hugo_server_bind`と`hugo_server_port`へproxyします。初回起動時はpreview portが接続可能になるまで短時間待機してからproxyします。サイトIDが存在しない場合は`400`、preview processを起動できない場合やport readiness timeout時は`502`を返します。
 
 iframe内でroot-relative URLへの遷移やasset requestが発生した場合、CMSは`Referer`の`/admin/preview/:site/...`から選択サイトを復元し、同じpreview route配下へ一時リダイレクトします。
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -299,6 +299,8 @@ CSRFトークンを取得します。
 
 このrouteは必要に応じて対象サイトのpreview processを起動し、Site Registryの`hugo_server_bind`と`hugo_server_port`へproxyします。サイトIDが存在しない場合は`400`、preview processを起動できない場合は`502`を返します。
 
+iframe内でroot-relative URLへの遷移やasset requestが発生した場合、CMSは`Referer`の`/admin/preview/:site/...`から選択サイトを復元し、同じpreview route配下へ一時リダイレクトします。
+
 ---
 
 ## Git API

--- a/main.go
+++ b/main.go
@@ -40,6 +40,40 @@ func configureGinMode() error {
 	}
 }
 
+func sitePreviewProxyHandler(c *gin.Context) {
+	siteID := strings.TrimSpace(c.Param("site"))
+	site, ok := config.GetSite(siteID)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Unknown site: " + siteID})
+		return
+	}
+
+	if err := services.StartPreviewForSite(site); err != nil {
+		slog.Warn("Failed to start site preview", "site", siteID, "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Preview unavailable"})
+		return
+	}
+
+	previewProxyURL, _ := url.Parse("http://" + site.HugoServerBind + ":" + site.HugoServerPort)
+	proxy := httputil.NewSingleHostReverseProxy(previewProxyURL)
+	previewPath := c.Param("path")
+	if previewPath == "" {
+		previewPath = "/"
+	}
+	proxy.Director = func(req *http.Request) {
+		req.URL.Scheme = previewProxyURL.Scheme
+		req.URL.Host = previewProxyURL.Host
+		req.URL.Path = previewPath
+		req.URL.RawPath = ""
+		req.Host = previewProxyURL.Host
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
+		slog.Warn("Site preview proxy failed", "site", siteID, "error", err)
+		http.Error(w, "Preview unavailable", http.StatusBadGateway)
+	}
+	proxy.ServeHTTP(c.Writer, c.Request)
+}
+
 func SetupRouter() (*gin.Engine, error) {
 	if err := configureGinMode(); err != nil {
 		return nil, err
@@ -111,14 +145,15 @@ func SetupRouter() (*gin.Engine, error) {
 			authorized.Static("/static", "./static")
 
 			authorized.GET("/", func(c *gin.Context) { c.HTML(http.StatusOK, "index.html", nil) })
+			authorized.Any("/preview/:site/*path", sitePreviewProxyHandler)
 
 			api := authorized.Group("/api")
 			api.Use(handlers.RequestBodyLimit(config.MaxUploadSize + (1 << 20)))
 			api.Use(handlers.CSRFProtection) // Apply CSRF protection to all API routes
 			{
 				api.GET("/csrf-token", handlers.GetCSRFToken) // Endpoint to get CSRF token
-				api.POST("/build", handlers.RuntimeLocked(handlers.HandleBuild))
-				api.POST("/build/restart", handlers.RuntimeLocked(handlers.HandleRestart))
+				api.POST("/build", handlers.HandleBuild)
+				api.POST("/build/restart", handlers.HandleRestart)
 				api.GET("/articles", handlers.SiteScoped(handlers.ListArticles))
 				api.GET("/article", handlers.SiteScoped(handlers.GetArticle))
 				api.POST("/article", handlers.SiteScoped(handlers.SaveArticle))
@@ -193,9 +228,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Start Hugo Server
+	// Start default preview server
 	if err := services.StartHugoServer(); err != nil {
-		slog.Error("Failed to start Hugo Server", "error", err)
+		slog.Error("Failed to start default preview server", "error", err)
 	}
 
 	srv := newHTTPServer(r)
@@ -212,9 +247,9 @@ func main() {
 	<-quit
 	slog.Info("Shutting down server...")
 
-	// Clean up Hugo Server
-	if err := services.StopHugoServer(); err != nil {
-		slog.Error("Failed to stop Hugo Server", "error", err)
+	// Clean up preview servers
+	if err := services.StopAllPreviewServers(); err != nil {
+		slog.Error("Failed to stop preview servers", "error", err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,11 @@ func configureGinMode() error {
 }
 
 func sitePreviewProxyHandler(c *gin.Context) {
+	// Preview pages need same-origin referrers so root-relative links and
+	// assets can be routed back to the selected site instead of the default
+	// root proxy. Other admin routes keep the stricter no-referrer policy.
+	c.Header("Referrer-Policy", "same-origin")
+
 	siteID := strings.TrimSpace(c.Param("site"))
 	site, ok := config.GetSite(siteID)
 	if !ok {
@@ -72,6 +77,43 @@ func sitePreviewProxyHandler(c *gin.Context) {
 		http.Error(w, "Preview unavailable", http.StatusBadGateway)
 	}
 	proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func previewSiteFromReferer(referer string) (config.SiteConfig, bool) {
+	if strings.TrimSpace(referer) == "" {
+		return config.SiteConfig{}, false
+	}
+	refererURL, err := url.Parse(referer)
+	if err != nil {
+		return config.SiteConfig{}, false
+	}
+
+	parts := strings.Split(strings.TrimPrefix(refererURL.EscapedPath(), "/"), "/")
+	if len(parts) < 3 || parts[0] != "admin" || parts[1] != "preview" {
+		return config.SiteConfig{}, false
+	}
+
+	siteID, err := url.PathUnescape(parts[2])
+	if err != nil {
+		return config.SiteConfig{}, false
+	}
+	return config.GetSite(siteID)
+}
+
+func previewRedirectTarget(req *http.Request, site config.SiteConfig) string {
+	path := req.URL.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+
+	target := "/admin/preview/" + url.PathEscape(site.ID) + path
+	if req.URL.RawQuery != "" {
+		target += "?" + req.URL.RawQuery
+	}
+	return target
 }
 
 func SetupRouter() (*gin.Engine, error) {
@@ -182,6 +224,10 @@ func SetupRouter() (*gin.Engine, error) {
 		http.Error(w, "Preview unavailable", http.StatusBadGateway)
 	}
 	r.NoRoute(handlers.AuthRequired, handlers.TokenValidation, func(c *gin.Context) {
+		if site, ok := previewSiteFromReferer(c.Request.Referer()); ok {
+			c.Redirect(http.StatusTemporaryRedirect, previewRedirectTarget(c.Request, site))
+			return
+		}
 		proxy.ServeHTTP(c.Writer, c.Request)
 	})
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"hugo-cms/pkg/handlers"
 	"hugo-cms/pkg/services"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -58,8 +59,18 @@ func sitePreviewProxyHandler(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "Preview unavailable"})
 		return
 	}
+	if err := waitForPreviewPort(c.Request.Context(), site, 5*time.Second); err != nil {
+		slog.Warn("Site preview did not become ready", "site", siteID, "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Preview unavailable"})
+		return
+	}
 
-	previewProxyURL, _ := url.Parse("http://" + site.HugoServerBind + ":" + site.HugoServerPort)
+	previewProxyURL, err := url.Parse("http://" + sitePreviewAddress(site))
+	if err != nil {
+		slog.Warn("Invalid site preview address", "site", siteID, "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "Preview unavailable"})
+		return
+	}
 	proxy := httputil.NewSingleHostReverseProxy(previewProxyURL)
 	previewPath := c.Param("path")
 	if previewPath == "" {
@@ -77,6 +88,39 @@ func sitePreviewProxyHandler(c *gin.Context) {
 		http.Error(w, "Preview unavailable", http.StatusBadGateway)
 	}
 	proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func sitePreviewAddress(site config.SiteConfig) string {
+	return net.JoinHostPort(site.HugoServerBind, site.HugoServerPort)
+}
+
+func waitForPreviewPort(parent context.Context, site config.SiteConfig, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	address := sitePreviewAddress(site)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		var dialer net.Dialer
+		conn, err := dialer.DialContext(ctx, "tcp", address)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		lastErr = err
+
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("preview port %s not ready: %w", address, lastErr)
+			}
+			return fmt.Errorf("preview port %s not ready: %w", address, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func previewSiteFromReferer(referer string) (config.SiteConfig, bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"hugo-cms/pkg/config"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -137,5 +138,36 @@ func TestSetupRouterRejectsInvalidGinMode(t *testing.T) {
 	_, err := SetupRouter()
 	if err == nil || !strings.Contains(err.Error(), "invalid GIN_MODE") {
 		t.Fatalf("SetupRouter() error = %v, want invalid-mode error", err)
+	}
+}
+
+func TestPreviewSiteFromReferer(t *testing.T) {
+	originalSites := config.Sites
+	t.Cleanup(func() {
+		config.Sites = originalSites
+	})
+
+	config.Sites = []config.SiteConfig{
+		{ID: "docs site", RepoPath: "C:/sites/docs"},
+	}
+
+	site, ok := previewSiteFromReferer("http://localhost:8080/admin/preview/docs%20site/posts/hello/")
+	if !ok {
+		t.Fatal("previewSiteFromReferer() did not find site")
+	}
+	if site.ID != "docs site" {
+		t.Fatalf("site.ID = %q, want docs site", site.ID)
+	}
+}
+
+func TestPreviewRedirectTargetPreservesPathAndQuery(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost:8080/images/logo.png?v=1", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	target := previewRedirectTarget(req, config.SiteConfig{ID: "docs site"})
+	if target != "/admin/preview/docs%20site/images/logo.png?v=1" {
+		t.Fatalf("previewRedirectTarget() = %q", target)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"hugo-cms/pkg/config"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -169,5 +171,37 @@ func TestPreviewRedirectTargetPreservesPathAndQuery(t *testing.T) {
 	target := previewRedirectTarget(req, config.SiteConfig{ID: "docs site"})
 	if target != "/admin/preview/docs%20site/images/logo.png?v=1" {
 		t.Fatalf("previewRedirectTarget() = %q", target)
+	}
+}
+
+func TestSitePreviewAddressSupportsIPv6(t *testing.T) {
+	address := sitePreviewAddress(config.SiteConfig{
+		HugoServerBind: "::1",
+		HugoServerPort: "1314",
+	})
+
+	if address != "[::1]:1314" {
+		t.Fatalf("sitePreviewAddress() = %q, want IPv6 host-port", address)
+	}
+}
+
+func TestWaitForPreviewPortReturnsWhenListening(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	_, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("SplitHostPort() error = %v", err)
+	}
+
+	err = waitForPreviewPort(context.Background(), config.SiteConfig{
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: port,
+	}, 500*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForPreviewPort() error = %v", err)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -209,6 +209,9 @@ func loadSiteRegistry() error {
 	if len(normalized) == 0 {
 		return fmt.Errorf("site registry config %q contains no usable sites", SitesConfigPath)
 	}
+	if err := validateUniquePreviewAddresses(normalized); err != nil {
+		return err
+	}
 
 	Sites = normalized
 	if strings.TrimSpace(registry.DefaultSite) != "" {
@@ -275,6 +278,18 @@ func normalizeSiteConfig(site SiteConfig) SiteConfig {
 	}
 	site.SnippetPaths = normalizeSnippetPaths(site.SnippetPaths, site.RepoPath)
 	return site
+}
+
+func validateUniquePreviewAddresses(sites []SiteConfig) error {
+	seen := map[string]string{}
+	for _, site := range sites {
+		key := site.HugoServerBind + ":" + site.HugoServerPort
+		if existingID, ok := seen[key]; ok {
+			return fmt.Errorf("preview address %s is used by both site %q and site %q", key, existingID, site.ID)
+		}
+		seen[key] = site.ID
+	}
+	return nil
 }
 
 func defaultSnippetPaths(repoPath string) []string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -283,7 +284,7 @@ func normalizeSiteConfig(site SiteConfig) SiteConfig {
 func validateUniquePreviewAddresses(sites []SiteConfig) error {
 	seen := map[string]string{}
 	for _, site := range sites {
-		key := site.HugoServerBind + ":" + site.HugoServerPort
+		key := net.JoinHostPort(site.HugoServerBind, site.HugoServerPort)
 		if existingID, ok := seen[key]; ok {
 			return fmt.Errorf("preview address %s is used by both site %q and site %q", key, existingID, site.ID)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,15 +282,42 @@ func normalizeSiteConfig(site SiteConfig) SiteConfig {
 }
 
 func validateUniquePreviewAddresses(sites []SiteConfig) error {
-	seen := map[string]string{}
+	seen := []previewAddressUse{}
 	for _, site := range sites {
-		key := net.JoinHostPort(site.HugoServerBind, site.HugoServerPort)
-		if existingID, ok := seen[key]; ok {
-			return fmt.Errorf("preview address %s is used by both site %q and site %q", key, existingID, site.ID)
+		current := newPreviewAddressUse(site)
+		for _, existing := range seen {
+			if existing.address == current.address {
+				return fmt.Errorf("preview address %s is used by both site %q and site %q", current.address, existing.siteID, current.siteID)
+			}
+			if existing.port == current.port && (existing.wildcard || current.wildcard) {
+				return fmt.Errorf("preview port %s conflicts because wildcard bind is used by site %q (%s) and site %q (%s)", current.port, existing.siteID, existing.address, current.siteID, current.address)
+			}
 		}
-		seen[key] = site.ID
+		seen = append(seen, current)
 	}
 	return nil
+}
+
+type previewAddressUse struct {
+	siteID   string
+	address  string
+	port     string
+	wildcard bool
+}
+
+func newPreviewAddressUse(site SiteConfig) previewAddressUse {
+	return previewAddressUse{
+		siteID:   site.ID,
+		address:  net.JoinHostPort(site.HugoServerBind, site.HugoServerPort),
+		port:     site.HugoServerPort,
+		wildcard: isWildcardBind(site.HugoServerBind),
+	}
+}
+
+func isWildcardBind(bind string) bool {
+	bind = strings.Trim(strings.TrimSpace(bind), "[]")
+	ip := net.ParseIP(bind)
+	return ip != nil && ip.IsUnspecified()
 }
 
 func defaultSnippetPaths(repoPath string) []string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -248,6 +248,77 @@ sites:
 	}
 }
 
+func TestLoadSiteRegistryRejectsWildcardPreviewBindPortCollision(t *testing.T) {
+	originalSites := Sites
+	originalDefaultSiteID := DefaultSiteID
+	originalRepoPath := RepoPath
+	originalSitesConfigPath := SitesConfigPath
+	t.Cleanup(func() {
+		Sites = originalSites
+		DefaultSiteID = originalDefaultSiteID
+		RepoPath = originalRepoPath
+		SitesConfigPath = originalSitesConfigPath
+	})
+
+	tests := []struct {
+		name           string
+		firstBind      string
+		secondBind     string
+		wantErrSnippet string
+	}{
+		{
+			name:           "IPv4 wildcard conflicts with concrete bind",
+			firstBind:      "0.0.0.0",
+			secondBind:     "127.0.0.1",
+			wantErrSnippet: "wildcard bind",
+		},
+		{
+			name:           "IPv6 wildcard conflicts with concrete bind",
+			firstBind:      "::",
+			secondBind:     "::1",
+			wantErrSnippet: "wildcard bind",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "sites.yml")
+			err := os.WriteFile(configPath, []byte(`
+default_site: blog
+sites:
+  - id: blog
+    repo_path: C:/sites/blog
+    generator: hugo
+    hugo_server_bind: "`+tt.firstBind+`"
+    hugo_server_port: "1314"
+  - id: notes
+    repo_path: C:/sites/notes
+    generator: eleventy
+    hugo_server_bind: "`+tt.secondBind+`"
+    hugo_server_port: "1314"
+`), 0644)
+			if err != nil {
+				t.Fatalf("write registry config: %v", err)
+			}
+
+			DefaultSiteID = "default"
+			RepoPath = "./repo"
+			SitesConfigPath = configPath
+
+			err = loadSiteRegistry()
+			if err == nil {
+				t.Fatal("loadSiteRegistry() should reject wildcard preview bind collisions")
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSnippet) {
+				t.Fatalf("loadSiteRegistry() error = %v, want %q", err, tt.wantErrSnippet)
+			}
+			if RepoPath != "./repo" {
+				t.Fatalf("RepoPath = %q, should not switch site after wildcard preview bind collision", RepoPath)
+			}
+		})
+	}
+}
+
 func TestNormalizeSiteConfigRejectsUnsafeDirs(t *testing.T) {
 	site := normalizeSiteConfig(SiteConfig{
 		ID:         "unsafe",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -205,6 +205,49 @@ sites:
 	}
 }
 
+func TestLoadSiteRegistryRejectsDuplicatePreviewAddress(t *testing.T) {
+	originalSites := Sites
+	originalDefaultSiteID := DefaultSiteID
+	originalRepoPath := RepoPath
+	originalSitesConfigPath := SitesConfigPath
+	t.Cleanup(func() {
+		Sites = originalSites
+		DefaultSiteID = originalDefaultSiteID
+		RepoPath = originalRepoPath
+		SitesConfigPath = originalSitesConfigPath
+	})
+
+	configPath := filepath.Join(t.TempDir(), "sites.yml")
+	err := os.WriteFile(configPath, []byte(`
+default_site: blog
+sites:
+  - id: blog
+    repo_path: C:/sites/blog
+    generator: hugo
+  - id: notes
+    repo_path: C:/sites/notes
+    generator: eleventy
+`), 0644)
+	if err != nil {
+		t.Fatalf("write registry config: %v", err)
+	}
+
+	DefaultSiteID = "default"
+	RepoPath = "./repo"
+	SitesConfigPath = configPath
+
+	err = loadSiteRegistry()
+	if err == nil {
+		t.Fatal("loadSiteRegistry() should reject duplicate preview addresses")
+	}
+	if !strings.Contains(err.Error(), "preview address 127.0.0.1:1314") {
+		t.Fatalf("loadSiteRegistry() error = %v, want duplicate preview address", err)
+	}
+	if RepoPath != "./repo" {
+		t.Fatalf("RepoPath = %q, should not switch site after duplicate preview address", RepoPath)
+	}
+}
+
 func TestNormalizeSiteConfigRejectsUnsafeDirs(t *testing.T) {
 	site := normalizeSiteConfig(SiteConfig{
 		ID:         "unsafe",

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -16,17 +16,29 @@ import (
 )
 
 func HandleBuild(c *gin.Context) {
-	// With Hugo Server running, explicit build is not needed for preview.
-	// We just return OK so frontend logic continues.
-	RespondOK(c, "Preview managed by Hugo Server")
+	site, err := requestedSite(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	if err := services.StartPreviewForSite(site); err != nil {
+		ErrorInternal(c, "Failed to start preview server: "+err.Error())
+		return
+	}
+	RespondOK(c, "Preview server is running")
 }
 
 func HandleRestart(c *gin.Context) {
-	if err := services.RestartHugoServer(); err != nil {
-		ErrorInternal(c, "Failed to restart Hugo server: "+err.Error())
+	site, err := requestedSite(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
 		return
 	}
-	RespondOK(c, "Hugo Server Restarted")
+	if err := services.RestartPreviewForSite(site); err != nil {
+		ErrorInternal(c, "Failed to restart preview server: "+err.Error())
+		return
+	}
+	RespondOK(c, "Preview server restarted")
 }
 
 func HandleSync(c *gin.Context) {

--- a/pkg/services/generator.go
+++ b/pkg/services/generator.go
@@ -3,6 +3,8 @@ package services
 import (
 	"fmt"
 	"hugo-cms/pkg/config"
+	"net/url"
+	"path/filepath"
 	"sync"
 )
 
@@ -19,6 +21,8 @@ type GeneratorAdapter interface {
 var (
 	generatorAdapterMu sync.RWMutex
 	generatorAdapter   GeneratorAdapter = NewHugoAdapter()
+	previewAdaptersMu  sync.Mutex
+	previewAdapters    = map[string]GeneratorAdapter{}
 )
 
 func CurrentGeneratorAdapter() GeneratorAdapter {
@@ -63,19 +67,19 @@ func NewGeneratorAdapter(name string) (GeneratorAdapter, error) {
 // Compatibility wrappers keep the existing API stable while generator-specific
 // behavior lives behind GeneratorAdapter.
 func StartHugoServer() error {
-	return CurrentGeneratorAdapter().StartPreview()
+	return StartPreviewForSite(defaultPreviewSite())
 }
 
 func StopHugoServer() error {
-	return CurrentGeneratorAdapter().StopPreview()
+	return StopPreviewForSite(defaultPreviewSite())
 }
 
 func RestartHugoServer() error {
-	return CurrentGeneratorAdapter().RestartPreview()
+	return RestartPreviewForSite(defaultPreviewSite())
 }
 
 func IsHugoServerRunning() bool {
-	return CurrentGeneratorAdapter().IsPreviewRunning()
+	return IsPreviewRunningForSite(defaultPreviewSite())
 }
 
 func BuildSite() (string, error) {
@@ -92,4 +96,102 @@ func CreateContent(path string) (string, error) {
 		return "", err
 	}
 	return adapter.CreateContent(path)
+}
+
+func StartPreviewForSite(site config.SiteConfig) error {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+
+	adapter, err := previewAdapterForSiteLocked(site)
+	if err != nil {
+		return err
+	}
+	return WithSiteRuntime(previewRuntimeSite(site), adapter.StartPreview)
+}
+
+func StopPreviewForSite(site config.SiteConfig) error {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+
+	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	if !ok {
+		return nil
+	}
+	return adapter.StopPreview()
+}
+
+func RestartPreviewForSite(site config.SiteConfig) error {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+
+	adapter, err := previewAdapterForSiteLocked(site)
+	if err != nil {
+		return err
+	}
+	if err := adapter.StopPreview(); err != nil {
+		return err
+	}
+	return WithSiteRuntime(previewRuntimeSite(site), adapter.StartPreview)
+}
+
+func IsPreviewRunningForSite(site config.SiteConfig) bool {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+
+	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	return ok && adapter.IsPreviewRunning()
+}
+
+func StopAllPreviewServers() error {
+	previewAdaptersMu.Lock()
+	adapters := make([]GeneratorAdapter, 0, len(previewAdapters))
+	for _, adapter := range previewAdapters {
+		adapters = append(adapters, adapter)
+	}
+	previewAdapters = map[string]GeneratorAdapter{}
+	previewAdaptersMu.Unlock()
+
+	var stopErr error
+	for _, adapter := range adapters {
+		if err := adapter.StopPreview(); err != nil && stopErr == nil {
+			stopErr = err
+		}
+	}
+	return stopErr
+}
+
+func previewAdapterForSiteLocked(site config.SiteConfig) (GeneratorAdapter, error) {
+	key := sitePreviewKey(site)
+	if adapter, ok := previewAdapters[key]; ok {
+		return adapter, nil
+	}
+
+	adapter, err := NewGeneratorAdapter(site.Generator)
+	if err != nil {
+		return nil, err
+	}
+	previewAdapters[key] = adapter
+	return adapter, nil
+}
+
+func sitePreviewKey(site config.SiteConfig) string {
+	if site.ID != "" {
+		return site.ID
+	}
+	return filepath.ToSlash(filepath.Clean(site.RepoPath)) + "\x00" + site.HugoServerBind + "\x00" + site.HugoServerPort
+}
+
+func defaultPreviewSite() config.SiteConfig {
+	if site, ok := config.GetSite(config.DefaultSiteID); ok {
+		return site
+	}
+	return config.RuntimeSiteConfig()
+}
+
+func previewRuntimeSite(site config.SiteConfig) config.SiteConfig {
+	if site.ID == "" {
+		return site
+	}
+	site.PreviewURL = "/admin/preview/" + url.PathEscape(site.ID) + "/"
+	return site
 }

--- a/pkg/services/generator.go
+++ b/pkg/services/generator.go
@@ -99,10 +99,7 @@ func CreateContent(path string) (string, error) {
 }
 
 func StartPreviewForSite(site config.SiteConfig) error {
-	previewAdaptersMu.Lock()
-	defer previewAdaptersMu.Unlock()
-
-	adapter, err := previewAdapterForSiteLocked(site)
+	adapter, err := previewAdapterForSite(site)
 	if err != nil {
 		return err
 	}
@@ -110,10 +107,7 @@ func StartPreviewForSite(site config.SiteConfig) error {
 }
 
 func StopPreviewForSite(site config.SiteConfig) error {
-	previewAdaptersMu.Lock()
-	defer previewAdaptersMu.Unlock()
-
-	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	adapter, ok := previewAdapterForSiteIfExists(site)
 	if !ok {
 		return nil
 	}
@@ -121,10 +115,7 @@ func StopPreviewForSite(site config.SiteConfig) error {
 }
 
 func RestartPreviewForSite(site config.SiteConfig) error {
-	previewAdaptersMu.Lock()
-	defer previewAdaptersMu.Unlock()
-
-	adapter, err := previewAdapterForSiteLocked(site)
+	adapter, err := previewAdapterForSite(site)
 	if err != nil {
 		return err
 	}
@@ -135,10 +126,7 @@ func RestartPreviewForSite(site config.SiteConfig) error {
 }
 
 func IsPreviewRunningForSite(site config.SiteConfig) bool {
-	previewAdaptersMu.Lock()
-	defer previewAdaptersMu.Unlock()
-
-	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	adapter, ok := previewAdapterForSiteIfExists(site)
 	return ok && adapter.IsPreviewRunning()
 }
 
@@ -158,6 +146,19 @@ func StopAllPreviewServers() error {
 		}
 	}
 	return stopErr
+}
+
+func previewAdapterForSite(site config.SiteConfig) (GeneratorAdapter, error) {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+	return previewAdapterForSiteLocked(site)
+}
+
+func previewAdapterForSiteIfExists(site config.SiteConfig) (GeneratorAdapter, bool) {
+	previewAdaptersMu.Lock()
+	defer previewAdaptersMu.Unlock()
+	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	return adapter, ok
 }
 
 func previewAdapterForSiteLocked(site config.SiteConfig) (GeneratorAdapter, error) {

--- a/pkg/services/generator_test.go
+++ b/pkg/services/generator_test.go
@@ -23,6 +23,17 @@ func TestSetGeneratorAdapterRejectsNil(t *testing.T) {
 	}
 }
 
+func TestPreviewRuntimeSiteUsesSitePreviewProxyBase(t *testing.T) {
+	site := previewRuntimeSite(config.SiteConfig{
+		ID:         "docs site",
+		PreviewURL: "/",
+	})
+
+	if site.PreviewURL != "/admin/preview/docs%20site/" {
+		t.Fatalf("PreviewURL = %q, want site preview proxy base", site.PreviewURL)
+	}
+}
+
 func TestNewGeneratorAdapterSupportsEleventy(t *testing.T) {
 	adapter, err := NewGeneratorAdapter("eleventy")
 	if err != nil {

--- a/pkg/services/generator_test.go
+++ b/pkg/services/generator_test.go
@@ -1,11 +1,55 @@
 package services
 
 import (
+	"fmt"
 	"hugo-cms/pkg/config"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+type testGeneratorAdapter struct {
+	start     func() error
+	stop      func() error
+	isRunning func() bool
+}
+
+func (adapter testGeneratorAdapter) Name() string { return "test" }
+
+func (adapter testGeneratorAdapter) StartPreview() error {
+	if adapter.start != nil {
+		return adapter.start()
+	}
+	return nil
+}
+
+func (adapter testGeneratorAdapter) StopPreview() error {
+	if adapter.stop != nil {
+		return adapter.stop()
+	}
+	return nil
+}
+
+func (adapter testGeneratorAdapter) RestartPreview() error {
+	if err := adapter.StopPreview(); err != nil {
+		return err
+	}
+	return adapter.StartPreview()
+}
+
+func (adapter testGeneratorAdapter) IsPreviewRunning() bool {
+	if adapter.isRunning != nil {
+		return adapter.isRunning()
+	}
+	return true
+}
+
+func (adapter testGeneratorAdapter) Build() (string, error) { return "", nil }
+
+func (adapter testGeneratorAdapter) CreateContent(_ string) (string, error) {
+	return "", nil
+}
 
 func TestDefaultGeneratorAdapterIsHugo(t *testing.T) {
 	adapter := CurrentGeneratorAdapter()
@@ -31,6 +75,70 @@ func TestPreviewRuntimeSiteUsesSitePreviewProxyBase(t *testing.T) {
 
 	if site.PreviewURL != "/admin/preview/docs%20site/" {
 		t.Fatalf("PreviewURL = %q, want site preview proxy base", site.PreviewURL)
+	}
+}
+
+func TestStartPreviewForSiteDoesNotHoldAdapterMapLockWhileStarting(t *testing.T) {
+	originalPreviewAdapters := previewAdapters
+	originalRepoPath := config.RepoPath
+	originalContentDir := config.ContentDir
+	originalStaticDir := config.StaticDir
+	originalPublicDir := config.PublicDir
+	originalPreviewURL := config.PreviewURL
+	originalPort := config.HugoServerPort
+	originalBind := config.HugoServerBind
+	t.Cleanup(func() {
+		previewAdaptersMu.Lock()
+		previewAdapters = originalPreviewAdapters
+		previewAdaptersMu.Unlock()
+
+		config.RepoPath = originalRepoPath
+		config.ContentDir = originalContentDir
+		config.StaticDir = originalStaticDir
+		config.PublicDir = originalPublicDir
+		config.PreviewURL = originalPreviewURL
+		config.HugoServerPort = originalPort
+		config.HugoServerBind = originalBind
+	})
+
+	site := config.SiteConfig{
+		ID:             "lock-test",
+		RepoPath:       t.TempDir(),
+		Generator:      "hugo",
+		ContentDir:     "content",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1314",
+	}
+
+	previewAdaptersMu.Lock()
+	previewAdapters = map[string]GeneratorAdapter{
+		sitePreviewKey(site): testGeneratorAdapter{
+			start: func() error {
+				if !IsPreviewRunningForSite(site) {
+					return fmt.Errorf("IsPreviewRunningForSite() = false, want true")
+				}
+				return nil
+			},
+			isRunning: func() bool { return true },
+		},
+	}
+	previewAdaptersMu.Unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- StartPreviewForSite(site)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("StartPreviewForSite() error = %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartPreviewForSite() deadlocked while starting preview")
 	}
 }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -449,8 +449,10 @@ export function setPreviewUrl(path) {
 
     const rootRelativePath = "/" + previewPath.replace(/^\//, "");
     const targetUrl = rootRelativePath + (rootRelativePath.endsWith("/") ? "" : "/");
+    const siteID = API.getCurrentSite();
+    const previewBase = siteID ? `/admin/preview/${encodeURIComponent(siteID)}` : "";
 
-    frame.src = targetUrl + "?t=" + Date.now();
+    frame.src = previewBase + targetUrl + "?t=" + Date.now();
 }
 
 export function showDiffModal(diffText) {


### PR DESCRIPTION
## Summary
- Add site-aware preview process management keyed by site ID.
- Route editor previews through authenticated /admin/preview/<site>/... proxy URLs.
- Make build/restart preview actions resolve the selected site instead of using global preview state.
- Document multi-site preview behavior and add a smoke test checklist.

## Validation
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- git diff --check
- bundled Node.js --check for static/js/api.js, app.js, editor.js, ui.js

## Notes
- This keeps the compatibility runtime bridge for existing services, while moving preview process ownership to explicit site configs.
- The PR is draft so review comments can be folded in before marking ready.