### PR TITLE
chore: prepare release readiness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Hugo CMSの利用方法、仕様、設計、および監査結果を目的別に
 
 - [設定ガイド](guides/configuration.md) - 環境変数と実行設定
 - [デプロイガイド](guides/deployment.md) - サーバー、Docker、リバースプロキシ
+- [`.homecms.yml` 移行ガイド](guides/migrating-to-homecms.md) - legacy `static/admin/config.yml` からの移行
+- [リリース前チェックリスト](guides/release-checklist.md) - リリース候補PRで確認する項目
 - [Smoke Test Checklist](guides/smoke-tests.md) - 変更後の最低限確認項目
 
 ## リファレンス

--- a/docs/guides/migrating-to-homecms.md
+++ b/docs/guides/migrating-to-homecms.md
@@ -1,0 +1,100 @@
+# `.homecms.yml` 移行ガイド
+
+既存の `static/admin/config.yml` は互換読み込みできますが、新しい機能はリポジトリ直下の `.homecms.yml` を基準にします。新規サイトや複数サイト構成では、`.homecms.yml` への移行を推奨します。
+
+## 移行の考え方
+
+`static/admin/config.yml` は「CMSの管理画面用の静的ファイル」としてサイト内に置かれていました。`.homecms.yml` は「HomeCMSが読むサイト設定」としてリポジトリ直下に置き、Hugo / Eleventy どちらでも同じ場所から読みます。
+
+| 旧設定 | 新設定 | 備考 |
+|---|---|---|
+| `collections` | `content.collections` | collection定義はほぼそのまま移せます |
+| `collections[].folder` | `content.collections[].folder` | リポジトリルート基準。通常は `content/posts` や `src/posts` |
+| `collections[].path` | `content.collections[].path` | `{{slug}}` などの変数を使う場合、同名fieldが必要 |
+| `collections[].format` | `content.collections[].frontmatter` | `yaml-frontmatter` は `yaml` に寄せます |
+| `media_folder` | `media.folder` | リポジトリルート基準。例: `static/images` |
+| `public_folder` / `public_path` | `media.public_path` | Markdownへ挿入する公開URL。例: `/images` |
+| なし | `preview.url_field` | permalink等からpreview URLを決めたい場合に指定 |
+
+## 手順
+
+1. 対象サイトのリポジトリ直下に `.homecms.yml` を作成する
+2. 旧 `collections` を `content.collections` へ移す
+3. `media_folder` / `public_folder` を `media.folder` / `media.public_path` へ移す
+4. `path` テンプレートで使う変数が `fields` に含まれているか確認する
+5. CMSを起動し、`/admin/api/config` の `_cms.warnings` とサイドバーのwarningを確認する
+6. 問題がなければ旧 `static/admin/config.yml` を削除する
+
+## 例
+
+旧 `static/admin/config.yml`:
+
+```yaml
+media_folder: static/images
+public_folder: /images
+collections:
+  - name: posts
+    label: Posts
+    folder: content/posts
+    path: "{{slug}}"
+    format: yaml-frontmatter
+    fields:
+      - { name: slug, label: Slug, widget: string }
+      - { name: title, label: Title, widget: string }
+      - { name: body, label: Body, widget: markdown }
+```
+
+新 `.homecms.yml`:
+
+```yaml
+version: 1
+
+content:
+  collections:
+    - name: posts
+      label: Posts
+      folder: content/posts
+      path: "{{slug}}"
+      frontmatter: yaml
+      fields:
+        - { name: slug, label: Slug, widget: string }
+        - { name: title, label: Title, widget: string }
+        - { name: body, label: Body, widget: markdown }
+
+media:
+  folder: static/images
+  public_path: /images
+
+preview:
+  url_field: permalink
+```
+
+## 複数サイトでの注意点
+
+Site Registryを使う場合、`.homecms.yml` は各サイトの `repo_path` 直下に置きます。`folder` や `media.folder` はそのサイトのリポジトリルート基準です。
+
+```yaml
+default_site: techblog
+sites:
+  - id: techblog
+    repo_path: D:/sites/techblog
+    content_dir: content
+
+  - id: docs
+    repo_path: D:/sites/docs
+    generator: eleventy
+    content_dir: src
+```
+
+この例では、`docs` サイトの collection folder は `src/posts` のように `docs` リポジトリ内の `content_dir` 配下を指す必要があります。`folder: content/posts` のような旧Hugo前提の値は、`content_dir: src` のサイトでは作成時に拒否されます。
+
+## 移行後の確認
+
+最低限、次を確認してください。
+
+- 記事一覧が表示される
+- 新規作成時に期待したパスへ `.md` が作られる
+- front matterのlabelやwidgetが維持されている
+- static media uploadの保存先と挿入URLが期待通り
+- `preview.url_field` を使うサイトでは、保存・preview・restart後も同じURLが表示される
+- `_cms.warnings` が空配列 `[]` になる、または残ったwarningの理由を説明できる

--- a/docs/guides/migrating-to-homecms.md
+++ b/docs/guides/migrating-to-homecms.md
@@ -59,6 +59,7 @@ content:
       fields:
         - { name: slug, label: Slug, widget: string }
         - { name: title, label: Title, widget: string }
+        - { name: permalink, label: Permalink, widget: string }
         - { name: body, label: Body, widget: markdown }
 
 media:

--- a/docs/guides/migrating-to-homecms.md
+++ b/docs/guides/migrating-to-homecms.md
@@ -86,7 +86,9 @@ sites:
     content_dir: src
 ```
 
-この例では、`docs` サイトの collection folder は `src/posts` のように `docs` リポジトリ内の `content_dir` 配下を指す必要があります。`folder: content/posts` のような旧Hugo前提の値は、`content_dir: src` のサイトでは作成時に拒否されます。
+この例では、`docs` サイトの新規 `.homecms.yml` では `src/posts` のように、そのサイトの `content_dir` 配下を明示することを推奨します。
+
+一方、既存の legacy config から移行する場合、`folder: content/posts` のような旧Hugo前提の値は互換処理で `src/posts` として扱われます。そのため、動作している既存設定を急いで書き換える必要はありません。新しく設定を書く場合や、互換挙動に依存したくない場合は、現在の `content_dir` に合わせた `folder` へ整理してください。
 
 ## 移行後の確認
 

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -1,0 +1,79 @@
+# リリース前チェックリスト
+
+このCMSをリリース可能な状態にする前に確認する項目です。機能追加PRではなく、リリース候補を作るPRではこのチェックリストを基準にします。
+
+## 1. 自動検証
+
+ローカルでは次を通します。
+
+```powershell
+mise run check
+git diff --check
+```
+
+`mise` を使わない場合は個別に実行します。
+
+```powershell
+go test ./...
+go vet ./...
+go build -buildvcs=false ./...
+npm run test:js
+git diff --check
+```
+
+## 2. 設定検証
+
+代表的なサイト構成で `/admin/api/config` を確認します。
+
+- `.homecms.yml` の `_cms.config_source` が `.homecms.yml`
+- legacy `static/admin/config.yml` の `_cms.config_source` が実ファイルに対応
+- warningがない設定では `_cms.warnings` が `[]`
+- warningがある設定ではサイドバーに表示される
+- `content_dir` / `static_dir` / `public_dir` / `site_generator` / `site_id` が選択サイトの値
+
+## 3. 単一サイトの基本動作
+
+- ログインできる
+- 記事一覧が表示される
+- 記事を開く、保存する、Diffを見る、削除する
+- 新規作成が `content_dir` 配下に作成される
+- メディア一覧、アップロード、削除、Markdown挿入が動く
+- スニペット挿入が動く
+- Preview / Restart Preview が動く
+- Publish が対象記事と関連メディアをcommit/pushする
+
+## 4. 複数サイトの基本動作
+
+Site Registryありで、少なくとも2サイトを用意して確認します。
+
+- Site selectorで切り替えられる
+- 記事一覧、記事取得、作成、保存、削除が選択サイトだけを対象にする
+- APIの `?site=<site_id>` と `X-CMS-Site` が同じ結果になる
+- default siteの `/ready` と選択site APIが混ざらない
+- siteごとの preview port が重複していない
+- 非default site previewのroot-relative URLがdefault siteへ落ちない
+- siteごとの snippets / media / Git設定が使われる
+
+## 5. Hugo / Eleventy
+
+Hugoサイトでは次を確認します。
+
+- `CONTENT_DIR` / Site Registryの `content_dir` を変えた場合も `hugo server` / `hugo build` が対象contentを読む
+- `hugo new content <path>` のfallback作成が期待通り
+
+Eleventyサイトでは次を確認します。
+
+- `package.json` とlockfileがある
+- lockfileに対応するpackage managerでpreview/buildされる
+- preview停止時にwrapperの子プロセスが残らない
+
+## 6. PR確認
+
+PR本文には次を含めます。
+
+- 変更概要
+- 動作確認コマンド
+- 手動確認した範囲
+- リリース時の注意点や既知の未対応
+
+リリース候補PRは、CIとレビューが通ったあとに draft を解除します。

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -4,6 +4,8 @@
 
 大きめの変更やSite Registry変更後に、最低限確認する項目です。
 
+リリース候補PRでは、ここに加えて[リリース前チェックリスト](release-checklist.md)も確認してください。
+
 ## 1. 共通
 
 ```powershell

--- a/pkg/handlers/site_scope_test.go
+++ b/pkg/handlers/site_scope_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"hugo-cms/pkg/config"
 	"net/http"
@@ -266,6 +267,255 @@ content:
 	}
 	if !strings.Contains(w.Body.String(), `"warnings":[]`) {
 		t.Fatalf("GetConfig() body = %s, want warnings empty array", w.Body.String())
+	}
+}
+
+func TestSelectedSiteArticleAPIsUseSelectedRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	restoreSiteScopeConfig(t)
+
+	defaultRepo := t.TempDir()
+	selectedRepo := t.TempDir()
+	writeSnippetFile(t, filepath.Join(defaultRepo, "content", "posts", "default.md"), `---
+title: Default Post
+---
+default body
+`)
+	writeSnippetFile(t, filepath.Join(selectedRepo, "src", "docs", "selected.md"), `---
+title: Selected Post
+---
+selected body
+`)
+
+	config.DefaultSiteID = "default"
+	config.Sites = []config.SiteConfig{
+		{
+			ID:             "default",
+			RepoPath:       defaultRepo,
+			Generator:      "hugo",
+			ContentDir:     "content",
+			StaticDir:      "static",
+			PublicDir:      "public",
+			PreviewURL:     "/",
+			HugoServerPort: "1314",
+			HugoServerBind: "127.0.0.1",
+		},
+		{
+			ID:             "docs",
+			RepoPath:       selectedRepo,
+			Generator:      "eleventy",
+			ContentDir:     "src",
+			StaticDir:      "public-assets",
+			PublicDir:      "_site",
+			PreviewURL:     "/docs/",
+			HugoServerPort: "1315",
+			HugoServerBind: "127.0.0.1",
+		},
+	}
+	config.ApplySiteRuntime(config.Sites[0])
+
+	listW := httptest.NewRecorder()
+	listC, _ := gin.CreateTestContext(listW)
+	listC.Request = httptest.NewRequest(http.MethodGet, "/admin/api/articles?site=docs", nil)
+
+	ListArticles(listC)
+
+	if listW.Code != http.StatusOK {
+		t.Fatalf("ListArticles() status = %d, body = %s", listW.Code, listW.Body.String())
+	}
+	var articles []map[string]interface{}
+	if err := json.Unmarshal(listW.Body.Bytes(), &articles); err != nil {
+		t.Fatalf("unmarshal articles: %v", err)
+	}
+	if len(articles) != 1 || articles[0]["path"] != "docs/selected.md" || articles[0]["title"] != "Selected Post" {
+		t.Fatalf("articles = %#v, want only selected site article", articles)
+	}
+
+	getW := httptest.NewRecorder()
+	getC, _ := gin.CreateTestContext(getW)
+	getC.Request = httptest.NewRequest(http.MethodGet, "/admin/api/article?site=docs&path=docs/selected.md", nil)
+
+	GetArticle(getC)
+
+	if getW.Code != http.StatusOK {
+		t.Fatalf("GetArticle() status = %d, body = %s", getW.Code, getW.Body.String())
+	}
+	var article map[string]interface{}
+	if err := json.Unmarshal(getW.Body.Bytes(), &article); err != nil {
+		t.Fatalf("unmarshal article: %v", err)
+	}
+	frontmatter, ok := article["frontmatter"].(map[string]interface{})
+	if !ok || frontmatter["title"] != "Selected Post" || article["body"] != "selected body" {
+		t.Fatalf("article = %#v, want selected site article content", article)
+	}
+	if config.RepoPath != defaultRepo || config.ContentDir != "content" {
+		t.Fatalf("global runtime leaked: repo=%q content=%q", config.RepoPath, config.ContentDir)
+	}
+}
+
+func TestSelectedSiteCreateArticleUsesSelectedConfigAndContentDir(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	restoreSiteScopeConfig(t)
+
+	defaultRepo := t.TempDir()
+	selectedRepo := t.TempDir()
+	writeSnippetFile(t, filepath.Join(defaultRepo, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: posts
+      folder: content/posts
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: string }
+        - { name: title, widget: string }
+        - { name: body, widget: markdown }
+`)
+	writeSnippetFile(t, filepath.Join(selectedRepo, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: docs
+      folder: src/docs
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: string }
+        - { name: title, widget: string }
+        - { name: body, widget: markdown }
+`)
+
+	config.DefaultSiteID = "default"
+	config.Sites = []config.SiteConfig{
+		{
+			ID:             "default",
+			RepoPath:       defaultRepo,
+			Generator:      "hugo",
+			ContentDir:     "content",
+			StaticDir:      "static",
+			PublicDir:      "public",
+			PreviewURL:     "/",
+			HugoServerPort: "1314",
+			HugoServerBind: "127.0.0.1",
+		},
+		{
+			ID:             "docs",
+			RepoPath:       selectedRepo,
+			Generator:      "eleventy",
+			ContentDir:     "src",
+			StaticDir:      "public-assets",
+			PublicDir:      "_site",
+			PreviewURL:     "/docs/",
+			HugoServerPort: "1315",
+			HugoServerBind: "127.0.0.1",
+		},
+	}
+	config.ApplySiteRuntime(config.Sites[0])
+
+	body := []byte(`{"collection":"docs","fields":{"slug":"launch","title":"Launch Notes","body":"Ready."}}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/api/create?site=docs", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	CreateArticle(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("CreateArticle() status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(selectedRepo, "src", "docs", "launch.md")); err != nil {
+		t.Fatalf("created article should be under selected site content dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(defaultRepo, "content", "docs", "launch.md")); !os.IsNotExist(err) {
+		t.Fatalf("article should not be created under default site, stat err = %v", err)
+	}
+	if config.RepoPath != defaultRepo || config.ContentDir != "content" {
+		t.Fatalf("global runtime leaked: repo=%q content=%q", config.RepoPath, config.ContentDir)
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp["path"] != "docs/launch.md" {
+		t.Fatalf("response path = %q, want docs/launch.md", resp["path"])
+	}
+}
+
+func TestSelectedSiteGetConfigIncludesSelectedMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	restoreSiteScopeConfig(t)
+
+	defaultRepo := t.TempDir()
+	selectedRepo := t.TempDir()
+	writeSnippetFile(t, filepath.Join(selectedRepo, ".homecms.yml"), `
+version: 1
+content:
+  collections:
+    - name: docs
+      folder: src/docs
+      path: "{{slug}}"
+      fields:
+        - { name: slug, widget: string }
+        - { name: title, widget: string }
+`)
+
+	config.DefaultSiteID = "default"
+	config.Sites = []config.SiteConfig{
+		{
+			ID:             "default",
+			RepoPath:       defaultRepo,
+			Generator:      "hugo",
+			ContentDir:     "content",
+			StaticDir:      "static",
+			PublicDir:      "public",
+			PreviewURL:     "/",
+			HugoServerPort: "1314",
+			HugoServerBind: "127.0.0.1",
+		},
+		{
+			ID:             "docs",
+			RepoPath:       selectedRepo,
+			Generator:      "eleventy",
+			ContentDir:     "src",
+			StaticDir:      "public-assets",
+			PublicDir:      "_site",
+			PreviewURL:     "/docs/",
+			HugoServerPort: "1315",
+			HugoServerBind: "127.0.0.1",
+		},
+	}
+	config.ApplySiteRuntime(config.Sites[0])
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/api/config?site=docs", nil)
+
+	GetConfig(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetConfig() status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	meta, ok := body["_cms"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("_cms = %#v, want metadata map", body["_cms"])
+	}
+	if meta["site_id"] != "docs" ||
+		meta["content_dir"] != "src" ||
+		meta["static_dir"] != "public-assets" ||
+		meta["public_dir"] != "_site" ||
+		meta["site_generator"] != "eleventy" ||
+		meta["config_source"] != ".homecms.yml" {
+		t.Fatalf("_cms = %#v, want selected site metadata", meta)
+	}
+	if warnings, ok := meta["warnings"].([]interface{}); !ok || warnings == nil {
+		t.Fatalf("warnings = %#v, want array", meta["warnings"])
+	}
+	if config.RepoPath != defaultRepo || config.ContentDir != "content" {
+		t.Fatalf("global runtime leaked: repo=%q content=%q", config.RepoPath, config.ContentDir)
 	}
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -13,7 +13,8 @@ aside { width: 300px; background: #252526; display: flex; flex-direction: column
 .site-selector.hidden { display: none; }
 .config-warning-panel { padding: 10px; border-bottom: 1px solid #333; background: #241f18; max-height: 180px; overflow-y: auto; }
 .config-warning-panel.hidden { display: none; }
-.config-warning-title { font-size: 12px; font-weight: bold; color: #e2c08d; margin-bottom: 8px; }
+.config-warning-title { font-size: 12px; font-weight: bold; color: #e2c08d; margin-bottom: 8px; cursor: pointer; }
+.config-warning-details:not([open]) .config-warning-title { margin-bottom: 0; }
 .config-warning-item { border-left: 3px solid #e2c08d; padding: 6px 8px; margin-bottom: 6px; background: rgba(226, 192, 141, 0.08); border-radius: 3px; }
 .config-warning-item.error { border-left-color: #ce3a3a; background: rgba(206, 58, 58, 0.10); }
 .config-warning-message { font-size: 12px; color: #ddd; line-height: 1.35; }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -98,10 +98,17 @@ export function renderConfigWarnings(config) {
     }
 
     panel.classList.remove('hidden');
-    const title = document.createElement('div');
-    title.className = 'config-warning-title';
-    title.textContent = `Config warnings (${warnings.length})`;
-    panel.appendChild(title);
+    const details = document.createElement('details');
+    details.className = 'config-warning-details';
+    details.open = warnings.some(warning => warning.severity === 'error');
+
+    const summary = document.createElement('summary');
+    summary.className = 'config-warning-title';
+    const errorCount = warnings.filter(warning => warning.severity === 'error').length;
+    summary.textContent = errorCount > 0
+        ? `Config warnings (${warnings.length}, ${errorCount} error${errorCount === 1 ? '' : 's'})`
+        : `Config warnings (${warnings.length})`;
+    details.appendChild(summary);
 
     warnings.forEach(warning => {
         const item = document.createElement('div');
@@ -120,8 +127,10 @@ export function renderConfigWarnings(config) {
             item.appendChild(meta);
         }
 
-        panel.appendChild(item);
+        details.appendChild(item);
     });
+
+    panel.appendChild(details);
 }
 
 export async function showLoadingEditor() {


### PR DESCRIPTION
## Summary
- Add selected-site integration coverage for article list/load/create/config APIs
- Make config warnings collapsible so release-time warnings do not dominate the sidebar
- Add .homecms.yml migration guidance and a release checklist

## Verification
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs using bundled Codex Node
- git diff --check

## Notes
- Created as draft for final review/CI before marking ready for release.