### PR TITLE
feat: add CMS config validation warnings

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -199,6 +199,10 @@ media:
 
 `content.collections[].path`で`{{slug}}`のような変数を使う場合は、作成フォームから値を送信できるように同名のfieldを定義してください。
 
+CMSは設定読み込み時に、collection名・folder・path変数・`preview.url_field`・media folderなどを検査します。注意点がある場合は`GET /admin/api/config`の`_cms.warnings`に入り、管理画面のサイドバーにも表示されます。
+
+既存互換の`<static_dir>/admin/config.yml`は引き続き読み込めますが、新規設定と新機能は`.homecms.yml`を基準にします。legacy configを使用しているサイトでは、移行を促すwarningが表示されます。
+
 ### Preview
 
 プレビューはサイトごとに独立したプロセスとして管理されます。選択中サイトのiframeは次の内部proxyを参照します。

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -76,6 +76,8 @@ sites:
 - `/admin/api/articles?site=<id>` が対象サイトの内容を返す
 - `/admin/api/config?site=<id>` の `_cms.site_id` が対象サイトになる
 - `.homecms.yml`があるサイトでは`/admin/api/config?site=<id>` の `_cms.config_source` が `.homecms.yml` になる
+- 設定に注意点がある場合、`/admin/api/config?site=<id>` の `_cms.warnings` と管理画面サイドバーに表示される
+- legacy `static/admin/config.yml` を使うサイトでは互換読み込みwarningが表示される
 - 記事の作成、保存、Diff、削除が選択サイトの`content_dir`配下だけを対象にする
 - メディア一覧、アップロード、削除、raw配信が選択サイトの`static_dir`/記事別メディア設定だけを対象にする
 - `static_media_dir`未指定かつ`.homecms.yml`の`media.folder`があるサイトでは、そのフォルダへstatic media uploadされ、`media.public_path`がMarkdown挿入パスに使われる

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -482,10 +482,20 @@ CMS設定を取得します。サイトリポジトリ直下の `.homecms.yml` �
         "static_dir": "static",
         "public_dir": "public",
         "site_generator": "hugo",
-        "config_source": ".homecms.yml"
+        "config_source": ".homecms.yml",
+        "warnings": [
+            {
+                "severity": "warning",
+                "code": "unknown_preview_url_field",
+                "path": "preview.url_field",
+                "message": "preview.url_field \"permalink\" is not defined in any collection fields; previews may fall back to file paths."
+            }
+        ]
     }
 }
 ```
+
+`_cms.warnings`は設定上の注意点がない場合は空配列です。`severity`は`warning`または`error`で、parse不能な設定は従来通りAPIエラーになります。
 
 ---
 

--- a/docs/reference/cms-config.md
+++ b/docs/reference/cms-config.md
@@ -3,7 +3,7 @@
 HomeCMSのコレクションとフィールドの設定方法について説明します。
 
 推奨設定ファイルは、サイトリポジトリ直下の `{REPO_PATH}/.homecms.yml` です。
-既存サイト向けの後方互換として `{REPO_PATH}/static/admin/config.yml` も読み込みますが、両方が存在する場合は `.homecms.yml` を優先します。
+既存サイト向けの後方互換として `{REPO_PATH}/static/admin/config.yml` も読み込みますが、両方が存在する場合は `.homecms.yml` を優先します。新規設定と新機能は `.homecms.yml` を前提に追加します。legacy configを読み込んだ場合、管理画面には互換読み込みのwarningが表示されます。
 
 ## `.homecms.yml` の基本構造
 
@@ -19,7 +19,9 @@ content:
       extension: md
       frontmatter: yaml
       fields:
+        - { label: "Slug", name: "slug", widget: "string" }
         - { label: "タイトル", name: "title", widget: "string" }
+        - { label: "Permalink", name: "permalink", widget: "string" }
         - { label: "本文", name: "body", widget: "markdown" }
 
 media:
@@ -34,7 +36,22 @@ preview:
 
 `media.folder` はリポジトリルート基準の保存先です。Site Registryや環境変数で `static_media_dir` / `STATIC_MEDIA_DIR` が指定されていない場合、static media mode の一覧・アップロード・削除・raw配信はこのフォルダを使います。`media.public_path` はMarkdownへ挿入する公開パスのベースです。
 
-`GET /admin/api/config` のレスポンスでは `_cms.config_source` に `.homecms.yml` または `config.yml` が入ります。
+`GET /admin/api/config` のレスポンスでは `_cms.config_source` に `.homecms.yml` または `config.yml` が入り、設定上の注意点がある場合は `_cms.warnings` に入ります。
+
+## 設定validation
+
+HomeCMSは設定を読み込むときに、編集・作成・previewで事故につながりやすい項目を検査します。検査結果は `/admin/api/config` の `_cms.warnings` に入り、管理画面のサイドバーにも表示されます。
+
+主な検査項目:
+
+- `content.collections[].name` と `folder` が指定されているか
+- `folder` や `media.folder` がリポジトリ外へ出ない安全な相対パスか
+- `path` に含まれる `{{slug}}` や `{{field_name}}` に対応するfieldがあるか
+- `preview.url_field` に指定したfieldが定義されているか
+- `frontmatter` が `yaml` / `toml` / `json` のいずれかか
+- 未対応のwidgetを使っていないか
+
+`path` を省略した場合は `{{slug}}` として扱われるため、記事作成UIを使うcollectionでは `slug` fieldを定義してください。
 
 ## 旧 `static/admin/config.yml` の基本構造
 

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -446,6 +446,7 @@ func GetConfig(c *gin.Context) {
 	}
 	configSource, _ := cfg["_config_source"].(string)
 	delete(cfg, "_config_source")
+	warnings := services.ValidateConfigForRuntime(runtime, configSource)
 	cfg["_cms"] = gin.H{
 		"content_dir":    runtime.ContentDir,
 		"static_dir":     runtime.StaticDir,
@@ -454,6 +455,7 @@ func GetConfig(c *gin.Context) {
 		"default_site":   config.DefaultSiteID,
 		"site_id":        runtime.ID,
 		"config_source":  configSource,
+		"warnings":       warnings,
 	}
 	c.JSON(http.StatusOK, cfg)
 }

--- a/pkg/handlers/site_scope_test.go
+++ b/pkg/handlers/site_scope_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -221,6 +222,50 @@ preview:
 	warnings, ok := meta["warnings"].([]interface{})
 	if !ok || len(warnings) == 0 {
 		t.Fatalf("warnings = %#v, want validation warnings", meta["warnings"])
+	}
+}
+
+func TestGetConfigReturnsEmptyWarningsArrayForCleanConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	restoreSiteScopeConfig(t)
+
+	repoPath := t.TempDir()
+	writeSnippetFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: content/posts
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: string }
+        - { name: title, widget: string }
+`)
+	config.DefaultSiteID = "default"
+	config.Sites = []config.SiteConfig{{
+		ID:             "default",
+		RepoPath:       repoPath,
+		Generator:      "hugo",
+		ContentDir:     "content",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/",
+		HugoServerPort: "1314",
+		HugoServerBind: "127.0.0.1",
+	}}
+	config.ApplySiteRuntime(config.Sites[0])
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/api/config", nil)
+
+	GetConfig(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig() status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"warnings":[]`) {
+		t.Fatalf("GetConfig() body = %s, want warnings empty array", w.Body.String())
 	}
 }
 

--- a/pkg/handlers/site_scope_test.go
+++ b/pkg/handlers/site_scope_test.go
@@ -170,6 +170,60 @@ func TestGetSnippetsUsesSelectedSitePaths(t *testing.T) {
 	}
 }
 
+func TestGetConfigIncludesValidationWarnings(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	restoreSiteScopeConfig(t)
+
+	repoPath := t.TempDir()
+	writeSnippetFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: content/posts
+      path: "{{slug}}"
+      fields:
+        - { name: title, widget: string }
+preview:
+  url_field: permalink
+`)
+	config.DefaultSiteID = "default"
+	config.Sites = []config.SiteConfig{{
+		ID:             "default",
+		RepoPath:       repoPath,
+		Generator:      "hugo",
+		ContentDir:     "content",
+		StaticDir:      "static",
+		PublicDir:      "public",
+		PreviewURL:     "/",
+		HugoServerPort: "1314",
+		HugoServerBind: "127.0.0.1",
+	}}
+	config.ApplySiteRuntime(config.Sites[0])
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/api/config", nil)
+
+	GetConfig(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig() status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	meta, ok := body["_cms"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("_cms = %#v, want metadata map", body["_cms"])
+	}
+	warnings, ok := meta["warnings"].([]interface{})
+	if !ok || len(warnings) == 0 {
+		t.Fatalf("warnings = %#v, want validation warnings", meta["warnings"])
+	}
+}
+
 func writeSnippetFile(t *testing.T, path, content string) {
 	t.Helper()
 

--- a/pkg/services/config_validation.go
+++ b/pkg/services/config_validation.go
@@ -91,7 +91,7 @@ func validateHomeCMSConfig(home models.HomeCMSConfig) []ConfigWarning {
 }
 
 func validateCMSConfig(cfg models.CMSConfig, source string) []ConfigWarning {
-	var warnings []ConfigWarning
+	warnings := []ConfigWarning{}
 	if len(cfg.Collections) == 0 {
 		warnings = append(warnings, configWarning("error", "missing_collections", collectionRootPath(source), "CMS config should define at least one collection."))
 	}
@@ -158,7 +158,7 @@ func validatePathTemplate(source, path, template string, fieldNames map[string]b
 		template = "{{slug}}"
 	}
 
-	var warnings []ConfigWarning
+	warnings := []ConfigWarning{}
 	for _, variable := range pathTemplateVariables(template) {
 		if isBuiltInPathVariable(variable) || fieldNames[variable] {
 			continue

--- a/pkg/services/config_validation.go
+++ b/pkg/services/config_validation.go
@@ -1,0 +1,265 @@
+package services
+
+import (
+	"fmt"
+	"hugo-cms/pkg/config"
+	"hugo-cms/pkg/models"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ConfigWarning struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Path     string `json:"path,omitempty"`
+	Message  string `json:"message"`
+}
+
+func ValidateConfigForRuntime(runtime config.SiteRuntime, source string) []ConfigWarning {
+	switch source {
+	case homeCMSConfigFile:
+		return validateHomeCMSConfigFile(filepath.Join(runtime.RepoPath, homeCMSConfigFile))
+	case legacyCMSConfigFile:
+		return validateLegacyCMSConfigFile(runtime)
+	default:
+		return []ConfigWarning{{
+			Severity: "warning",
+			Code:     "unknown_config_source",
+			Message:  "CMS config source could not be identified.",
+		}}
+	}
+}
+
+func validateHomeCMSConfigFile(path string) []ConfigWarning {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return []ConfigWarning{configWarning("error", "config_read_failed", ".homecms.yml", "Failed to read .homecms.yml: "+err.Error())}
+	}
+	var home models.HomeCMSConfig
+	if err := yaml.Unmarshal(content, &home); err != nil {
+		return []ConfigWarning{configWarning("error", "config_parse_failed", ".homecms.yml", "Failed to parse .homecms.yml: "+err.Error())}
+	}
+	return validateHomeCMSConfig(home)
+}
+
+func validateLegacyCMSConfigFile(runtime config.SiteRuntime) []ConfigWarning {
+	warnings := []ConfigWarning{configWarning(
+		"warning",
+		"legacy_config",
+		"static/admin/config.yml",
+		"Legacy static/admin/config.yml is loaded for compatibility. Prefer .homecms.yml for new configuration and new features.",
+	)}
+
+	content, err := os.ReadFile(legacyCMSConfigPath(runtime))
+	if err != nil {
+		return append(warnings, configWarning("error", "config_read_failed", "static/admin/config.yml", "Failed to read legacy CMS config: "+err.Error()))
+	}
+	var cfg models.CMSConfig
+	if err := yaml.Unmarshal(content, &cfg); err != nil {
+		return append(warnings, configWarning("error", "config_parse_failed", "static/admin/config.yml", "Failed to parse legacy CMS config: "+err.Error()))
+	}
+	return append(warnings, validateCMSConfig(cfg, legacyCMSConfigFile)...)
+}
+
+func validateHomeCMSConfig(home models.HomeCMSConfig) []ConfigWarning {
+	cfg := models.CMSConfig{
+		MediaFolder:  home.Media.Folder,
+		PublicFolder: home.Media.PublicPath,
+		Preview: models.CMSPreview{
+			URLField: home.Preview.URLField,
+		},
+		Collections: make([]models.Collection, 0, len(home.Content.Collections)),
+	}
+	for _, collection := range home.Content.Collections {
+		cfg.Collections = append(cfg.Collections, models.Collection{
+			Name:         collection.Name,
+			Label:        collection.Label,
+			Folder:       collection.Folder,
+			Path:         collection.Path,
+			Extension:    collection.Extension,
+			Format:       collection.FrontMatter,
+			MediaFolder:  collection.MediaFolder,
+			PublicFolder: collection.PublicFolder,
+			Fields:       collection.Fields,
+		})
+	}
+	return validateCMSConfig(cfg, homeCMSConfigFile)
+}
+
+func validateCMSConfig(cfg models.CMSConfig, source string) []ConfigWarning {
+	var warnings []ConfigWarning
+	if len(cfg.Collections) == 0 {
+		warnings = append(warnings, configWarning("error", "missing_collections", collectionRootPath(source), "CMS config should define at least one collection."))
+	}
+
+	previewField := strings.TrimSpace(cfg.Preview.URLField)
+	previewFieldFound := previewField == ""
+
+	for i, collection := range cfg.Collections {
+		pathPrefix := collectionPath(source, i)
+		fieldNames := map[string]bool{}
+		for j, field := range collection.Fields {
+			fieldPath := fmt.Sprintf("%s.fields[%d]", pathPrefix, j)
+			name := strings.TrimSpace(field.Name)
+			if name == "" {
+				warnings = append(warnings, configWarning("warning", "missing_field_name", fieldPath+".name", "Field name is empty; the field cannot be saved reliably."))
+				continue
+			}
+			fieldNames[name] = true
+			if previewField != "" && name == previewField {
+				previewFieldFound = true
+			}
+			if widget := strings.TrimSpace(field.Widget); widget != "" && !isSupportedWidget(widget) {
+				warnings = append(warnings, configWarning("warning", "unsupported_widget", fieldPath+".widget", fmt.Sprintf("Widget %q is not explicitly supported by the editor and will be rendered as a string input.", widget)))
+			}
+		}
+
+		if strings.TrimSpace(collection.Name) == "" {
+			warnings = append(warnings, configWarning("error", "missing_collection_name", pathPrefix+".name", "Collection name is required."))
+		}
+		folder := strings.TrimSpace(collection.Folder)
+		if folder == "" {
+			warnings = append(warnings, configWarning("error", "missing_collection_folder", pathPrefix+".folder", "Collection folder is required."))
+		} else if cleanConfigPath(folder) == "" {
+			warnings = append(warnings, configWarning("error", "invalid_collection_folder", pathPrefix+".folder", "Collection folder must be a safe relative path inside the repository."))
+		}
+
+		if format := strings.TrimSpace(collection.Format); format != "" && !isSupportedFrontMatterFormat(format, source) {
+			warnings = append(warnings, configWarning("warning", "unsupported_frontmatter", pathPrefix+".frontmatter", fmt.Sprintf("Front matter format %q is not supported; use yaml, toml, or json.", format)))
+		}
+
+		warnings = append(warnings, validatePathTemplate(source, pathPrefix+".path", collection.Path, fieldNames)...)
+	}
+
+	if previewField != "" && !previewFieldFound {
+		warnings = append(warnings, configWarning("warning", "unknown_preview_url_field", previewPath(source)+".url_field", fmt.Sprintf("preview.url_field %q is not defined in any collection fields; previews may fall back to file paths.", previewField)))
+	}
+
+	mediaFolder := strings.TrimSpace(cfg.MediaFolder)
+	if mediaFolder != "" {
+		valid := cleanConfigPath(mediaFolder) != ""
+		if source == legacyCMSConfigFile {
+			valid = cleanMediaRepoRelDir(mediaFolder) != ""
+		}
+		if !valid {
+			warnings = append(warnings, configWarning("error", "invalid_media_folder", mediaFolderPath(source), "Media folder must be a safe repository-relative path."))
+		}
+	}
+
+	return warnings
+}
+
+func validatePathTemplate(source, path, template string, fieldNames map[string]bool) []ConfigWarning {
+	if strings.TrimSpace(template) == "" {
+		template = "{{slug}}"
+	}
+
+	var warnings []ConfigWarning
+	for _, variable := range pathTemplateVariables(template) {
+		if isBuiltInPathVariable(variable) || fieldNames[variable] {
+			continue
+		}
+		if variable == "slug" {
+			warnings = append(warnings, configWarning("error", "missing_slug_field", path, "Path template uses {{slug}}, but the collection does not define a slug field. Add a slug field or change the path template."))
+			continue
+		}
+		warnings = append(warnings, configWarning("warning", "unknown_path_variable", path, fmt.Sprintf("Path template uses {{%s}}, but no matching field is defined.", variable)))
+	}
+	return warnings
+}
+
+func pathTemplateVariables(template string) []string {
+	re := regexp.MustCompile(`{{([^}]+)}}`)
+	matches := re.FindAllStringSubmatch(template, -1)
+	var variables []string
+	seen := map[string]bool{}
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		variable := strings.TrimSpace(match[1])
+		if variable == "" || seen[variable] {
+			continue
+		}
+		seen[variable] = true
+		variables = append(variables, variable)
+	}
+	return variables
+}
+
+func isBuiltInPathVariable(variable string) bool {
+	switch variable {
+	case "year", "month", "day", "hour", "minute", "second":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSupportedWidget(widget string) bool {
+	switch strings.ToLower(strings.TrimSpace(widget)) {
+	case "string", "text", "markdown", "boolean", "datetime", "list", "number", "select":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSupportedFrontMatterFormat(format, source string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(format))
+	if source == homeCMSConfigFile {
+		switch normalized {
+		case "yaml", "yml", "toml", "json":
+			return true
+		default:
+			return false
+		}
+	}
+	switch normalized {
+	case "yaml", "yml", "toml", "json", "yaml-frontmatter", "toml-frontmatter", "json-frontmatter":
+		return true
+	default:
+		return false
+	}
+}
+
+func collectionRootPath(source string) string {
+	if source == homeCMSConfigFile {
+		return "content.collections"
+	}
+	return "collections"
+}
+
+func collectionPath(source string, index int) string {
+	if source == homeCMSConfigFile {
+		return fmt.Sprintf("content.collections[%d]", index)
+	}
+	return fmt.Sprintf("collections[%d]", index)
+}
+
+func previewPath(source string) string {
+	if source == homeCMSConfigFile {
+		return "preview"
+	}
+	return "preview"
+}
+
+func mediaFolderPath(source string) string {
+	if source == homeCMSConfigFile {
+		return "media.folder"
+	}
+	return "media_folder"
+}
+
+func configWarning(severity, code, path, message string) ConfigWarning {
+	return ConfigWarning{
+		Severity: severity,
+		Code:     code,
+		Path:     path,
+		Message:  message,
+	}
+}

--- a/pkg/services/config_validation.go
+++ b/pkg/services/config_validation.go
@@ -22,7 +22,7 @@ type ConfigWarning struct {
 func ValidateConfigForRuntime(runtime config.SiteRuntime, source string) []ConfigWarning {
 	switch source {
 	case homeCMSConfigFile:
-		return validateHomeCMSConfigFile(filepath.Join(runtime.RepoPath, homeCMSConfigFile))
+		return validateHomeCMSConfigFile(runtime, filepath.Join(runtime.RepoPath, homeCMSConfigFile))
 	case legacyCMSConfigFile:
 		return validateLegacyCMSConfigFile(runtime)
 	default:
@@ -34,7 +34,7 @@ func ValidateConfigForRuntime(runtime config.SiteRuntime, source string) []Confi
 	}
 }
 
-func validateHomeCMSConfigFile(path string) []ConfigWarning {
+func validateHomeCMSConfigFile(runtime config.SiteRuntime, path string) []ConfigWarning {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return []ConfigWarning{configWarning("error", "config_read_failed", ".homecms.yml", "Failed to read .homecms.yml: "+err.Error())}
@@ -43,29 +43,30 @@ func validateHomeCMSConfigFile(path string) []ConfigWarning {
 	if err := yaml.Unmarshal(content, &home); err != nil {
 		return []ConfigWarning{configWarning("error", "config_parse_failed", ".homecms.yml", "Failed to parse .homecms.yml: "+err.Error())}
 	}
-	return validateHomeCMSConfig(home)
+	return validateHomeCMSConfig(runtime, home)
 }
 
 func validateLegacyCMSConfigFile(runtime config.SiteRuntime) []ConfigWarning {
+	legacyPath := filepath.ToSlash(filepath.Join(runtime.StaticDir, "admin", legacyCMSConfigFile))
 	warnings := []ConfigWarning{configWarning(
 		"warning",
 		"legacy_config",
-		"static/admin/config.yml",
-		"Legacy static/admin/config.yml is loaded for compatibility. Prefer .homecms.yml for new configuration and new features.",
+		legacyPath,
+		fmt.Sprintf("Legacy %s is loaded for compatibility. Prefer .homecms.yml for new configuration and new features.", legacyPath),
 	)}
 
 	content, err := os.ReadFile(legacyCMSConfigPath(runtime))
 	if err != nil {
-		return append(warnings, configWarning("error", "config_read_failed", "static/admin/config.yml", "Failed to read legacy CMS config: "+err.Error()))
+		return append(warnings, configWarning("error", "config_read_failed", legacyPath, "Failed to read legacy CMS config: "+err.Error()))
 	}
 	var cfg models.CMSConfig
 	if err := yaml.Unmarshal(content, &cfg); err != nil {
-		return append(warnings, configWarning("error", "config_parse_failed", "static/admin/config.yml", "Failed to parse legacy CMS config: "+err.Error()))
+		return append(warnings, configWarning("error", "config_parse_failed", legacyPath, "Failed to parse legacy CMS config: "+err.Error()))
 	}
-	return append(warnings, validateCMSConfig(cfg, legacyCMSConfigFile)...)
+	return append(warnings, validateCMSConfig(runtime, cfg, legacyCMSConfigFile)...)
 }
 
-func validateHomeCMSConfig(home models.HomeCMSConfig) []ConfigWarning {
+func validateHomeCMSConfig(runtime config.SiteRuntime, home models.HomeCMSConfig) []ConfigWarning {
 	cfg := models.CMSConfig{
 		MediaFolder:  home.Media.Folder,
 		PublicFolder: home.Media.PublicPath,
@@ -87,10 +88,10 @@ func validateHomeCMSConfig(home models.HomeCMSConfig) []ConfigWarning {
 			Fields:       collection.Fields,
 		})
 	}
-	return validateCMSConfig(cfg, homeCMSConfigFile)
+	return validateCMSConfig(runtime, cfg, homeCMSConfigFile)
 }
 
-func validateCMSConfig(cfg models.CMSConfig, source string) []ConfigWarning {
+func validateCMSConfig(runtime config.SiteRuntime, cfg models.CMSConfig, source string) []ConfigWarning {
 	warnings := []ConfigWarning{}
 	if len(cfg.Collections) == 0 {
 		warnings = append(warnings, configWarning("error", "missing_collections", collectionRootPath(source), "CMS config should define at least one collection."))
@@ -124,8 +125,8 @@ func validateCMSConfig(cfg models.CMSConfig, source string) []ConfigWarning {
 		folder := strings.TrimSpace(collection.Folder)
 		if folder == "" {
 			warnings = append(warnings, configWarning("error", "missing_collection_folder", pathPrefix+".folder", "Collection folder is required."))
-		} else if cleanConfigPath(folder) == "" {
-			warnings = append(warnings, configWarning("error", "invalid_collection_folder", pathPrefix+".folder", "Collection folder must be a safe relative path inside the repository."))
+		} else if _, err := CollectionFolderWithinContentForRuntime(runtime, collection); err != nil {
+			warnings = append(warnings, configWarning("error", "invalid_collection_folder", pathPrefix+".folder", fmt.Sprintf("Collection folder must be a safe relative path under %s.", runtime.ContentDir)))
 		}
 
 		if format := strings.TrimSpace(collection.Format); format != "" && !isSupportedFrontMatterFormat(format, source) {

--- a/pkg/services/config_validation_test.go
+++ b/pkg/services/config_validation_test.go
@@ -46,6 +46,30 @@ collections:
 	assertNoWarningCode(t, warnings, "unknown_path_variable")
 }
 
+func TestValidateConfigForRuntimeReportsLegacyConfigPathWithStaticDir(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, "public-assets", "admin", "config.yml"), `
+collections:
+  - name: posts
+    folder: content/posts
+    fields:
+      - name: slug
+        widget: string
+`)
+
+	runtime := config.NewSiteRuntime(config.SiteConfig{
+		ID:         "test",
+		RepoPath:   repoPath,
+		ContentDir: "content",
+		StaticDir:  "public-assets",
+	})
+	warnings := ValidateConfigForRuntime(runtime, "config.yml")
+	warning := findWarningCode(t, warnings, "legacy_config")
+	if warning.Path != "public-assets/admin/config.yml" {
+		t.Fatalf("legacy warning path = %q, want public-assets/admin/config.yml", warning.Path)
+	}
+}
+
 func TestValidateConfigForRuntimeWarnsAboutInvalidPaths(t *testing.T) {
 	repoPath := t.TempDir()
 	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
@@ -70,6 +94,28 @@ media:
 	assertWarningCode(t, warnings, "invalid_collection_folder")
 	assertWarningCode(t, warnings, "invalid_media_folder")
 	assertWarningCode(t, warnings, "unsupported_widget")
+}
+
+func TestValidateConfigForRuntimeWarnsAboutCollectionOutsideContentDir(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: assets/posts
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: string }
+`)
+
+	warnings := ValidateConfigForRuntime(config.NewSiteRuntime(config.SiteConfig{
+		ID:         "test",
+		RepoPath:   repoPath,
+		ContentDir: "content",
+		StaticDir:  "static",
+	}), ".homecms.yml")
+	assertWarningCode(t, warnings, "invalid_collection_folder")
 }
 
 func TestValidateConfigForRuntimeReturnsEmptySliceForCleanHomeCMSConfig(t *testing.T) {
@@ -101,12 +147,18 @@ preview:
 
 func assertWarningCode(t *testing.T, warnings []ConfigWarning, code string) {
 	t.Helper()
+	_ = findWarningCode(t, warnings, code)
+}
+
+func findWarningCode(t *testing.T, warnings []ConfigWarning, code string) ConfigWarning {
+	t.Helper()
 	for _, warning := range warnings {
 		if warning.Code == code {
-			return
+			return warning
 		}
 	}
 	t.Fatalf("warning code %q not found in %#v", code, warnings)
+	return ConfigWarning{}
 }
 
 func assertNoWarningCode(t *testing.T, warnings []ConfigWarning, code string) {

--- a/pkg/services/config_validation_test.go
+++ b/pkg/services/config_validation_test.go
@@ -1,0 +1,92 @@
+package services
+
+import (
+	"hugo-cms/pkg/config"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateConfigForRuntimeWarnsAboutHomeCMSCreateAndPreviewIssues(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: content/posts
+      path: "{{slug}}"
+      frontmatter: yaml
+      fields:
+        - { name: title, widget: string }
+media:
+  folder: static/images
+preview:
+  url_field: permalink
+`)
+
+	warnings := ValidateConfigForRuntime(testRuntime(repoPath), ".homecms.yml")
+	assertWarningCode(t, warnings, "missing_slug_field")
+	assertWarningCode(t, warnings, "unknown_preview_url_field")
+}
+
+func TestValidateConfigForRuntimeWarnsAboutLegacyConfig(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, "static", "admin", "config.yml"), `
+collections:
+  - name: posts
+    folder: content/posts
+    path: "{{title}}"
+    fields:
+      - name: title
+        widget: string
+`)
+
+	warnings := ValidateConfigForRuntime(testRuntime(repoPath), "config.yml")
+	assertWarningCode(t, warnings, "legacy_config")
+	assertNoWarningCode(t, warnings, "unknown_path_variable")
+}
+
+func TestValidateConfigForRuntimeWarnsAboutInvalidPaths(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: ../posts
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: mystery }
+media:
+  folder: /absolute
+`)
+
+	warnings := ValidateConfigForRuntime(config.NewSiteRuntime(config.SiteConfig{
+		ID:         "test",
+		RepoPath:   repoPath,
+		ContentDir: "content",
+		StaticDir:  "static",
+	}), ".homecms.yml")
+	assertWarningCode(t, warnings, "invalid_collection_folder")
+	assertWarningCode(t, warnings, "invalid_media_folder")
+	assertWarningCode(t, warnings, "unsupported_widget")
+}
+
+func assertWarningCode(t *testing.T, warnings []ConfigWarning, code string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return
+		}
+	}
+	t.Fatalf("warning code %q not found in %#v", code, warnings)
+}
+
+func assertNoWarningCode(t *testing.T, warnings []ConfigWarning, code string) {
+	t.Helper()
+	for _, warning := range warnings {
+		if warning.Code == code {
+			t.Fatalf("warning code %q unexpectedly found in %#v", code, warnings)
+		}
+	}
+}

--- a/pkg/services/config_validation_test.go
+++ b/pkg/services/config_validation_test.go
@@ -72,6 +72,33 @@ media:
 	assertWarningCode(t, warnings, "unsupported_widget")
 }
 
+func TestValidateConfigForRuntimeReturnsEmptySliceForCleanHomeCMSConfig(t *testing.T) {
+	repoPath := t.TempDir()
+	writeTestFile(t, filepath.Join(repoPath, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: content/posts
+      path: "{{slug}}"
+      frontmatter: yaml
+      fields:
+        - { name: slug, widget: string }
+        - { name: title, widget: string }
+        - { name: permalink, widget: string }
+preview:
+  url_field: permalink
+`)
+
+	warnings := ValidateConfigForRuntime(testRuntime(repoPath), ".homecms.yml")
+	if warnings == nil {
+		t.Fatal("ValidateConfigForRuntime() returned nil warnings, want empty slice")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %#v, want empty slice", warnings)
+	}
+}
+
 func assertWarningCode(t *testing.T, warnings []ConfigWarning, code string) {
 	t.Helper()
 	for _, warning := range warnings {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,6 +11,13 @@ aside { width: 300px; background: #252526; display: flex; flex-direction: column
 .site-selector label { display: block; color: #9cdcfe; font-size: 12px; margin-bottom: 4px; }
 .site-selector select { width: 100%; background: #3c3c3c; color: #ddd; border: 1px solid #555; border-radius: 3px; padding: 6px; }
 .site-selector.hidden { display: none; }
+.config-warning-panel { padding: 10px; border-bottom: 1px solid #333; background: #241f18; max-height: 180px; overflow-y: auto; }
+.config-warning-panel.hidden { display: none; }
+.config-warning-title { font-size: 12px; font-weight: bold; color: #e2c08d; margin-bottom: 8px; }
+.config-warning-item { border-left: 3px solid #e2c08d; padding: 6px 8px; margin-bottom: 6px; background: rgba(226, 192, 141, 0.08); border-radius: 3px; }
+.config-warning-item.error { border-left-color: #ce3a3a; background: rgba(206, 58, 58, 0.10); }
+.config-warning-message { font-size: 12px; color: #ddd; line-height: 1.35; }
+.config-warning-meta { font-size: 11px; color: #9a9a9a; margin-top: 3px; word-break: break-word; }
 .sidebar-actions { padding: 10px; display: flex; gap: 5px; border-bottom: 1px solid #333; flex-wrap: wrap; }
 .sidebar-actions button { flex: 1; }
 #file-list { flex: 1; overflow-y: auto; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -128,6 +128,7 @@ async function init() {
 async function loadSiteData() {
     cmsConfig = await API.fetchConfig();
     Editor.setConfig(cmsConfig);
+    UI.renderConfigWarnings(cmsConfig);
     await refreshFileList();
 }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -86,6 +86,44 @@ export function renderSiteSelector(registry, selectedSiteID, onChange) {
     container.appendChild(select);
 }
 
+export function renderConfigWarnings(config) {
+    const panel = document.getElementById('config-warning-panel');
+    if (!panel) return;
+
+    const warnings = Array.isArray(config?._cms?.warnings) ? config._cms.warnings : [];
+    panel.innerHTML = '';
+    if (warnings.length === 0) {
+        panel.classList.add('hidden');
+        return;
+    }
+
+    panel.classList.remove('hidden');
+    const title = document.createElement('div');
+    title.className = 'config-warning-title';
+    title.textContent = `Config warnings (${warnings.length})`;
+    panel.appendChild(title);
+
+    warnings.forEach(warning => {
+        const item = document.createElement('div');
+        const severity = warning.severity === 'error' ? 'error' : 'warning';
+        item.className = `config-warning-item ${severity}`;
+
+        const message = document.createElement('div');
+        message.className = 'config-warning-message';
+        message.textContent = warning.message || warning.code || 'Configuration warning';
+        item.appendChild(message);
+
+        if (warning.path || warning.code) {
+            const meta = document.createElement('div');
+            meta.className = 'config-warning-meta';
+            meta.textContent = [warning.path, warning.code].filter(Boolean).join(' · ');
+            item.appendChild(meta);
+        }
+
+        panel.appendChild(item);
+    });
+}
+
 export async function showLoadingEditor() {
     const fmContainer = document.getElementById('fm-container');
     const editor = document.getElementById('editor');

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
             <button class="action-btn secondary mobile-only" onclick="toggleSidebar()" style="padding: 2px 8px;">×</button>
         </div>
         <div id="site-selector-container" class="site-selector"></div>
+        <div id="config-warning-panel" class="config-warning-panel hidden"></div>
         <div class="sidebar-actions">
             <button class="action-btn success" onclick="createNewFile()">+ New File</button>
             <button class="action-btn secondary" onclick="runSync()">🔄 Sync</button>


### PR DESCRIPTION
## Summary
- add CMS config validation for HomeCMS and legacy config files
- expose validation results through _cms.warnings in the config API
- render config warnings in the admin sidebar
- document HomeCMS as the primary config path and legacy config as compatibility

## Validation
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs
- git diff --check