### PR TITLE
fix: preview proxyのbase pathを保持する

### DIFF
--- a/docs/architecture/current-architecture.md
+++ b/docs/architecture/current-architecture.md
@@ -50,7 +50,7 @@ Hugo CMSのシステム構成と実装詳細について説明します。
 アプリケーションの起動と設定を担当:
 
 1. 設定の初期化 (`config.Init()`)
-2. Hugoサーバーの起動
+2. default siteのpreview server起動
 3. Ginルーターの設定
 4. ミドルウェアの適用
 5. グレースフルシャットダウン
@@ -60,7 +60,7 @@ Hugo CMSのシステム構成と実装詳細について説明します。
 /admin              # CMS UI
 /admin/auth/*       # 認証 (OAuth)
 /admin/api/*        # REST API (認証必須)
-/preview/*          # Hugoプレビュー (プロキシ)
+/admin/preview/:site/* # サイト別プレビュー (認証付きプロキシ)
 /health             # ヘルスチェック
 /ready              # 詳細ヘルスチェック
 ```
@@ -135,6 +135,8 @@ GIT_TOKEN=xxx
 #### generator.go / hugo_adapter.go / eleventy_adapter.go - ジェネレーター管理
 
 `GeneratorAdapter`がプレビュー起動・停止・再起動、ビルド、コンテンツ作成を抽象化する。`SITE_GENERATOR`またはSite Registryのdefault site設定から`HugoAdapter`または`EleventyAdapter`を選択する。従来の関数名は互換ラッパーとして維持している。
+
+各Adapterはpreview serverを`SiteRuntime.PreviewURL`配下へmountする。Hugoは`--baseURL`、Eleventyは`--pathprefix`を使い、HTTP proxyは認証付きpreview pathとそのencoding/queryを維持したまま上流へ転送する。
 
 `ProcessManager`はプロセス終了を明示的に待ち、世代の異なる監視処理が新しいプロセス状態を消去しないよう管理する。
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -200,6 +200,8 @@ flowchart LR
 
 preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:<preview-port>`をブラウザへ露出しないことで、previewプロセスのbind先をローカルに閉じ込めやすくする。
 
+すべてのGenerator Adapterはpreview processを`SiteRuntime.PreviewURL`配下へmountする。Hugoは`--baseURL`、Eleventyは`--pathprefix`を使用する。proxyは外向きrequestのpath、`RawPath`、queryを再構築せず上流へ渡す。これにより、サイト固有のsection、permalink、percent-encodingをproxyが推測せず、新しいadapterも同じroute契約で追加できる。
+
 ### Site Runtime Bridge
 
 新しいsite-aware APIの主要経路では、HTTP handler層で選択サイトを`SiteRuntime`へ解決し、その値をサービスへ明示的に渡す。以前のようにリクエスト処理中だけ`config.RepoPath`などのprocess-wide runtime値を書き換えるbridgeは撤去済みである。
@@ -271,7 +273,7 @@ Eleventyはサイトの`package.json`にローカル依存関係として追加�
 mise exec -C <repository> -- npm run cms:preview -- --port=<allocated-port>
 ```
 
-Eleventyは入力・出力ディレクトリをサイト設定で変更でき、`--serve`と`--port`を提供している。
+Eleventyは入力・出力ディレクトリをサイト設定で変更でき、`--serve`と`--port`を提供している。previewでは`--pathprefix SiteRuntime.PreviewURL`も渡し、Hugoと同じ認証付きpreview route配下へmountする。
 
 - <https://www.11ty.dev/docs/usage/>
 - <https://www.11ty.dev/docs/config/>

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -250,7 +250,9 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 /admin/preview/<site_id>/<page-path>
 ```
 
-サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。`0.0.0.0`や`::`のようなwildcard bindは同じportの任意bindと衝突扱いになります。Hugoでは`hugo server`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve`を使用します。
+サイトごとに`hugo_server_bind`と`hugo_server_port`の組み合わせを重複しない値にしてください。重複がある場合、CMSは起動時にSite Registryを不正として拒否します。`0.0.0.0`や`::`のようなwildcard bindは同じportの任意bindと衝突扱いになります。Hugoでは`hugo server --baseURL <preview_url>`、Eleventyではlockfileに対応するpackage manager経由の`eleventy --serve --pathprefix <preview_url>`を使用します。
+
+すべてのGenerator Adapterはpreview serverを`/admin/preview/<site_id>/`配下へmountします。CMSのproxyは受け取ったpath、percent-encoding、queryをそのまま上流へ転送します。新しいGenerator Adapterもこの契約を満たす必要があり、proxy側へサイト固有のsection名やpermalink規則を追加しません。
 
 初回preview requestで対象サイトのpreview processを起動した場合、CMSはproxyする前にpreview portが実際に接続可能になるまで短時間待機します。これにより、process起動直後にiframeが`502 Preview unavailable`になる揺らぎを抑えます。
 

--- a/docs/guides/release-checklist.md
+++ b/docs/guides/release-checklist.md
@@ -52,6 +52,7 @@ Site Registryありで、少なくとも2サイトを用意して確認します
 - default siteの `/ready` と選択site APIが混ざらない
 - siteごとの preview port が重複していない
 - 非default site previewのroot-relative URLがdefault siteへ落ちない
+- preview proxyが`/admin/preview/<site_id>/`、percent-encoding、queryを保持して上流へ転送する
 - siteごとの snippets / media / Git設定が使われる
 
 ## 5. Hugo / Eleventy
@@ -65,6 +66,7 @@ Eleventyサイトでは次を確認します。
 
 - `package.json` とlockfileがある
 - lockfileに対応するpackage managerでpreview/buildされる
+- `--pathprefix`で認証付きpreview route配下へmountされる
 - preview停止時にwrapperの子プロセスが残らない
 
 ## 6. Docker

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -85,6 +85,8 @@ sites:
 - `static_media_dir`未指定かつ`.homecms.yml`の`media.folder`があるサイトでは、そのフォルダへstatic media uploadされ、`media.public_path`がMarkdown挿入パスに使われる
 - スニペットが選択サイトの`snippet_paths`または`<repo_path>/.vscode/md.code-snippets`から読み込まれる
 - Preview iframe が `/admin/preview/<site_id>/...` を参照する
+- Hugo/Eleventyのpreview serverが同じ`/admin/preview/<site_id>/...`配下で応答し、Hugoだけ404にならない
+- percent-encodingを含むpathとqueryがpreview proxyで書き換わらない
 - 初回previewでも、preview process起動直後のport未listenによる一時的な`502`にならない
 - preview内のroot-relative URL (`/images/foo.png`, `/about/`など) が同じsiteの`/admin/preview/<site_id>/...`へリダイレクトされる
 - サイトごとに別のpreview processが起動する
@@ -106,6 +108,7 @@ sites:
 - 記事一覧が`content_dir`配下から取得される
 - 記事を保存できる
 - Previewが`eleventy --serve`で起動する
+- Preview起動時に`--pathprefix /admin/preview/<site_id>/`が渡される
 - Buildがlockfileに対応するpackage manager経由で実行される
 - Dockerでは`tool-bootstrap`がlockfileに対応するfrozen installを完了してからPreview/Buildを実行できる
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -299,6 +299,8 @@ CSRFトークンを取得します。
 
 このrouteは必要に応じて対象サイトのpreview processを起動し、Site Registryの`hugo_server_bind`と`hugo_server_port`へproxyします。初回起動時はpreview portが接続可能になるまで短時間待機してからproxyします。サイトIDが存在しない場合は`400`、preview processを起動できない場合やport readiness timeout時は`502`を返します。
 
+Generator Adapterはpreview serverを`/admin/preview/:site/`配下へmountする共通契約です。Hugoは`--baseURL`、Eleventyは`--pathprefix`を使用します。proxyは外向きrequestのpath、percent-encoding、queryを再構築せず上流へ転送するため、ジェネレーター固有のsectionやpermalinkをproxy側へハードコードしません。
+
 iframe内でroot-relative URLへの遷移やasset requestが発生した場合、CMSは`Referer`の`/admin/preview/:site/...`から選択サイトを復元し、同じpreview route配下へ一時リダイレクトします。
 
 ---

--- a/main.go
+++ b/main.go
@@ -71,23 +71,22 @@ func sitePreviewProxyHandler(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "Preview unavailable"})
 		return
 	}
-	proxy := httputil.NewSingleHostReverseProxy(previewProxyURL)
-	previewPath := c.Param("path")
-	if previewPath == "" {
-		previewPath = "/"
-	}
-	proxy.Director = func(req *http.Request) {
-		req.URL.Scheme = previewProxyURL.Scheme
-		req.URL.Host = previewProxyURL.Host
-		req.URL.Path = previewPath
-		req.URL.RawPath = ""
-		req.Host = previewProxyURL.Host
-	}
+	proxy := newPreviewProxy(previewProxyURL)
 	proxy.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {
 		slog.Warn("Site preview proxy failed", "site", siteID, "error", err)
 		http.Error(w, "Preview unavailable", http.StatusBadGateway)
 	}
 	proxy.ServeHTTP(c.Writer, c.Request)
+}
+
+func newPreviewProxy(target *url.URL) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	baseDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		baseDirector(req)
+		req.Host = target.Host
+	}
+	return proxy
 }
 
 func sitePreviewAddress(site config.SiteConfig) string {

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -171,6 +172,36 @@ func TestPreviewRedirectTargetPreservesPathAndQuery(t *testing.T) {
 	target := previewRedirectTarget(req, config.SiteConfig{ID: "docs site"})
 	if target != "/admin/preview/docs%20site/images/logo.png?v=1" {
 		t.Fatalf("previewRedirectTarget() = %q", target)
+	}
+}
+
+func TestPreviewProxyDirectorPreservesPathEscapingAndQuery(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"http://cms.example/admin/preview/docs%20site/assets/a%2Fb.css?q=a%2Fb&x=1+2",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	target, err := url.Parse("http://127.0.0.1:1314")
+	if err != nil {
+		t.Fatalf("url.Parse() error = %v", err)
+	}
+
+	newPreviewProxy(target).Director(req)
+
+	if req.URL.Scheme != "http" || req.URL.Host != "127.0.0.1:1314" {
+		t.Fatalf("proxy target = %s://%s", req.URL.Scheme, req.URL.Host)
+	}
+	if got := req.URL.EscapedPath(); got != "/admin/preview/docs%20site/assets/a%2Fb.css" {
+		t.Fatalf("EscapedPath() = %q", got)
+	}
+	if req.URL.RawQuery != "q=a%2Fb&x=1+2" {
+		t.Fatalf("RawQuery = %q", req.URL.RawQuery)
+	}
+	if req.Host != "127.0.0.1:1314" {
+		t.Fatalf("Host = %q, want upstream host", req.Host)
 	}
 }
 

--- a/pkg/services/eleventy_adapter.go
+++ b/pkg/services/eleventy_adapter.go
@@ -38,12 +38,7 @@ func (adapter *EleventyAdapter) StartPreview(runtime config.SiteRuntime) error {
 
 	err = adapter.preview.Start(func() managedProcess {
 		args := append([]string{}, pm.Args...)
-		args = append(args,
-			"--serve",
-			"--port", runtime.HugoServerPort,
-			"--input", runtime.ContentDir,
-			"--output", runtime.PublicDir,
-		)
+		args = append(args, eleventyServerArgs(runtime)...)
 		cmd := generatorCommandWithEnv(runtime, []string{"NODE_ENV=development"}, pm.Bin, args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
@@ -69,6 +64,16 @@ func (adapter *EleventyAdapter) StopPreview() error {
 
 func (adapter *EleventyAdapter) IsPreviewRunning() bool {
 	return adapter.preview.Running()
+}
+
+func eleventyServerArgs(runtime config.SiteRuntime) []string {
+	return []string{
+		"--serve",
+		"--port", runtime.HugoServerPort,
+		"--input", runtime.ContentDir,
+		"--output", runtime.PublicDir,
+		"--pathprefix", runtime.PreviewURL,
+	}
 }
 
 func (*EleventyAdapter) Build(runtime config.SiteRuntime) (string, error) {

--- a/pkg/services/eleventy_adapter_test.go
+++ b/pkg/services/eleventy_adapter_test.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"hugo-cms/pkg/config"
+	"testing"
+)
+
+func TestEleventyServerArgsMountPreviewAtConfiguredBase(t *testing.T) {
+	runtime := PreviewRuntimeForSite(config.SiteConfig{
+		ID:             "docs site",
+		RepoPath:       "repo",
+		Generator:      "eleventy",
+		ContentDir:     "content",
+		PublicDir:      "_site",
+		HugoServerPort: "1320",
+	})
+
+	args := eleventyServerArgs(runtime)
+	if got := argValue(args, "--pathprefix"); got != "/admin/preview/docs%20site/" {
+		t.Fatalf("eleventyServerArgs pathprefix = %q, want authenticated preview base", got)
+	}
+	if got := argValue(args, "--port"); got != "1320" {
+		t.Fatalf("eleventyServerArgs port = %q, want 1320", got)
+	}
+	if got := argValue(args, "--input"); got != "content" {
+		t.Fatalf("eleventyServerArgs input = %q, want content", got)
+	}
+	if got := argValue(args, "--output"); got != "_site" {
+		t.Fatalf("eleventyServerArgs output = %q, want _site", got)
+	}
+}

--- a/pkg/services/generator.go
+++ b/pkg/services/generator.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 )
 
+// GeneratorAdapter implementations must mount their preview server at
+// runtime.PreviewURL. The HTTP proxy preserves that public path verbatim so
+// preview routing remains generator-independent.
 type GeneratorAdapter interface {
 	Name() string
 	StartPreview(runtime config.SiteRuntime) error

--- a/pkg/services/hugo_adapter_test.go
+++ b/pkg/services/hugo_adapter_test.go
@@ -54,6 +54,7 @@ func TestHugoAdapterCreateContentReturnsMatchedCollectionFormatError(t *testing.
 }
 
 func TestHugoArgsIncludeConfiguredContentDir(t *testing.T) {
+	t.Setenv("APP_URL", "http://cms.example")
 	runtime := config.NewSiteRuntime(config.SiteConfig{
 		ID:             "test",
 		RepoPath:       "repo",
@@ -77,6 +78,9 @@ func TestHugoArgsIncludeConfiguredContentDir(t *testing.T) {
 	}
 	if got := argValue(hugoServerArgs(runtime), "--source"); got != "." {
 		t.Fatalf("hugoServerArgs source = %q, want current working directory", got)
+	}
+	if got := argValue(hugoServerArgs(runtime), "--baseURL"); got != "http://cms.example/preview/" {
+		t.Fatalf("hugoServerArgs baseURL = %q, want authenticated preview base", got)
 	}
 	if got := argValue(hugoBuildArgs(runtime), "--source"); got != "." {
 		t.Fatalf("hugoBuildArgs source = %q, want current working directory", got)


### PR DESCRIPTION
## 変更内容

- preview proxyが外向きrequestのpath、percent-encoding、queryを維持したまま上流へ転送するよう修正
- Generator Adapterのpreview serverを`SiteRuntime.PreviewURL`配下へmountする共通契約を明文化
- Eleventy previewへ`--pathprefix`を追加し、Hugoと同じ認証付きroute配下へmount
- Hugo/Eleventy、空白を含むsite ID、escaped path、queryの回帰テストを追加
- architecture、API、configuration、smoke test、release checklistを更新

## 原因

Hugoには`/admin/preview/<site_id>/`を含む`--baseURL`を渡していましたが、reverse proxyがGinのwildcard parameterだけを上流pathへ設定して接頭辞を除去していました。そのため、Hugoがmountしているpathとproxy先が一致せず404になっていました。

## 影響

Hugo固有のsectionやpermalinkをCMSへハードコードせず、すべてのGenerator Adapterが同じpreview route契約を利用できます。root-relative assetのReferer fallbackも同じrouteへ戻るため、複数サイトで維持されます。

## 検証

- `mise run check`
  - `go test ./...`
  - `go vet ./...`
  - `go build -buildvcs=false ./...`
  - `npm run test:js`

Closes #28
