### PR TITLE
refactor: introduce site runtime for generators

### DIFF
--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -4,7 +4,7 @@
 
 ## ステータス
 
-段階実装中。現在のHugo向け動作を維持しながら、Site Registry、site-aware API、site別preview processへ移行している。
+段階実装中。現在のHugo向け動作を維持しながら、Site Registry、site-aware API、site別preview processを導入済み。次の焦点はprocess-wide runtime bridgeを縮小し、サービスへ`SiteRuntime`を明示的に渡すことである。
 
 ## 背景
 
@@ -201,13 +201,16 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 
 既存サービスの多くは`config.RepoPath`などのprocess-wide runtime値を参照している。現在は互換性を保つため、HTTP handler層で選択サイトを解決し、短時間だけruntime値を適用するbridgeを使っている。
 
+`SiteRuntime`は、Site Registry由来の`SiteConfig`に、現在グローバルで管理している実行時設定（Git設定、App URL、解決済みPublicPathなど）を合わせたサービス向けの値オブジェクトである。新規または改修するサービスは、`SiteConfig`やprocess-wide globalsではなく`SiteRuntime`を受け取る。
+
 - site-scoped APIは`?site=`または`X-CMS-Site`で対象サイトを指定する。
 - preview process管理はサイト設定を明示的に受け取り、site IDごとにadapterを保持する。
+- generator adapterのpreview/build/createは`SiteRuntime`を明示的に受け取り、Hugo/Eleventyコマンド生成では`config.RepoPath`等のprocess-wide値を直接読まない。
 - 記事キャッシュは`repo_path + content_dir`でkey分割する。
 - process-wide runtimeを読むscope外処理はruntime lockで保護する。
 - preview adapter mapのlockはmapアクセス中だけ保持し、preview process操作やruntime bridge呼び出し中には保持しない。`/ready`などがruntime lockを先に取るため、lock順序の反転を避ける。
 
-今後の最終形は、記事・メディア・Git・generatorサービスへ`SiteConfig`または`SiteRuntime`を明示的に渡し、process-wide runtime mutationを削減することである。
+今後の最終形は、記事・メディア・Gitサービスにも`SiteRuntime`を明示的に渡し、process-wide runtime mutationを削減することである。
 
 ## ジェネレーターごとの差異
 
@@ -370,12 +373,19 @@ Eleventyの設定はJavaScriptであり、npm依存関係のインストール�
 
 `SITES_CONFIG_PATH`からSite Registryを読み込み、default siteの`repo_path`、`generator`、`content_dir`、`static_dir`、`public_dir`を既存APIへ適用できるようにした。`GET /admin/api/sites`で読み込み結果を確認できる。
 
-未実装:
+実装済み:
 
 - UI上のサイト切替
-- `/admin/sites/{siteID}/api/...`形式のsiteId付きAPI
-- サイト単位のプレビューProcessManager
+- `?site=`および`X-CMS-Site`によるsite-aware API
+- サイト単位のpreview process管理
+- `/admin/preview/{siteID}/...`の認証付きpreview proxy
+- preview bind/portの重複検証
+
+未実装:
+
+- `/admin/sites/{siteID}/api/...`形式のpath-based site API
 - サイトごとのmise実行
+- `SiteRuntime`の全サービスへの展開
 
 ### Phase 3: コンテンツとメディアの共通化
 
@@ -404,10 +414,13 @@ Hugo/Eleventyの子プロセスへ渡す環境変数をallowlist方式にし、`
 
 初期版の`EleventyAdapter`を追加した。`package.json`とlockファイルを必須とし、lockfileに対応するpackage managerでローカル依存のEleventyを起動・ビルドする。新規記事はCMS configのcollectionに一致する場合だけFront Matter codec経由で生成する。
 
+実装済み:
+
+- siteId単位のEleventyプレビュー
+
 未実装:
 
 - UIからのgenerator差分表示
-- siteId単位のEleventyプレビュー
 - JavaScript Front Matterのraw編集表示
 - Eleventy Data Cascadeの実効値表示
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -400,36 +400,26 @@ func applyDefaultSite(site SiteConfig) {
 }
 
 func RuntimeSiteConfig() SiteConfig {
-	return SiteConfig{
-		ID:              DefaultSiteID,
-		Name:            "Current",
-		RepoPath:        RepoPath,
-		Generator:       SiteGenerator,
-		ContentDir:      ContentDir,
-		StaticDir:       StaticDir,
-		PublicDir:       PublicDir,
-		PreviewURL:      PreviewURL,
-		HugoServerPort:  HugoServerPort,
-		HugoServerBind:  HugoServerBind,
-		ArticleMediaDir: ArticleMediaDir,
-		StaticMediaDir:  StaticMediaDir,
-		SnippetPaths:    SnippetPaths,
-	}
+	return CurrentSiteRuntime().SiteConfig()
 }
 
 func ApplySiteRuntime(site SiteConfig) {
-	RepoPath = site.RepoPath
-	SiteGenerator = site.Generator
-	ContentDir = site.ContentDir
-	StaticDir = site.StaticDir
-	PublicDir = site.PublicDir
-	PublicPath = filepath.Join(site.RepoPath, site.PublicDir)
-	PreviewURL = site.PreviewURL
-	HugoServerPort = site.HugoServerPort
-	HugoServerBind = site.HugoServerBind
-	ArticleMediaDir = site.ArticleMediaDir
-	StaticMediaDir = site.StaticMediaDir
-	SnippetPaths = site.SnippetPaths
+	ApplyRuntime(NewSiteRuntime(site))
+}
+
+func ApplyRuntime(runtime SiteRuntime) {
+	RepoPath = runtime.RepoPath
+	SiteGenerator = runtime.Generator
+	ContentDir = runtime.ContentDir
+	StaticDir = runtime.StaticDir
+	PublicDir = runtime.PublicDir
+	PublicPath = runtime.PublicPath
+	PreviewURL = runtime.PreviewURL
+	HugoServerPort = runtime.HugoServerPort
+	HugoServerBind = runtime.HugoServerBind
+	ArticleMediaDir = runtime.ArticleMediaDir
+	StaticMediaDir = runtime.StaticMediaDir
+	SnippetPaths = append([]string(nil), runtime.SnippetPaths...)
 }
 
 // ValidateSecurityConfig rejects insecure authorization defaults.

--- a/pkg/config/site_runtime.go
+++ b/pkg/config/site_runtime.go
@@ -1,0 +1,96 @@
+package config
+
+import "path/filepath"
+
+// SiteRuntime is the resolved, process-local view of a site used by services.
+//
+// SiteConfig is the persisted/admin-facing registry entry. SiteRuntime adds
+// process settings that are currently global, so services can gradually accept
+// explicit runtime data instead of reading mutable package globals.
+type SiteRuntime struct {
+	ID              string
+	Name            string
+	RepoPath        string
+	Generator       string
+	ContentDir      string
+	StaticDir       string
+	PublicDir       string
+	PublicPath      string
+	PreviewURL      string
+	HugoServerPort  string
+	HugoServerBind  string
+	ArticleMediaDir string
+	StaticMediaDir  string
+	SnippetPaths    []string
+	AppURL          string
+	GitUserEmail    string
+	GitUserName     string
+	GitBranch       string
+	GitRemote       string
+}
+
+func NewSiteRuntime(site SiteConfig) SiteRuntime {
+	return SiteRuntime{
+		ID:              site.ID,
+		Name:            site.Name,
+		RepoPath:        site.RepoPath,
+		Generator:       site.Generator,
+		ContentDir:      site.ContentDir,
+		StaticDir:       site.StaticDir,
+		PublicDir:       site.PublicDir,
+		PublicPath:      filepath.Join(site.RepoPath, site.PublicDir),
+		PreviewURL:      site.PreviewURL,
+		HugoServerPort:  site.HugoServerPort,
+		HugoServerBind:  site.HugoServerBind,
+		ArticleMediaDir: site.ArticleMediaDir,
+		StaticMediaDir:  site.StaticMediaDir,
+		SnippetPaths:    append([]string(nil), site.SnippetPaths...),
+		AppURL:          GetAppURL(),
+		GitUserEmail:    GitUserEmail,
+		GitUserName:     GitUserName,
+		GitBranch:       GitBranch,
+		GitRemote:       GitRemote,
+	}
+}
+
+func CurrentSiteRuntime() SiteRuntime {
+	return SiteRuntime{
+		ID:              DefaultSiteID,
+		Name:            "Current",
+		RepoPath:        RepoPath,
+		Generator:       SiteGenerator,
+		ContentDir:      ContentDir,
+		StaticDir:       StaticDir,
+		PublicDir:       PublicDir,
+		PublicPath:      PublicPath,
+		PreviewURL:      PreviewURL,
+		HugoServerPort:  HugoServerPort,
+		HugoServerBind:  HugoServerBind,
+		ArticleMediaDir: ArticleMediaDir,
+		StaticMediaDir:  StaticMediaDir,
+		SnippetPaths:    append([]string(nil), SnippetPaths...),
+		AppURL:          GetAppURL(),
+		GitUserEmail:    GitUserEmail,
+		GitUserName:     GitUserName,
+		GitBranch:       GitBranch,
+		GitRemote:       GitRemote,
+	}
+}
+
+func (runtime SiteRuntime) SiteConfig() SiteConfig {
+	return SiteConfig{
+		ID:              runtime.ID,
+		Name:            runtime.Name,
+		RepoPath:        runtime.RepoPath,
+		Generator:       runtime.Generator,
+		ContentDir:      runtime.ContentDir,
+		StaticDir:       runtime.StaticDir,
+		PublicDir:       runtime.PublicDir,
+		PreviewURL:      runtime.PreviewURL,
+		HugoServerPort:  runtime.HugoServerPort,
+		HugoServerBind:  runtime.HugoServerBind,
+		ArticleMediaDir: runtime.ArticleMediaDir,
+		StaticMediaDir:  runtime.StaticMediaDir,
+		SnippetPaths:    append([]string(nil), runtime.SnippetPaths...),
+	}
+}

--- a/pkg/config/site_runtime_test.go
+++ b/pkg/config/site_runtime_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewSiteRuntimeCopiesSiteConfigAndGlobalProcessSettings(t *testing.T) {
+	originalGitRemote := GitRemote
+	originalGitBranch := GitBranch
+	originalGitUserName := GitUserName
+	originalGitUserEmail := GitUserEmail
+	t.Cleanup(func() {
+		GitRemote = originalGitRemote
+		GitBranch = originalGitBranch
+		GitUserName = originalGitUserName
+		GitUserEmail = originalGitUserEmail
+	})
+
+	GitRemote = "upstream"
+	GitBranch = "publish"
+	GitUserName = "CMS Bot"
+	GitUserEmail = "cms@example.com"
+
+	site := SiteConfig{
+		ID:             "docs",
+		Name:           "Docs",
+		RepoPath:       filepath.Join("C:", "sites", "docs"),
+		Generator:      "hugo",
+		ContentDir:     "content",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/preview/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1314",
+		SnippetPaths:   []string{"one.code-snippets"},
+	}
+
+	runtime := NewSiteRuntime(site)
+	if runtime.ID != site.ID || runtime.RepoPath != site.RepoPath || runtime.ContentDir != site.ContentDir {
+		t.Fatalf("runtime = %#v, want site fields copied", runtime)
+	}
+	if runtime.PublicPath != filepath.Join(site.RepoPath, site.PublicDir) {
+		t.Fatalf("PublicPath = %q", runtime.PublicPath)
+	}
+	if runtime.GitRemote != "upstream" || runtime.GitBranch != "publish" {
+		t.Fatalf("git settings = %q/%q", runtime.GitRemote, runtime.GitBranch)
+	}
+
+	site.SnippetPaths[0] = "mutated"
+	if runtime.SnippetPaths[0] != "one.code-snippets" {
+		t.Fatalf("runtime snippets were not copied: %#v", runtime.SnippetPaths)
+	}
+}
+
+func TestSiteRuntimeSiteConfigCopiesSlices(t *testing.T) {
+	runtime := SiteRuntime{
+		ID:           "docs",
+		SnippetPaths: []string{"one.code-snippets"},
+	}
+
+	site := runtime.SiteConfig()
+	site.SnippetPaths[0] = "mutated"
+	if runtime.SnippetPaths[0] != "one.code-snippets" {
+		t.Fatalf("runtime snippets were mutated through SiteConfig(): %#v", runtime.SnippetPaths)
+	}
+}

--- a/pkg/services/eleventy_adapter.go
+++ b/pkg/services/eleventy_adapter.go
@@ -30,23 +30,23 @@ func (*EleventyAdapter) Name() string {
 	return "eleventy"
 }
 
-func (adapter *EleventyAdapter) StartPreview() error {
-	pm, err := detectEleventyPackageManager(config.RepoPath)
+func (adapter *EleventyAdapter) StartPreview(runtime config.SiteRuntime) error {
+	pm, err := detectEleventyPackageManager(runtime.RepoPath)
 	if err != nil {
 		return err
 	}
-	slog.Info("Starting Eleventy server", "port", config.HugoServerPort, "package_manager", pm.Name)
+	slog.Info("Starting Eleventy server", "site", runtime.ID, "port", runtime.HugoServerPort, "package_manager", pm.Name)
 
 	err = adapter.preview.Start(func() managedProcess {
 		args := append([]string{}, pm.Args...)
 		args = append(args,
 			"--serve",
-			"--port", config.HugoServerPort,
-			"--input", config.ContentDir,
-			"--output", config.PublicDir,
+			"--port", runtime.HugoServerPort,
+			"--input", runtime.ContentDir,
+			"--output", runtime.PublicDir,
 		)
 		cmd := exec.Command(pm.Bin, args...)
-		cmd.Dir = config.RepoPath
+		cmd.Dir = runtime.RepoPath
 		cmd.Env = generatorProcessEnvironment("NODE_ENV=development")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -70,26 +70,19 @@ func (adapter *EleventyAdapter) StopPreview() error {
 	return nil
 }
 
-func (adapter *EleventyAdapter) RestartPreview() error {
-	if err := adapter.StopPreview(); err != nil {
-		return err
-	}
-	return adapter.StartPreview()
-}
-
 func (adapter *EleventyAdapter) IsPreviewRunning() bool {
 	return adapter.preview.Running()
 }
 
-func (*EleventyAdapter) Build() (string, error) {
-	pm, err := detectEleventyPackageManager(config.RepoPath)
+func (*EleventyAdapter) Build(runtime config.SiteRuntime) (string, error) {
+	pm, err := detectEleventyPackageManager(runtime.RepoPath)
 	if err != nil {
 		return "", err
 	}
 
 	start := time.Now()
 	defer func() {
-		slog.Info("Eleventy build completed", "duration", time.Since(start), "package_manager", pm.Name)
+		slog.Info("Eleventy build completed", "site", runtime.ID, "duration", time.Since(start), "package_manager", pm.Name)
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -97,11 +90,11 @@ func (*EleventyAdapter) Build() (string, error) {
 
 	args := append([]string{}, pm.Args...)
 	args = append(args,
-		"--input", config.ContentDir,
-		"--output", config.PublicDir,
+		"--input", runtime.ContentDir,
+		"--output", runtime.PublicDir,
 	)
 	cmd := exec.CommandContext(ctx, pm.Bin, args...)
-	cmd.Dir = config.RepoPath
+	cmd.Dir = runtime.RepoPath
 	cmd.Env = generatorProcessEnvironment("NODE_ENV=production")
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
@@ -110,13 +103,13 @@ func (*EleventyAdapter) Build() (string, error) {
 	return string(output), err
 }
 
-func (*EleventyAdapter) CreateContent(path string) (string, error) {
+func (*EleventyAdapter) CreateContent(runtime config.SiteRuntime, path string) (string, error) {
 	start := time.Now()
 	defer func() {
-		slog.Info("Eleventy new content", "path", path, "duration", time.Since(start))
+		slog.Info("Eleventy new content", "site", runtime.ID, "path", path, "duration", time.Since(start))
 	}()
 
-	fullPath := SafeJoin(config.RepoPath, config.ContentDir, path)
+	fullPath := SafeJoin(runtime.RepoPath, runtime.ContentDir, path)
 	if fullPath == "" {
 		return "Invalid path", fmt.Errorf("invalid path: %s", path)
 	}
@@ -124,12 +117,12 @@ func (*EleventyAdapter) CreateContent(path string) (string, error) {
 		return "File already exists", os.ErrExist
 	}
 
-	cmsConfig, err := GetCMSConfig()
+	cmsConfig, err := GetCMSConfigForRuntime(runtime)
 	if err != nil {
 		return "Eleventy content creation requires CMS config", err
 	}
 
-	relContentPath := filepath.Join(config.ContentDir, path)
+	relContentPath := filepath.Join(runtime.ContentDir, path)
 	for _, collection := range cmsConfig.Collections {
 		collFolder := filepath.Clean(collection.Folder)
 		targetFolder := filepath.Dir(relContentPath)

--- a/pkg/services/file.go
+++ b/pkg/services/file.go
@@ -130,7 +130,11 @@ func DeleteFile(targetPath string) error {
 }
 
 func GetConfig() (map[string]interface{}, error) {
-	configPath := filepath.Join(config.RepoPath, config.StaticDir, "admin", "config.yml")
+	return GetConfigForRuntime(config.CurrentSiteRuntime())
+}
+
+func GetConfigForRuntime(runtime config.SiteRuntime) (map[string]interface{}, error) {
+	configPath := filepath.Join(runtime.RepoPath, runtime.StaticDir, "admin", "config.yml")
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -144,7 +148,11 @@ func GetConfig() (map[string]interface{}, error) {
 }
 
 func GetCMSConfig() (*models.CMSConfig, error) {
-	configPath := filepath.Join(config.RepoPath, config.StaticDir, "admin", "config.yml")
+	return GetCMSConfigForRuntime(config.CurrentSiteRuntime())
+}
+
+func GetCMSConfigForRuntime(runtime config.SiteRuntime) (*models.CMSConfig, error) {
+	configPath := filepath.Join(runtime.RepoPath, runtime.StaticDir, "admin", "config.yml")
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, err

--- a/pkg/services/generator.go
+++ b/pkg/services/generator.go
@@ -10,12 +10,11 @@ import (
 
 type GeneratorAdapter interface {
 	Name() string
-	StartPreview() error
+	StartPreview(runtime config.SiteRuntime) error
 	StopPreview() error
-	RestartPreview() error
 	IsPreviewRunning() bool
-	Build() (string, error)
-	CreateContent(path string) (string, error)
+	Build(runtime config.SiteRuntime) (string, error)
+	CreateContent(runtime config.SiteRuntime, path string) (string, error)
 }
 
 var (
@@ -83,31 +82,47 @@ func IsHugoServerRunning() bool {
 }
 
 func BuildSite() (string, error) {
-	adapter, err := NewGeneratorAdapter(config.SiteGenerator)
+	return BuildSiteForRuntime(config.CurrentSiteRuntime())
+}
+
+func BuildSiteForRuntime(runtime config.SiteRuntime) (string, error) {
+	adapter, err := NewGeneratorAdapter(runtime.Generator)
 	if err != nil {
 		return "", err
 	}
-	return adapter.Build()
+	return adapter.Build(runtime)
 }
 
 func CreateContent(path string) (string, error) {
-	adapter, err := NewGeneratorAdapter(config.SiteGenerator)
+	return CreateContentForRuntime(config.CurrentSiteRuntime(), path)
+}
+
+func CreateContentForRuntime(runtime config.SiteRuntime, path string) (string, error) {
+	adapter, err := NewGeneratorAdapter(runtime.Generator)
 	if err != nil {
 		return "", err
 	}
-	return adapter.CreateContent(path)
+	return adapter.CreateContent(runtime, path)
 }
 
 func StartPreviewForSite(site config.SiteConfig) error {
-	adapter, err := previewAdapterForSite(site)
+	return StartPreviewForRuntime(previewRuntime(site))
+}
+
+func StartPreviewForRuntime(runtime config.SiteRuntime) error {
+	adapter, err := previewAdapterForRuntime(runtime)
 	if err != nil {
 		return err
 	}
-	return WithSiteRuntime(previewRuntimeSite(site), adapter.StartPreview)
+	return adapter.StartPreview(runtime)
 }
 
 func StopPreviewForSite(site config.SiteConfig) error {
-	adapter, ok := previewAdapterForSiteIfExists(site)
+	return StopPreviewForRuntime(config.NewSiteRuntime(site))
+}
+
+func StopPreviewForRuntime(runtime config.SiteRuntime) error {
+	adapter, ok := previewAdapterForRuntimeIfExists(runtime)
 	if !ok {
 		return nil
 	}
@@ -115,18 +130,26 @@ func StopPreviewForSite(site config.SiteConfig) error {
 }
 
 func RestartPreviewForSite(site config.SiteConfig) error {
-	adapter, err := previewAdapterForSite(site)
+	return RestartPreviewForRuntime(previewRuntime(site))
+}
+
+func RestartPreviewForRuntime(runtime config.SiteRuntime) error {
+	adapter, err := previewAdapterForRuntime(runtime)
 	if err != nil {
 		return err
 	}
 	if err := adapter.StopPreview(); err != nil {
 		return err
 	}
-	return WithSiteRuntime(previewRuntimeSite(site), adapter.StartPreview)
+	return adapter.StartPreview(runtime)
 }
 
 func IsPreviewRunningForSite(site config.SiteConfig) bool {
-	adapter, ok := previewAdapterForSiteIfExists(site)
+	return IsPreviewRunningForRuntime(config.NewSiteRuntime(site))
+}
+
+func IsPreviewRunningForRuntime(runtime config.SiteRuntime) bool {
+	adapter, ok := previewAdapterForRuntimeIfExists(runtime)
 	return ok && adapter.IsPreviewRunning()
 }
 
@@ -148,26 +171,26 @@ func StopAllPreviewServers() error {
 	return stopErr
 }
 
-func previewAdapterForSite(site config.SiteConfig) (GeneratorAdapter, error) {
+func previewAdapterForRuntime(runtime config.SiteRuntime) (GeneratorAdapter, error) {
 	previewAdaptersMu.Lock()
 	defer previewAdaptersMu.Unlock()
-	return previewAdapterForSiteLocked(site)
+	return previewAdapterForRuntimeLocked(runtime)
 }
 
-func previewAdapterForSiteIfExists(site config.SiteConfig) (GeneratorAdapter, bool) {
+func previewAdapterForRuntimeIfExists(runtime config.SiteRuntime) (GeneratorAdapter, bool) {
 	previewAdaptersMu.Lock()
 	defer previewAdaptersMu.Unlock()
-	adapter, ok := previewAdapters[sitePreviewKey(site)]
+	adapter, ok := previewAdapters[sitePreviewKey(runtime)]
 	return adapter, ok
 }
 
-func previewAdapterForSiteLocked(site config.SiteConfig) (GeneratorAdapter, error) {
-	key := sitePreviewKey(site)
+func previewAdapterForRuntimeLocked(runtime config.SiteRuntime) (GeneratorAdapter, error) {
+	key := sitePreviewKey(runtime)
 	if adapter, ok := previewAdapters[key]; ok {
 		return adapter, nil
 	}
 
-	adapter, err := NewGeneratorAdapter(site.Generator)
+	adapter, err := NewGeneratorAdapter(runtime.Generator)
 	if err != nil {
 		return nil, err
 	}
@@ -175,11 +198,11 @@ func previewAdapterForSiteLocked(site config.SiteConfig) (GeneratorAdapter, erro
 	return adapter, nil
 }
 
-func sitePreviewKey(site config.SiteConfig) string {
-	if site.ID != "" {
-		return site.ID
+func sitePreviewKey(runtime config.SiteRuntime) string {
+	if runtime.ID != "" {
+		return runtime.ID
 	}
-	return filepath.ToSlash(filepath.Clean(site.RepoPath)) + "\x00" + site.HugoServerBind + "\x00" + site.HugoServerPort
+	return filepath.ToSlash(filepath.Clean(runtime.RepoPath)) + "\x00" + runtime.HugoServerBind + "\x00" + runtime.HugoServerPort
 }
 
 func defaultPreviewSite() config.SiteConfig {
@@ -190,9 +213,13 @@ func defaultPreviewSite() config.SiteConfig {
 }
 
 func previewRuntimeSite(site config.SiteConfig) config.SiteConfig {
+	return previewRuntime(site).SiteConfig()
+}
+
+func previewRuntime(site config.SiteConfig) config.SiteRuntime {
 	if site.ID == "" {
-		return site
+		return config.NewSiteRuntime(site)
 	}
 	site.PreviewURL = "/admin/preview/" + url.PathEscape(site.ID) + "/"
-	return site
+	return config.NewSiteRuntime(site)
 }

--- a/pkg/services/generator_test.go
+++ b/pkg/services/generator_test.go
@@ -17,7 +17,7 @@ type testGeneratorAdapter struct {
 
 func (adapter testGeneratorAdapter) Name() string { return "test" }
 
-func (adapter testGeneratorAdapter) StartPreview() error {
+func (adapter testGeneratorAdapter) StartPreview(_ config.SiteRuntime) error {
 	if adapter.start != nil {
 		return adapter.start()
 	}
@@ -31,13 +31,6 @@ func (adapter testGeneratorAdapter) StopPreview() error {
 	return nil
 }
 
-func (adapter testGeneratorAdapter) RestartPreview() error {
-	if err := adapter.StopPreview(); err != nil {
-		return err
-	}
-	return adapter.StartPreview()
-}
-
 func (adapter testGeneratorAdapter) IsPreviewRunning() bool {
 	if adapter.isRunning != nil {
 		return adapter.isRunning()
@@ -45,9 +38,9 @@ func (adapter testGeneratorAdapter) IsPreviewRunning() bool {
 	return true
 }
 
-func (adapter testGeneratorAdapter) Build() (string, error) { return "", nil }
+func (adapter testGeneratorAdapter) Build(_ config.SiteRuntime) (string, error) { return "", nil }
 
-func (adapter testGeneratorAdapter) CreateContent(_ string) (string, error) {
+func (adapter testGeneratorAdapter) CreateContent(_ config.SiteRuntime, _ string) (string, error) {
 	return "", nil
 }
 
@@ -115,7 +108,7 @@ func TestStartPreviewForSiteDoesNotHoldAdapterMapLockWhileStarting(t *testing.T)
 
 	previewAdaptersMu.Lock()
 	previewAdapters = map[string]GeneratorAdapter{
-		sitePreviewKey(site): testGeneratorAdapter{
+		sitePreviewKey(config.NewSiteRuntime(site)): testGeneratorAdapter{
 			start: func() error {
 				if !IsPreviewRunningForSite(site) {
 					return fmt.Errorf("IsPreviewRunningForSite() = false, want true")
@@ -312,7 +305,7 @@ collections:
 		t.Fatalf("write cms config: %v", err)
 	}
 
-	log, err := NewEleventyAdapter().CreateContent("posts/new.md")
+	log, err := NewEleventyAdapter().CreateContent(config.CurrentSiteRuntime(), "posts/new.md")
 	if err != nil {
 		t.Fatalf("CreateContent() error = %v, log = %q", err, log)
 	}

--- a/pkg/services/hugo_adapter.go
+++ b/pkg/services/hugo_adapter.go
@@ -23,11 +23,11 @@ func (*HugoAdapter) Name() string {
 	return "hugo"
 }
 
-func (adapter *HugoAdapter) StartPreview() error {
-	slog.Info("Starting Hugo server", "port", config.HugoServerPort)
+func (adapter *HugoAdapter) StartPreview(runtime config.SiteRuntime) error {
+	slog.Info("Starting Hugo server", "site", runtime.ID, "port", runtime.HugoServerPort)
 
 	err := adapter.preview.Start(func() managedProcess {
-		cmd := exec.Command("hugo", hugoServerArgs()...)
+		cmd := exec.Command("hugo", hugoServerArgs(runtime)...)
 		cmd.Env = generatorProcessEnvironment()
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -51,27 +51,20 @@ func (adapter *HugoAdapter) StopPreview() error {
 	return nil
 }
 
-func (adapter *HugoAdapter) RestartPreview() error {
-	if err := adapter.StopPreview(); err != nil {
-		return err
-	}
-	return adapter.StartPreview()
-}
-
 func (adapter *HugoAdapter) IsPreviewRunning() bool {
 	return adapter.preview.Running()
 }
 
-func (*HugoAdapter) Build() (string, error) {
+func (*HugoAdapter) Build(runtime config.SiteRuntime) (string, error) {
 	start := time.Now()
 	defer func() {
-		slog.Info("Hugo build completed", "duration", time.Since(start))
+		slog.Info("Hugo build completed", "site", runtime.ID, "duration", time.Since(start))
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "hugo", hugoBuildArgs()...)
+	cmd := exec.CommandContext(ctx, "hugo", hugoBuildArgs(runtime)...)
 	cmd.Env = generatorProcessEnvironment()
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
@@ -80,14 +73,14 @@ func (*HugoAdapter) Build() (string, error) {
 	return string(output), err
 }
 
-func hugoServerArgs() []string {
+func hugoServerArgs(runtime config.SiteRuntime) []string {
 	return []string{
 		"server",
-		"--source", config.RepoPath,
-		"--contentDir", config.ContentDir,
-		"--bind", config.HugoServerBind,
-		"--port", config.HugoServerPort,
-		"--baseURL", config.GetAppURL() + config.PreviewURL,
+		"--source", runtime.RepoPath,
+		"--contentDir", runtime.ContentDir,
+		"--bind", runtime.HugoServerBind,
+		"--port", runtime.HugoServerPort,
+		"--baseURL", runtime.AppURL + runtime.PreviewURL,
 		"--appendPort=false",
 		"--disableLiveReload",
 		"-D",
@@ -95,25 +88,25 @@ func hugoServerArgs() []string {
 	}
 }
 
-func hugoBuildArgs() []string {
+func hugoBuildArgs(runtime config.SiteRuntime) []string {
 	return []string{
-		"--source", config.RepoPath,
-		"--contentDir", config.ContentDir,
-		"--destination", config.PublicDir,
-		"--baseURL", config.GetAppURL() + config.PreviewURL,
+		"--source", runtime.RepoPath,
+		"--contentDir", runtime.ContentDir,
+		"--destination", runtime.PublicDir,
+		"--baseURL", runtime.AppURL + runtime.PreviewURL,
 		"--cleanDestinationDir",
 		"-D",
 		"-F",
 	}
 }
 
-func (*HugoAdapter) CreateContent(path string) (string, error) {
+func (*HugoAdapter) CreateContent(runtime config.SiteRuntime, path string) (string, error) {
 	start := time.Now()
 	defer func() {
-		slog.Info("Hugo new content", "path", path, "duration", time.Since(start))
+		slog.Info("Hugo new content", "site", runtime.ID, "path", path, "duration", time.Since(start))
 	}()
 
-	fullPath := SafeJoin(config.RepoPath, config.ContentDir, path)
+	fullPath := SafeJoin(runtime.RepoPath, runtime.ContentDir, path)
 	if fullPath == "" {
 		return "Invalid path", fmt.Errorf("invalid path: %s", path)
 	}
@@ -122,9 +115,9 @@ func (*HugoAdapter) CreateContent(path string) (string, error) {
 		return "File already exists", os.ErrExist
 	}
 
-	cmsConfig, err := GetCMSConfig()
+	cmsConfig, err := GetCMSConfigForRuntime(runtime)
 	if err == nil {
-		relContentPath := filepath.Join(config.ContentDir, path)
+		relContentPath := filepath.Join(runtime.ContentDir, path)
 
 		for _, collection := range cmsConfig.Collections {
 			collFolder := filepath.Clean(collection.Folder)
@@ -149,8 +142,8 @@ func (*HugoAdapter) CreateContent(path string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "hugo", hugoNewContentArgs(path)...)
-	cmd.Dir = config.RepoPath
+	cmd := exec.CommandContext(ctx, "hugo", hugoNewContentArgs(runtime, path)...)
+	cmd.Dir = runtime.RepoPath
 	cmd.Env = generatorProcessEnvironment()
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
@@ -159,11 +152,11 @@ func (*HugoAdapter) CreateContent(path string) (string, error) {
 	return string(output), err
 }
 
-func hugoNewContentArgs(path string) []string {
+func hugoNewContentArgs(runtime config.SiteRuntime, path string) []string {
 	return []string{
 		"new",
 		"content",
-		"--contentDir", config.ContentDir,
+		"--contentDir", runtime.ContentDir,
 		filepath.ToSlash(path),
 	}
 }

--- a/pkg/services/hugo_adapter_test.go
+++ b/pkg/services/hugo_adapter_test.go
@@ -26,11 +26,19 @@ func TestHugoAdapterCreateContentReturnsMatchedCollectionFormatError(t *testing.
 		t.Fatalf("write CMS config: %v", err)
 	}
 
-	originalRepoPath := config.RepoPath
-	config.RepoPath = repoPath
-	t.Cleanup(func() { config.RepoPath = originalRepoPath })
+	runtime := config.NewSiteRuntime(config.SiteConfig{
+		ID:             "test",
+		RepoPath:       repoPath,
+		Generator:      "hugo",
+		ContentDir:     "content",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1314",
+	})
 
-	log, err := NewHugoAdapter().CreateContent("posts/new.md")
+	log, err := NewHugoAdapter().CreateContent(runtime, "posts/new.md")
 	if err == nil {
 		t.Fatal("CreateContent() should return the matched collection format error")
 	}
@@ -46,35 +54,28 @@ func TestHugoAdapterCreateContentReturnsMatchedCollectionFormatError(t *testing.
 }
 
 func TestHugoArgsIncludeConfiguredContentDir(t *testing.T) {
-	originalRepoPath := config.RepoPath
-	originalContentDir := config.ContentDir
-	originalPublicDir := config.PublicDir
-	originalPort := config.HugoServerPort
-	originalBind := config.HugoServerBind
-	t.Cleanup(func() {
-		config.RepoPath = originalRepoPath
-		config.ContentDir = originalContentDir
-		config.PublicDir = originalPublicDir
-		config.HugoServerPort = originalPort
-		config.HugoServerBind = originalBind
+	runtime := config.NewSiteRuntime(config.SiteConfig{
+		ID:             "test",
+		RepoPath:       "repo",
+		Generator:      "hugo",
+		ContentDir:     "src",
+		StaticDir:      "static",
+		PublicDir:      "_site",
+		PreviewURL:     "/preview/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1320",
 	})
 
-	config.RepoPath = "repo"
-	config.ContentDir = "src"
-	config.PublicDir = "_site"
-	config.HugoServerPort = "1320"
-	config.HugoServerBind = "127.0.0.1"
-
-	if got := argValue(hugoServerArgs(), "--contentDir"); got != "src" {
+	if got := argValue(hugoServerArgs(runtime), "--contentDir"); got != "src" {
 		t.Fatalf("hugoServerArgs contentDir = %q, want src", got)
 	}
-	if got := argValue(hugoBuildArgs(), "--contentDir"); got != "src" {
+	if got := argValue(hugoBuildArgs(runtime), "--contentDir"); got != "src" {
 		t.Fatalf("hugoBuildArgs contentDir = %q, want src", got)
 	}
-	if got := argValue(hugoBuildArgs(), "--destination"); got != "_site" {
+	if got := argValue(hugoBuildArgs(runtime), "--destination"); got != "_site" {
 		t.Fatalf("hugoBuildArgs destination = %q, want _site", got)
 	}
-	newArgs := hugoNewContentArgs("posts/a.md")
+	newArgs := hugoNewContentArgs(runtime, "posts/a.md")
 	if len(newArgs) < 3 || newArgs[0] != "new" || newArgs[1] != "content" {
 		t.Fatalf("hugoNewContentArgs = %#v, want hugo new content subcommand", newArgs)
 	}

--- a/pkg/services/site_scope.go
+++ b/pkg/services/site_scope.go
@@ -20,13 +20,20 @@ func WithSiteRuntimeLock(fn func() error) error {
 // a selected site explicitly. Calls are serialized so concurrent requests do
 // not observe another site's runtime settings.
 func WithSiteRuntime(site config.SiteConfig, fn func() error) error {
+	return WithRuntime(config.NewSiteRuntime(site), fn)
+}
+
+// WithRuntime temporarily applies a resolved runtime while executing fn.
+// Prefer passing config.SiteRuntime directly into services for new code; this
+// bridge exists for legacy services that still read config package globals.
+func WithRuntime(runtime config.SiteRuntime, fn func() error) error {
 	siteScopeMu.Lock()
 	defer siteScopeMu.Unlock()
 
-	previous := config.RuntimeSiteConfig()
-	config.ApplySiteRuntime(site)
+	previous := config.CurrentSiteRuntime()
+	config.ApplyRuntime(runtime)
 	defer func() {
-		config.ApplySiteRuntime(previous)
+		config.ApplyRuntime(previous)
 	}()
 
 	return fn()


### PR DESCRIPTION
## Summary
- Add a resolved SiteRuntime value object for service-level runtime settings.
- Keep the legacy runtime bridge, but route it through SiteRuntime.
- Make Hugo and Eleventy generator preview/build/create paths receive explicit SiteRuntime instead of reading process-wide config globals.
- Add runtime-aware CMS config readers and update generator tests.
- Update multi-site generator docs to reflect PR #18 and the new SiteRuntime migration status.

## Validation
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- git diff --check

## Notes
- This is the first slice of bridge reduction. Article, media, and git services still need explicit SiteRuntime migration in follow-up PRs.