### PR TITLE
test: add smoke and frontend preview tests

### DIFF
--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -10,8 +10,17 @@
 go test ./...
 go vet ./...
 go build -buildvcs=false ./...
+npm run test:js
 git diff --check
 ```
+
+miseを使う場合は、同じ検証をまとめて実行できます。
+
+```powershell
+mise run check
+```
+
+`mise run check`はGoのtest/vet/buildに加えて、Node標準テストランナーによるフロントエンドの軽量テストも実行します。
 
 ブラウザでは以下を確認します。
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.24.11"
+node = "22"
 
 [tasks.format]
 description = "Format Go source files"
@@ -9,13 +10,17 @@ run = "go fmt ./..."
 description = "Run tests"
 run = "go test ./..."
 
+[tasks.test-js]
+description = "Run frontend JavaScript tests"
+run = "npm run test:js"
+
 [tasks.vet]
 description = "Run go vet"
 run = "go vet ./..."
 
 [tasks.build]
 description = "Compile all packages"
-run = "go build ./..."
+run = "go build -buildvcs=false ./..."
 
 [tasks.dev]
 description = "Start the CMS"
@@ -23,4 +28,4 @@ run = "go run ."
 
 [tasks.check]
 description = "Run all non-mutating checks"
-depends = ["vet", "test", "build"]
+depends = ["vet", "test", "test-js", "build"]

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "hugo-cms",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "npm run test:js",
+    "test:js": "node --test static/js/*.test.mjs"
+  }
+}

--- a/pkg/services/cache.go
+++ b/pkg/services/cache.go
@@ -64,6 +64,7 @@ func GetArticlesCacheForRuntime(runtime config.SiteRuntime) ([]models.Article, e
 			defer func() { <-sem }()
 
 			relPath, _ := filepath.Rel(contentDir, path)
+			relPath = filepath.ToSlash(relPath)
 
 			repoRelPath, _ := filepath.Rel(runtime.RepoPath, path)
 			repoRelPath = filepath.ToSlash(repoRelPath)

--- a/pkg/services/smoke_test.go
+++ b/pkg/services/smoke_test.go
@@ -1,0 +1,173 @@
+package services
+
+import (
+	"hugo-cms/pkg/config"
+	"path/filepath"
+	"testing"
+)
+
+func TestSmokeHomeCMSHugoCustomContentDir(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      label: Posts
+      folder: src/posts
+      path: "{{slug}}"
+      extension: md
+      frontmatter: yaml
+      fields:
+        - { name: slug, label: Slug, widget: string }
+        - { name: title, label: Title, widget: string }
+        - { name: permalink, label: Permalink, widget: string }
+        - { name: body, label: Body, widget: markdown }
+media:
+  folder: static
+preview:
+  url_field: permalink
+`)
+	writeTestFile(t, filepath.Join(repoPath, "src", "posts", "hello.md"), `---
+title: Hello Smoke
+permalink: /blog/hello/
+---
+
+Body
+`)
+
+	runtime := config.NewSiteRuntime(config.SiteConfig{
+		ID:             "hugo-smoke",
+		RepoPath:       repoPath,
+		Generator:      "hugo",
+		ContentDir:     "src",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1314",
+	})
+
+	rawConfig, err := GetConfigForRuntime(runtime)
+	if err != nil {
+		t.Fatalf("GetConfigForRuntime() error = %v", err)
+	}
+	if rawConfig["_config_source"] != ".homecms.yml" {
+		t.Fatalf("_config_source = %q, want .homecms.yml", rawConfig["_config_source"])
+	}
+	preview, ok := rawConfig["preview"].(map[string]interface{})
+	if !ok || preview["url_field"] != "permalink" {
+		t.Fatalf("preview = %#v, want permalink url field", rawConfig["preview"])
+	}
+
+	cmsConfig, err := GetCMSConfigForRuntime(runtime)
+	if err != nil {
+		t.Fatalf("GetCMSConfigForRuntime() error = %v", err)
+	}
+	if got := cmsConfig.Preview.URLField; got != "permalink" {
+		t.Fatalf("Preview.URLField = %q, want permalink", got)
+	}
+	if len(cmsConfig.Collections) != 1 {
+		t.Fatalf("collections = %#v, want one collection", cmsConfig.Collections)
+	}
+	if got := cmsConfig.Collections[0].Folder; got != "src/posts" {
+		t.Fatalf("collection folder = %q, want src/posts", got)
+	}
+
+	articles, err := GetArticlesCacheForRuntime(runtime)
+	if err != nil {
+		t.Fatalf("GetArticlesCacheForRuntime() error = %v", err)
+	}
+	if len(articles) != 1 {
+		t.Fatalf("articles = %#v, want one article", articles)
+	}
+	if articles[0].Path != "posts/hello.md" {
+		t.Fatalf("article path = %q, want posts/hello.md", articles[0].Path)
+	}
+	if articles[0].Title != "Hello Smoke" {
+		t.Fatalf("article title = %q, want Hello Smoke", articles[0].Title)
+	}
+
+	collection, err := GetCollectionForPathForRuntime(runtime, "src/posts/hello.md")
+	if err != nil {
+		t.Fatalf("GetCollectionForPathForRuntime() error = %v", err)
+	}
+	relFolder, err := CollectionFolderWithinContentForRuntime(runtime, *collection)
+	if err != nil {
+		t.Fatalf("CollectionFolderWithinContentForRuntime() error = %v", err)
+	}
+	if relFolder != filepath.ToSlash(filepath.Join("src", "posts")) {
+		t.Fatalf("collection content folder = %q, want src/posts", relFolder)
+	}
+}
+
+func TestSmokeEleventyHomeCMSRuntimeMetadata(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, "package.json"), `{
+  "dependencies": {
+    "@11ty/eleventy": "^3.0.0"
+  }
+}
+`)
+	writeTestFile(t, filepath.Join(repoPath, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n")
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: notes
+      label: Notes
+      folder: src/notes
+      path: "{{slug}}"
+      extension: md
+      frontmatter: yaml
+      fields:
+        - { name: slug, label: Slug, widget: string }
+        - { name: title, label: Title, widget: string }
+        - { name: body, label: Body, widget: markdown }
+media:
+  folder: public-assets/images
+  public_path: /images
+`)
+	writeTestFile(t, filepath.Join(repoPath, "src", "notes", "first.md"), `---
+title: First Note
+---
+
+Body
+`)
+
+	runtime := config.NewSiteRuntime(config.SiteConfig{
+		ID:             "eleventy-smoke",
+		RepoPath:       repoPath,
+		Generator:      "eleventy",
+		ContentDir:     "src",
+		StaticDir:      "public-assets",
+		PublicDir:      "_site",
+		PreviewURL:     "/",
+		HugoServerBind: "127.0.0.1",
+		HugoServerPort: "1315",
+	})
+
+	pm, err := detectEleventyPackageManager(runtime.RepoPath)
+	if err != nil {
+		t.Fatalf("detectEleventyPackageManager() error = %v", err)
+	}
+	if pm.Name != "pnpm" {
+		t.Fatalf("package manager = %q, want pnpm", pm.Name)
+	}
+
+	articles, err := GetArticlesCacheForRuntime(runtime)
+	if err != nil {
+		t.Fatalf("GetArticlesCacheForRuntime() error = %v", err)
+	}
+	if len(articles) != 1 || articles[0].Path != "notes/first.md" || articles[0].Title != "First Note" {
+		t.Fatalf("articles = %#v, want notes/first.md titled First Note", articles)
+	}
+
+	mediaTarget := staticMediaTargetForRuntime(runtime)
+	if mediaTarget.repoRelDir != "public-assets/images" {
+		t.Fatalf("static media repo dir = %q, want public-assets/images", mediaTarget.repoRelDir)
+	}
+	if mediaTarget.publicBase != "/images" {
+		t.Fatalf("static media public base = %q, want /images", mediaTarget.publicBase)
+	}
+}

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -437,7 +437,7 @@ export function collectFrontMatter() {
     return fm;
 }
 
-function previewUrlFromPath(path) {
+export function previewUrlFromPath(path) {
     let previewPath = path.replace(/\.md$/, "");
 
     if (previewPath.endsWith("/index") || previewPath.endsWith("/_index")) {
@@ -450,7 +450,7 @@ function previewUrlFromPath(path) {
     return rootRelativePath + (rootRelativePath.endsWith("/") ? "" : "/");
 }
 
-function previewUrlFromFrontMatter(config, frontmatter) {
+export function previewUrlFromFrontMatter(config, frontmatter) {
     const fieldName = config?.preview?.url_field;
     if (!fieldName || !frontmatter || frontmatter[fieldName] === undefined || frontmatter[fieldName] === null) {
         return "";
@@ -475,12 +475,12 @@ function previewUrlFromFrontMatter(config, frontmatter) {
     return "/" + rawValue.replace(/^\//, "");
 }
 
-function addCacheBuster(url) {
+export function addCacheBuster(url, now = Date.now()) {
     const hashIndex = url.indexOf("#");
     const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
     const hash = hashIndex === -1 ? "" : url.slice(hashIndex);
     const separator = base.includes("?") ? "&" : "?";
-    return base + separator + "t=" + Date.now() + hash;
+    return base + separator + "t=" + now + hash;
 }
 
 export function setPreviewUrl(path, config, frontmatter) {

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+globalThis.window = {
+    localStorage: {
+        getItem() { return ""; },
+        setItem() {},
+        removeItem() {},
+    },
+    location: {
+        origin: "http://localhost:8080",
+    },
+};
+
+const {
+    addCacheBuster,
+    previewUrlFromFrontMatter,
+    previewUrlFromPath,
+} = await import("./ui.js");
+
+describe("previewUrlFromPath", () => {
+    it("converts regular content files to trailing-slash preview paths", () => {
+        assert.equal(previewUrlFromPath("posts/hello.md"), "/posts/hello/");
+    });
+
+    it("collapses leaf bundle index files to their bundle URL", () => {
+        assert.equal(previewUrlFromPath("posts/hello/index.md"), "/posts/hello/");
+    });
+
+    it("maps root index files to the site root", () => {
+        assert.equal(previewUrlFromPath("index.md"), "/");
+        assert.equal(previewUrlFromPath("_index.md"), "/");
+    });
+});
+
+describe("previewUrlFromFrontMatter", () => {
+    const config = { preview: { url_field: "permalink" } };
+
+    it("uses a root-relative permalink field when configured", () => {
+        assert.equal(
+            previewUrlFromFrontMatter(config, { permalink: "/blog/hello/" }),
+            "/blog/hello/",
+        );
+    });
+
+    it("normalizes relative permalink values to root-relative paths", () => {
+        assert.equal(
+            previewUrlFromFrontMatter(config, { permalink: "blog/hello/" }),
+            "/blog/hello/",
+        );
+    });
+
+    it("keeps the path, query, and hash from absolute http URLs", () => {
+        assert.equal(
+            previewUrlFromFrontMatter(config, { permalink: "https://example.com/blog/hello/?draft=1#top" }),
+            "/blog/hello/?draft=1#top",
+        );
+    });
+
+    it("falls back when the configured field is missing or empty", () => {
+        assert.equal(previewUrlFromFrontMatter(config, {}), "");
+        assert.equal(previewUrlFromFrontMatter(config, { permalink: "" }), "");
+    });
+
+    it("rejects non-http schemes and protocol-relative URLs", () => {
+        assert.equal(previewUrlFromFrontMatter(config, { permalink: "javascript:alert(1)" }), "");
+        assert.equal(previewUrlFromFrontMatter(config, { permalink: "//example.com/blog/" }), "");
+    });
+});
+
+describe("addCacheBuster", () => {
+    it("adds the cache buster before a hash fragment", () => {
+        assert.equal(addCacheBuster("/blog/hello/#top", 123), "/blog/hello/?t=123#top");
+    });
+
+    it("uses an ampersand when the URL already has a query string", () => {
+        assert.equal(addCacheBuster("/blog/hello/?draft=1#top", 123), "/blog/hello/?draft=1&t=123#top");
+    });
+});


### PR DESCRIPTION
## Summary
- add Go smoke coverage for HomeCMS Hugo custom content-dir and Eleventy runtime metadata
- add lightweight Node test coverage for preview URL generation
- include frontend tests in mise run check and document the smoke command

## Validation
- mise run test
- mise run check
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs