### PR TITLE
fix: Dockerの既存GID衝突を回避する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           sed -i 's|^ALLOWED_GITHUB_USERS=.*|ALLOWED_GITHUB_USERS=ci-user|' .env
           sed -i 's|^REPO_PATH=.*|REPO_PATH=/data/repos/ci|' .env
           sed -i 's|^HUGO_CMS_REPOS=.*|HUGO_CMS_REPOS=/data/repos/ci|' .env
+          sed -i 's|^HUGO_CMS_UID=.*|HUGO_CMS_UID=1000|' .env
+          sed -i 's|^HUGO_CMS_GID=.*|HUGO_CMS_GID=27|' .env
 
       - name: Validate Compose configuration
         run: docker compose config --quiet
@@ -79,7 +81,9 @@ jobs:
       - name: Verify non-root runtime
         run: |
           runtime_uid="$(docker compose run --rm --no-deps --entrypoint id hugo-cms -u)"
-          test "${runtime_uid}" != "0"
+          runtime_gid="$(docker compose run --rm --no-deps --entrypoint id hugo-cms -g)"
+          test "${runtime_uid}" = "1000"
+          test "${runtime_gid}" = "27"
 
       - name: Verify tools profile without implicit repository discovery
         run: docker compose --profile tools run --rm tool-bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,23 @@ jobs:
           docker compose config --format json \
             | jq -e '.services["hugo-cms"].ports[0].host_ip == "127.0.0.1"'
 
+      - name: Reject root-equivalent runtime IDs
+        run: |
+          if docker build \
+            --build-arg HUGO_CMS_UID=00 \
+            --build-arg HUGO_CMS_GID=27 \
+            --tag hugo-cms:invalid-uid .; then
+            echo "zero-padded root UID was accepted" >&2
+            exit 1
+          fi
+          if docker build \
+            --build-arg HUGO_CMS_UID=1000 \
+            --build-arg HUGO_CMS_GID=000 \
+            --tag hugo-cms:invalid-gid .; then
+            echo "zero-padded root GID was accepted" >&2
+            exit 1
+          fi
+
       - name: Build image
         run: docker compose build hugo-cms
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,15 @@ RUN curl -fsSL https://mise.run \
 
 ARG HUGO_CMS_UID=10001
 ARG HUGO_CMS_GID=10001
-RUN groupadd --gid "${HUGO_CMS_GID}" hugo-cms \
-    && useradd --uid "${HUGO_CMS_UID}" --gid hugo-cms \
-        --home-dir /home/hugo-cms --create-home --shell /usr/sbin/nologin hugo-cms
+RUN case "${HUGO_CMS_UID}" in ""|*[!0-9]*|0) echo "HUGO_CMS_UID must be a positive integer" >&2; exit 1 ;; esac \
+    && case "${HUGO_CMS_GID}" in ""|*[!0-9]*|0) echo "HUGO_CMS_GID must be a positive integer" >&2; exit 1 ;; esac \
+    && if ! getent group "${HUGO_CMS_GID}" >/dev/null; then \
+        groupadd --gid "${HUGO_CMS_GID}" hugo-cms; \
+    fi \
+    && if ! getent passwd "${HUGO_CMS_UID}" >/dev/null; then \
+        useradd --uid "${HUGO_CMS_UID}" --gid "${HUGO_CMS_GID}" \
+            --home-dir /home/hugo-cms --create-home --shell /usr/sbin/nologin hugo-cms; \
+    fi
 
 WORKDIR /app
 COPY --from=builder /out/hugo-cms /app/hugo-cms
@@ -46,7 +52,7 @@ COPY deploy/docker-tool-bootstrap.sh /usr/local/bin/docker-tool-bootstrap
 
 RUN chmod 0755 /app/hugo-cms /usr/local/bin/docker-tool-bootstrap \
     && mkdir -p /data/repos /data/mise /home/hugo-cms \
-    && chown -R hugo-cms:hugo-cms /data/mise /home/hugo-cms
+    && chown -R "${HUGO_CMS_UID}:${HUGO_CMS_GID}" /data/mise /home/hugo-cms
 
 ENV HOME=/home/hugo-cms \
     MISE_DATA_DIR=/data/mise \
@@ -58,6 +64,6 @@ ENV HOME=/home/hugo-cms \
 
 EXPOSE 8080
 
-USER hugo-cms:hugo-cms
+USER ${HUGO_CMS_UID}:${HUGO_CMS_GID}
 ENTRYPOINT ["tini", "--"]
 CMD ["/app/hugo-cms"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,19 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 
 FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
+ARG HUGO_CMS_UID=10001
+ARG HUGO_CMS_GID=10001
+RUN case "${HUGO_CMS_UID}" in \
+        ""|*[!0-9]*) echo "HUGO_CMS_UID must be a positive integer" >&2; exit 1 ;; \
+        *[1-9]*) : ;; \
+        *) echo "HUGO_CMS_UID must be a positive integer" >&2; exit 1 ;; \
+    esac \
+    && case "${HUGO_CMS_GID}" in \
+        ""|*[!0-9]*) echo "HUGO_CMS_GID must be a positive integer" >&2; exit 1 ;; \
+        *[1-9]*) : ;; \
+        *) echo "HUGO_CMS_GID must be a positive integer" >&2; exit 1 ;; \
+    esac
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         bash \
@@ -32,11 +45,7 @@ RUN curl -fsSL https://mise.run \
     | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_PATH=/usr/local/bin/mise sh \
     && chmod 0755 /usr/local/bin/mise
 
-ARG HUGO_CMS_UID=10001
-ARG HUGO_CMS_GID=10001
-RUN case "${HUGO_CMS_UID}" in ""|*[!0-9]*|0) echo "HUGO_CMS_UID must be a positive integer" >&2; exit 1 ;; esac \
-    && case "${HUGO_CMS_GID}" in ""|*[!0-9]*|0) echo "HUGO_CMS_GID must be a positive integer" >&2; exit 1 ;; esac \
-    && if ! getent group "${HUGO_CMS_GID}" >/dev/null; then \
+RUN if ! getent group "${HUGO_CMS_GID}" >/dev/null; then \
         groupadd --gid "${HUGO_CMS_GID}" hugo-cms; \
     fi \
     && if ! getent passwd "${HUGO_CMS_UID}" >/dev/null; then \

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -407,7 +407,7 @@ Dockerのtool bootstrapは`/data/repos`を自動探索せず、`HUGO_CMS_REPOS`�
 - プレビューを別オリジンに分離する。
 - 依存関係の準備処理を管理者操作として追加する。
 
-Hugo/Eleventyの子プロセスへ渡す環境変数をallowlist方式にし、`SESSION_SECRET`やGitHub OAuth secretなどCMS側の秘密情報を継承しないようにした。Dockerではsecret-freeな`tool-bootstrap` one-shot serviceによるmise toolchainとlockfile別Node.js依存の準備フローを追加した。appはbuild ARGで作る非root UID/GIDで動作し、repoを`chown`しない。リソース制限、別オリジン配信、サイト単位のコンテナ分離は未実装。
+Hugo/Eleventyの子プロセスへ渡す環境変数をallowlist方式にし、`SESSION_SECRET`やGitHub OAuth secretなどCMS側の秘密情報を継承しないようにした。Dockerではsecret-freeな`tool-bootstrap` one-shot serviceによるmise toolchainとlockfile別Node.js依存の準備フローを追加した。appはbuild ARGで指定した数値の非root UID/GIDで動作し、base imageに同じIDがあれば再利用する。repoは`chown`しない。リソース制限、別オリジン配信、サイト単位のコンテナ分離は未実装。
 
 ### Phase 5: Eleventy対応
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -111,7 +111,7 @@ volumes:
   mise-data:
 ```
 
-appはbuild ARGで作成した非root UID/GIDで動作し、bind mountを`chown`しません。ホスト公開はloopbackだけです。`PORT`はコンテナ内で`8080`に固定し、ホスト側は`HUGO_CMS_HOST_PORT`で変更します。rootの`compose.yml`には、同じimageとvolumeを使いappの`env_file`を持たない`tool-bootstrap` serviceも定義されています。
+appはbuild ARGで指定した数値の非root UID/GIDで動作し、base imageに同じIDが存在する場合は再利用します。bind mountは`chown`しません。ホスト公開はloopbackだけです。`PORT`はコンテナ内で`8080`に固定し、ホスト側は`HUGO_CMS_HOST_PORT`で変更します。rootの`compose.yml`には、同じimageとvolumeを使いappの`env_file`を持たない`tool-bootstrap` serviceも定義されています。
 
 #### ツール準備と起動
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -79,6 +79,8 @@ sudo systemctl start hugo-cms
 
 app起動時にはtoolchainを変更しません。管理者が明示したリポジトリだけを、秘密情報を持たない`tool-bootstrap` one-shot serviceで準備してからCMSを起動します。
 
+単一管理者によるCompose運用では`$HOME/hugo-cms`への配置を推奨します。`/srv`や`/opt`を使う場合も、親directory全体ではなくCMS専用directoryだけを管理ユーザーの所有にし、通常の`git`と`docker compose`は`sudo`なしで実行します。
+
 詳細は [Docker + mise デプロイガイド](docker-mise-deployment.md) を参照してください。
 
 #### compose.yml

--- a/docs/guides/docker-mise-deployment.md
+++ b/docs/guides/docker-mise-deployment.md
@@ -89,7 +89,7 @@ sed -i "s/^HUGO_CMS_UID=.*/HUGO_CMS_UID=$(id -u)/" .env
 sed -i "s/^HUGO_CMS_GID=.*/HUGO_CMS_GID=$(id -g)/" .env
 ```
 
-UID/GIDを変更した場合はimageを再buildしてください。`root`相当の`0`は指定しないでください。Docker Desktopでは通常、配布時の既定値を利用できます。
+UID/GIDを変更した場合はimageを再buildしてください。`root`相当の`0`は、`00`などのゼロ埋め表現を含めて指定できません。Docker Desktopでは通常、配布時の既定値を利用できます。
 
 指定したUID/GIDがbase image内ですでに使われている場合、imageはその数値IDを再利用します。container内のuser/group名ではなく、`HUGO_CMS_UID`と`HUGO_CMS_GID`の数値が実行権限の基準です。
 

--- a/docs/guides/docker-mise-deployment.md
+++ b/docs/guides/docker-mise-deployment.md
@@ -60,6 +60,10 @@ sed -i "s/^HUGO_CMS_GID=.*/HUGO_CMS_GID=$(id -g)/" .env
 
 UID/GIDを変更した場合はimageを再buildしてください。`root`相当の`0`は指定しないでください。Docker Desktopでは通常、配布時の既定値を利用できます。
 
+指定したUID/GIDがbase image内ですでに使われている場合、imageはその数値IDを再利用します。container内のuser/group名ではなく、`HUGO_CMS_UID`と`HUGO_CMS_GID`の数値が実行権限の基準です。
+
+すでに`mise-data` volumeを作成したあとでUID/GIDを変更すると、volume内に以前の所有権が残ることがあります。toolchainを再取得できる環境では、意図した初期化として`docker compose down --volumes`を実行してからimageを再buildし、bootstrapをやり直してください。既存volumeを保持する必要がある場合は、削除せず管理者がvolume内の所有権を新しいUID/GIDへ移行してください。
+
 サイトリポジトリはappユーザーが記事やGit metadataを書き込める権限で配置します。コンテナは権限を自動修復しないため、permission errorはホスト側のUID/GIDとディレクトリ権限を確認してください。
 
 ## サイトリポジトリ
@@ -256,6 +260,8 @@ docker compose run --rm --no-deps --entrypoint id hugo-cms
 ```
 
 値を修正した場合は`docker compose build --no-cache`でappユーザーを作り直します。
+
+UID/GIDを変更済みで`mise-data`に以前の所有権が残っている場合は、上記「コンテナUID/GID」のvolume移行手順も確認してください。
 
 ### `hugo`またはpackage managerが見つからない
 

--- a/docs/guides/docker-mise-deployment.md
+++ b/docs/guides/docker-mise-deployment.md
@@ -38,16 +38,47 @@ docker compose version
 
 ## サーバーへ配置
 
+単一の管理者が`git`と`docker compose`を実行する構成では、管理者のhome directory配下を推奨します。`/opt`全体の所有者を変更したり、通常運用で`sudo`を付けたりする必要がありません。
+
 ```bash
-sudo mkdir -p /opt
-sudo chown "$USER:$USER" /opt
-git clone https://github.com/kitashimauni/hugo-cms.git /opt/hugo-cms
-cd /opt/hugo-cms
+git clone https://github.com/kitashimauni/hugo-cms.git "$HOME/hugo-cms"
+cd "$HOME/hugo-cms"
 mkdir -p repos
 cp deploy/.env.example .env
 ```
 
 `.env`は必須です。Composeは設定ファイルがない状態では起動しません。
+
+system-managedな配置として`/srv`または`/opt`を使う場合は、親directoryではなくCMS専用directoryだけを管理ユーザーへ委譲します。以後の`git`と`docker compose`は`sudo`なしで実行します。
+
+```bash
+sudo install -d -o "$(id -un)" -g "$(id -gn)" /srv/hugo-cms
+git clone https://github.com/kitashimauni/hugo-cms.git /srv/hugo-cms
+cd /srv/hugo-cms
+```
+
+`/opt/hugo-cms`を選ぶ場合も同様に、`sudo install -d ... /opt/hugo-cms`で対象directoryだけを作成してください。`sudo chown ... /opt`のように`/opt`全体の所有者を変更してはなりません。
+
+すでに`/opt/hugo-cms`へ配置済みでhome directoryへ移す場合は、containerを停止してから移動します。named volumeを保持するため`--volumes`は付けません。
+
+```bash
+cd /opt/hugo-cms
+docker compose down
+cd "$HOME"
+test ! -e "$HOME/hugo-cms"
+sudo mv /opt/hugo-cms "$HOME/hugo-cms"
+sudo chown -R "$(id -un):$(id -gn)" "$HOME/hugo-cms"
+cd "$HOME/hugo-cms"
+docker compose up -d hugo-cms
+```
+
+配置場所にかかわらず`docker compose`だけがpermission errorになる場合は、filesystemではなくDocker daemonへのアクセス権を確認します。
+
+```bash
+docker info
+```
+
+Docker groupを利用する場合、そのメンバーは実質的にroot相当の操作が可能です。サーバーの権限方針に応じて、管理ユーザーをDocker groupへ追加するかrootless Dockerを利用してください。日常運用で`sudo docker compose`を使うと、作業treeへroot所有のファイルを作る原因になるため推奨しません。
 
 ## コンテナUID/GID
 

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -74,6 +74,7 @@ Eleventyサイトでは次を確認します。
 - appが非rootで動作し、repoを再帰`chown`しない
 - base image内に存在するGIDを指定してもbuildでき、runtimeの数値UID/GIDが指定値と一致する
 - `.env`が必須で、container内`PORT=8080`、host公開がloopbackのみ
+- 推奨配置が`$HOME/hugo-cms`で、`/opt`や`/srv`の親directory全体を`chown`する手順がない
 - `mise-data`がnamed volumeとして永続化する
 - `tool-bootstrap`が`tools` profileのone-shotで、app secretを受け取らない
 - `HUGO_CMS_REPOS`へUnixの`:`区切りで列挙したrepoだけをtrust・準備する

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -73,6 +73,7 @@ Eleventyサイトでは次を確認します。
 - imageを実際にbuildできる
 - appが非rootで動作し、repoを再帰`chown`しない
 - base image内に存在するGIDを指定してもbuildでき、runtimeの数値UID/GIDが指定値と一致する
+- UID/GIDの`0`と`00`などのゼロ埋め表現がbuild時に拒否される
 - `.env`が必須で、container内`PORT=8080`、host公開がloopbackのみ
 - 推奨配置が`$HOME/hugo-cms`で、`/opt`や`/srv`の親directory全体を`chown`する手順がない
 - `mise-data`がnamed volumeとして永続化する

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -72,6 +72,7 @@ Eleventyサイトでは次を確認します。
 - `bash -n deploy/*.sh`と`docker compose config --quiet`が成功する
 - imageを実際にbuildできる
 - appが非rootで動作し、repoを再帰`chown`しない
+- base image内に存在するGIDを指定してもbuildでき、runtimeの数値UID/GIDが指定値と一致する
 - `.env`が必須で、container内`PORT=8080`、host公開がloopbackのみ
 - `mise-data`がnamed volumeとして永続化する
 - `tool-bootstrap`が`tools` profileのone-shotで、app secretを受け取らない

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -113,6 +113,7 @@ sites:
 
 - `.env`がない場合はComposeがapp起動前に明確に失敗する
 - appと`tool-bootstrap`のUID/GIDが非rootで、app起動によってhost repoの所有者が変わらない
+- host GIDがbase image内の既存groupと重複してもimageをbuildでき、指定した数値UID/GIDで動作する
 - host portが`127.0.0.1:${HUGO_CMS_HOST_PORT:-8080}`だけに公開され、container内`PORT`が`8080`
 - `mise-data`がnamed volumeで、app再作成後も準備済みtoolchainを利用できる
 - app起動・再起動では`mise install`やNode.js依存installが実行されない

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -114,6 +114,7 @@ sites:
 - `.env`がない場合はComposeがapp起動前に明確に失敗する
 - appと`tool-bootstrap`のUID/GIDが非rootで、app起動によってhost repoの所有者が変わらない
 - host GIDがbase image内の既存groupと重複してもimageをbuildでき、指定した数値UID/GIDで動作する
+- UID/GIDに`0`または`00`などのゼロ埋め表現を指定するとimage buildが失敗する
 - host portが`127.0.0.1:${HUGO_CMS_HOST_PORT:-8080}`だけに公開され、container内`PORT`が`8080`
 - `mise-data`がnamed volumeで、app再作成後も準備済みtoolchainを利用できる
 - app起動・再起動では`mise install`やNode.js依存installが実行されない


### PR DESCRIPTION
## 概要

Docker build時に、ホストから指定したGIDがDebian base image内の既存groupと重複しても、非root runtimeを作成できるようにします。

Closes #26

## 原因

Dockerfileが`HUGO_CMS_GID`の使用状況を確認せず、常に同じGIDで`groupadd`していました。Debian bookworm-slimですでに使われているGID 27などを指定すると、`groupadd`が終了コード4で失敗していました。

## 変更内容

- UID/GIDが未使用の場合だけuser/group entryを作成
- 既存IDは再利用し、`chown`とruntime `USER`は指定された数値UID/GIDを使用
- UID/GID 0（`00`などのゼロ埋め表現を含む）、空値、非数値をbuild時に拒否
- UIDとGIDそれぞれのゼロ埋めroot IDを拒否するnegative Docker buildをCIへ追加
- CIのDocker smoke testをUID 1000/GID 27で実行し、runtime IDも検証
- 既存IDの再利用と`mise-data` volumeの所有権移行手順を文書化
- Composeの推奨配置を`$HOME/hugo-cms`へ変更し、`/opt`や`/srv`ではCMS専用directoryだけを委譲
- 既存`/opt/hugo-cms`からnamed volumeを保持して移行する手順と、sudo/Docker daemon権限の注意を追加

## 影響

ホストの実UID/GIDを変更せずに指定できるため、bind mountの書き込み権限を維持したままbuildできます。通常の既定UID/GIDの動作は変わりません。単一管理者のCompose運用では、通常の`git`と`docker compose`にsudoが不要になります。

## 検証

- `docker build --build-arg HUGO_CMS_UID=1000 --build-arg HUGO_CMS_GID=27 ...`
- `HUGO_CMS_UID=00`と`HUGO_CMS_GID=000`のbuild失敗を確認
- container内で`runtime=1000:27`を確認
- `/data/mise`への書き込みを確認
- `go test ./...`
- `go vet ./...`
- `go build -buildvcs=false ./...`
- `npm run test:js`
- `bash -n deploy/docker-tool-bootstrap.sh`
- `docker compose --env-file deploy/.env.example config --quiet`
