### PR TITLE
feat: add Phase 1 local Live Preview foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,17 @@ ARTICLE_MEDIA_DIR=src
 # Directory inside static/ for static images (e.g. "uploads" or leave empty for static root)
 STATIC_MEDIA_DIR=images
 
-# Preview Settings. Leave provider empty to use only the safe Markdown preview.
+# Preview Settings
 MARKDOWN_PREVIEW_ENABLED=true
+
+# Optional local Live Preview. PREVIEW_DOMAIN is the base domain only; do not
+# include scheme, wildcard, path, or port. DNS/TLS/Tailscale ingress is managed
+# outside hugo-cms. Example URL: https://tech.preview.example.com/
+LOCAL_LIVE_PREVIEW_ENABLED=false
+PREVIEW_DOMAIN=
+PREVIEW_SCHEME=https
+
+# Deployment Preview. Leave provider empty when not used.
 PREVIEW_DEPLOYMENT_PROVIDER=
 CLOUDFLARE_PAGES_ACCOUNT_ID=
 CLOUDFLARE_PAGES_PROJECT_NAME=
@@ -51,6 +60,6 @@ PREVIEW_STATE_DIR=./data/preview-deployments
 
 # Git Settings
 GIT_USER_NAME="Hugo CMS Bot"
-GIT_USER_EMAIL="bot@hugo-cms.local"
+GIT_USER_EMAIL=bot@hugo-cms.local
 GIT_BRANCH=main
 GIT_REMOTE=origin

--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,6 @@ PREVIEW_STATE_DIR=./data/preview-deployments
 
 # Git Settings
 GIT_USER_NAME="Hugo CMS Bot"
-GIT_USER_EMAIL=bot@hugo-cms.local
+GIT_USER_EMAIL="bot@hugo-cms.local"
 GIT_BRANCH=main
 GIT_REMOTE=origin

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Hugoサイト用のセルフホスト型ヘッドレスCMSです。GitHub OAuth�
 - ⚡ **高速キャッシュ** - 並列処理による記事一覧の高速表示
 - 🛡️ **セキュリティ** - CSRF保護、パストラバーサル対策、入力検証
 
-> Hugoのtheme/layout/shortcode/CSS/JSを含むローカルLive Previewは現在未実装です。Issue #32で、`https://<site-id>.<preview-domain>/`形式のwildcard subdomainを使う方式を検討しています。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
+> Issue #32 Phase 1で、`https://<site-id>.<preview-domain>/`形式のLocal Live Preview向け設定、URL生成、Host validation、process lifecycle/port reservation基盤を追加しています。Hugo/Eleventy preview serverの実起動、proxy、LiveReload、editor連携はPhase 2以降です。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
 
 ## クイックスタート
 
@@ -129,6 +129,9 @@ appは非rootで動作し、bind mountしたrepoを`chown`しません。mise to
 | `ARTICLE_MEDIA_DIR` | 記事バンドル内の画像ディレクトリ | (空) |
 | `STATIC_MEDIA_DIR` | static内の画像ディレクトリ | (空) |
 | `MARKDOWN_PREVIEW_ENABLED` | 安全な本文プレビュー | `true` |
+| `LOCAL_LIVE_PREVIEW_ENABLED` | Local Live Previewの全体既定値 | `false` |
+| `PREVIEW_DOMAIN` | Local Live Previewの共通domain | (空) |
+| `PREVIEW_SCHEME` | Local Live Preview URL scheme (`http` / `https`) | `https` |
 | `PREVIEW_DEPLOYMENT_PROVIDER` | デプロイprovider (`cloudflare_pages`または空) | (空) |
 | `CLOUDFLARE_PAGES_ACCOUNT_ID` | Cloudflare account ID | (provider使用時必須) |
 | `CLOUDFLARE_PAGES_PROJECT_NAME` | Cloudflare Pages project | (provider使用時必須) |
@@ -145,11 +148,13 @@ appは非rootで動作し、bind mountしたrepoを`chown`しません。mise to
 
 - [ドキュメント一覧](docs/README.md) - 目的別の索引
 - [設定ガイド](docs/guides/configuration.md) - 詳細な設定オプション
+- [Local Live Preview設定ガイド](docs/guides/local-live-preview.md) - wildcard subdomain、閲覧制御、Host validation
 - [Docker + mise デプロイガイド](docs/guides/docker-mise-deployment.md) - secret-free bootstrapと非root appによる推奨デプロイ
 - [CMS設定](docs/reference/cms-config.md) - コレクションとフィールドの設定
 - [現行アーキテクチャ](docs/architecture/current-architecture.md) - 現在のシステム構成
 - [マルチサイト・マルチジェネレーター設計](docs/architecture/multi-site-generator-design.md) - 複数HugoサイトとEleventy等への対応方針
 - [本文プレビューとデプロイプレビュー](docs/architecture/preview-deployment-design.md) - 安全な本文表示、draft deployment、Local Live Previewとの役割分担
+- [Local Live Preview設計](docs/architecture/local-live-preview-design.md) - hostname、process lifecycle、shadow workspace、security boundary
 - [セキュリティ・品質監査](docs/audits/security-and-quality-audit.md) - 既知の問題と推奨対応
 
 ## プロジェクト構造
@@ -215,6 +220,7 @@ mise run build
 - **CSRF保護**: 全てのPOST/PUT/DELETEリクエストにCSRFトークンを要求
 - **パス検証**: パストラバーサル攻撃を防止
 - **トークン検証**: GitHubトークンの定期的な有効性確認
+- **Local Live Preview**: preview ingressはprivate networkまたは独立viewer authenticationで保護し、CMS session cookieは共有しない
 
 ## ライセンス
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Hugo CMSの利用方法、仕様、設計、および監査結果を目的別に
 ## ガイド
 
 - [設定ガイド](guides/configuration.md) - 環境変数と実行設定
+- [Local Live Preview設定ガイド](guides/local-live-preview.md) - wildcard subdomain、Host validation、private ingress設定
 - [デプロイガイド](guides/deployment.md) - サーバー、Docker、リバースプロキシ
 - [Docker + mise デプロイガイド](guides/docker-mise-deployment.md) - secret-free one-shot bootstrap、非root app、サイト別toolchainの運用
 - [`.homecms.yml` 移行ガイド](guides/migrating-to-homecms.md) - legacy `static/admin/config.yml` からの移行
@@ -22,6 +23,7 @@ Hugo CMSの利用方法、仕様、設計、および監査結果を目的別に
 - [現行アーキテクチャ](architecture/current-architecture.md) - 現在のHugo向け実装
 - [マルチサイト・マルチジェネレーター設計](architecture/multi-site-generator-design.md) - 複数HugoサイトとEleventy等へ対応するための提案
 - [本文プレビューとデプロイプレビュー](architecture/preview-deployment-design.md) - preview責務、draft branch、provider、security、cleanup
+- [Local Live Preview設計](architecture/local-live-preview-design.md) - wildcard hostname、process lifecycle、port reservation、shadow workspace
 - [ADR-0001: Cloudflare Pages preview](architecture/adr-0001-cloudflare-pages-preview.md) - 初期providerの選定理由
 
 ## 監査

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -2,7 +2,7 @@
 
 ## ステータス
 
-Issue #32 Phase 1で設計・設定契約を確定する。Phase 1ではgenerator processの実起動、reverse proxy、LiveReload中継、editorからshadow workspaceへの書き込みはまだ実装しない。
+Issue #32 Phase 1で設計・設定契約を確定し、設定model、derived URL、Host validation、process lifecycle/port reservationの基盤まで実装済み。Phase 1ではgenerator processの実起動、reverse proxy、LiveReload中継、editorからshadow workspaceへの書き込みはまだ実装しない。
 
 Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えず、第3のpreview段階として追加する。
 
@@ -31,7 +31,20 @@ daily -> https://daily.preview.example.com/
 
 DNSは`*.preview.example.com`のwildcardを想定し、site追加ごとのDNS変更を要求しない。
 
-TLS、wildcard certificate、DNS-01 challenge、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。Tailscale内だけでpreview ingressへ到達できる構成を正式な運用形態として許容する。
+TLS、wildcard certificate、DNS-01 challenge、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。
+
+### 閲覧者認可
+
+wildcard DNSやHost validationは閲覧者認可ではない。Local Live Previewは未公開contentとrepository由来のJavaScriptを配信し得るため、**preview ingressは必ずCMSとは独立した閲覧制御の内側に置く**。
+
+許容する運用は次のいずれかとする。
+
+- Tailscale等のprivate networkからのみpreview ingressへ到達可能にする
+- Internet reachableにする場合は、Cloudflare Access等のpreview専用viewer authenticationを必須にする
+
+CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使わない。preview側で実行されるsite由来JavaScriptへCMS sessionを露出させないためである。
+
+hugo-cmsは外部ingressの認証方式そのものを実装・検出しないため、この要件はoperatorが満たすdeployment contractとする。Phase 2の実装でも「hostnameを知っているだけで閲覧可能」なpublic ingressを推奨構成として扱わない。
 
 ## 設定契約
 
@@ -65,6 +78,8 @@ Local Live Previewを有効にするsite IDはDNS labelとしてそのままhost
 - 1〜63文字
 
 `PREVIEW_DOMAIN`はscheme、`*.`、path、portを含まないDNS名だけを受け付ける。`PREVIEW_SCHEME`は`http`または`https`だけを許可する。
+
+さらに`<site-id>.<preview-domain>`を連結したhostname全体がDNS名として有効で、253文字以内であることを必須とする。設定検証、URL生成、Host resolverは同じ制約を使用する。
 
 Site RegistryをAPIへ返す際、Local Live Previewが有効ならderived valueとして`preview.local_preview.url`を返す。URLはYAMLへ永続化しない。
 
@@ -196,11 +211,12 @@ Phase 3は以下を実装する。
 ## セキュリティ要点
 
 - wildcard DNSはauthorizationではない
+- preview ingressにはprivate networkまたは独立viewer authenticationを必須とする
+- CMS session cookieをpreview subdomainと共有しない
 - unknown site IDは404相当で拒否する
 - Local Live Preview無効siteは起動しない
 - Host値をcommand/path/portへ直接変換しない
 - generatorは明示的に登録されたrepositoryだけで実行する
 - internal generator serverはloopback bindのみ
 - TLS/DNS credentialをCMSへ要求しない
-- private ingress/Tailscale運用を許容する
 - Local Live Previewはrepository内generator codeを実行するため、Markdown本文プレビューより広いtrust boundaryである

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -1,0 +1,206 @@
+# Local Live Preview設計
+
+## ステータス
+
+Issue #32 Phase 1で設計・設定契約を確定する。Phase 1ではgenerator processの実起動、reverse proxy、LiveReload中継、editorからshadow workspaceへの書き込みはまだ実装しない。
+
+Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えず、第3のpreview段階として追加する。
+
+```text
+Markdown本文プレビュー
+  -> generatorを実行しない即時確認
+
+Local Live Preview
+  -> 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
+
+Deployment Preview
+  -> remote buildした特定commitを公開前に最終確認
+```
+
+## URLとingress境界
+
+Local Live Previewはpath prefixではなくsiteごとのhostnameをorigin rootとして使用する。
+
+```text
+PREVIEW_DOMAIN=preview.example.com
+PREVIEW_SCHEME=https
+
+tech  -> https://tech.preview.example.com/
+daily -> https://daily.preview.example.com/
+```
+
+DNSは`*.preview.example.com`のwildcardを想定し、site追加ごとのDNS変更を要求しない。
+
+TLS、wildcard certificate、DNS-01 challenge、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。Tailscale内だけでpreview ingressへ到達できる構成を正式な運用形態として許容する。
+
+## 設定契約
+
+全体既定値:
+
+```env
+LOCAL_LIVE_PREVIEW_ENABLED=false
+PREVIEW_DOMAIN=preview.example.com
+PREVIEW_SCHEME=https
+```
+
+Site Registryでは全体既定値をoverrideできる。
+
+```yaml
+sites:
+  - id: tech
+    repo_path: /data/repos/tech-blog
+    generator: hugo
+    preview:
+      local_preview:
+        enabled: true
+```
+
+`preview.local_preview.enabled`を省略した場合は`LOCAL_LIVE_PREVIEW_ENABLED`を継承する。
+
+Local Live Previewを有効にするsite IDはDNS labelとしてそのままhostnameへ使用するため、次を必須とする。
+
+- lowercase ASCII
+- `a-z`、`0-9`、`-`のみ
+- 先頭・末尾の`-`は禁止
+- 1〜63文字
+
+`PREVIEW_DOMAIN`はscheme、`*.`、path、portを含まないDNS名だけを受け付ける。`PREVIEW_SCHEME`は`http`または`https`だけを許可する。
+
+Site RegistryをAPIへ返す際、Local Live Previewが有効ならderived valueとして`preview.local_preview.url`を返す。URLはYAMLへ永続化しない。
+
+## Host routing
+
+Phase 2のpreview ingress routeはHTTP `Host`を`ResolveLocalPreviewHost`へ渡し、Site Registryに登録済みかつLocal Live Previewが有効なsiteだけへ解決する。
+
+許可例:
+
+```text
+tech.preview.example.com
+tech.preview.example.com:443
+```
+
+拒否例:
+
+```text
+preview.example.com
+foo.tech.preview.example.com
+tech.preview.example.com.evil.example
+unknown.preview.example.com
+tech.example.com
+```
+
+Hostからrepository path、generator command、internal portを生成してはならない。Hostから得られる値はSite Registry lookup keyだけとする。
+
+## Generator process lifecycle
+
+Phase 2ではLocal Live Preview専用managerを追加し、次のstate machineを使う。
+
+```text
+stopped
+  -> starting
+  -> ready
+  -> stopping
+  -> stopped
+
+starting/ready/stopping
+  -> failed
+
+failed
+  -> starting
+  -> stopped
+```
+
+Phase 1では`LocalPreviewLifecycle`がstateと内部port reservationだけを管理する。generator processの起動、終了待ち、readiness、proxyはPhase 2で実装する。
+
+### 起動契約
+
+- Local Live Previewは設定だけでCMS起動時に全siteを起動しない
+- 最初のpreview requestまたは明示的なUI操作でlazy startする
+- Host validationとSite Registry lookupが成功する前にprocessを起動しない
+- generator processは`127.0.0.1`へだけbindする
+- generator portをhost/public interfaceへ直接公開しない
+- child processへ渡す環境変数はallowlistする
+- CMSのOAuth/session/provider secretは継承させない
+- CMS shutdown時には起動済みprocessを停止し、終了を待つ
+
+### port allocation
+
+旧`hugo_server_port`のようなsiteごとの手動port指定をLocal Live Previewの標準契約にはしない。
+
+managerが内部rangeからsiteごとにportを予約する。
+
+```text
+14100-14999
+```
+
+Phase 1のallocatorは同一siteに安定した予約を返し、別siteとの重複を防ぐ。Phase 2では予約候補についてloopback bind可能性を確認してからprocessを起動する。
+
+port availability確認とchild process bindの間には競合余地があるため、実際のbindに失敗した場合はそのslotを解放し、別portを予約して有限回retryする。port番号を外部URLへ露出させないため、retryしてもbrowser側URLは変化しない。
+
+## 編集中state: shadow content workspace
+
+### 決定
+
+Local Live Previewの未保存編集はproduction repositoryのworking treeへキー入力ごとに書き込まず、**shadow content workspace**へ反映する。
+
+Git worktreeをLocal Live Previewの基本方式にはしない。
+
+理由:
+
+- Live Previewはcommit/branchを必要としない編集UI機能であり、Git ref/index操作を増やす必要がない
+- Deployment Previewはすでにtemporary index + draft branchというGit境界を持っており、Live PreviewまでGit lifecycleへ結合しない方が責務が明確
+- 保存済みworking treeと未保存editor stateを分離できる
+- preview破棄時に一時directoryを削除するだけでcleanupできる
+
+### workspaceの内容
+
+初期実装ではsiteの`content_dir`をshadow workspaceへmirrorし、editorの未保存変更はshadow側の記事だけへ適用する。generatorのsource、layout、theme、config、static/assets等は登録済みrepositoryを基準にする。
+
+Hugoはcontent directoryを別pathへ切り替えられるため、Phase 3でHugo adapterがshadow content directoryをpreview commandへ渡す。generatorごとに同じ方式が使えない場合はadapter内で別方式を実装し、CMS共通層へgenerator固有path処理を漏らさない。
+
+shadow workspaceのrootはCMS管理領域に置き、site IDやarticle pathを直接filesystem pathとして連結せず既存のpath validationと同等の境界を設ける。
+
+### 同一siteの複数editor
+
+`<site-id>.<preview-domain>`はsiteごとに1つのhostnameなので、初期実装では**同一siteにつきactive Local Live Preview sessionを1つ**に制限する。別draft/tabから同時にshadow stateを更新しようとした場合は混在させず競合として拒否する。
+
+将来、複数sessionを同一hostnameで安全にroutingする仕組みを導入する場合のみ、この制約を緩和する。
+
+## Phase 2への契約
+
+Phase 2は以下を実装する。
+
+- generator preview command生成
+- lazy start/stop/restart
+- lifecycle stateとprocess実体の接続
+- loopback port probe + bind failure retry
+- hostnameから内部processへのreverse proxy
+- redirect/`Location`処理
+- WebSocket / Hugo LiveReload中継
+- root-relative CSS/JS/imageの確認
+- UIへready/failed状態とLocal Preview URLを公開
+
+旧`/admin/preview/:site/*` path-prefix proxyは再導入しない。
+
+## Phase 3への契約
+
+Phase 3は以下を実装する。
+
+- shadow content workspace作成/同期/cleanup
+- editor変更のdebounce反映
+- generator watcherによる再build
+- 保存操作とshadow stateの同期
+- 同一site concurrent preview sessionの競合拒否
+- abnormal shutdown後のstale workspace cleanup
+
+## セキュリティ要点
+
+- wildcard DNSはauthorizationではない
+- unknown site IDは404相当で拒否する
+- Local Live Preview無効siteは起動しない
+- Host値をcommand/path/portへ直接変換しない
+- generatorは明示的に登録されたrepositoryだけで実行する
+- internal generator serverはloopback bindのみ
+- TLS/DNS credentialをCMSへ要求しない
+- private ingress/Tailscale運用を許容する
+- Local Live Previewはrepository内generator codeを実行するため、Markdown本文プレビューより広いtrust boundaryである

--- a/docs/architecture/preview-deployment-design.md
+++ b/docs/architecture/preview-deployment-design.md
@@ -4,7 +4,7 @@
 
 現在の実装では、Hugo CMSのプレビューをCMS内の安全な「本文プレビュー」と、外部providerが生成する「デプロイプレビュー」に分離している。Issue #30で旧`/admin/preview/:site/*` path-prefix proxyとローカルgenerator preview processを廃止したため、現時点ではCMSプロセスはHugo/Eleventyのpreview serverを常駐起動しない。
 
-Issue #32では、この2段階を維持したまま、`https://<site-id>.<preview-domain>/`をorigin rootとして使う任意の「Local Live Preview」を第3段階として追加する方針を検討している。これは旧path-prefix proxyの復活ではない。TLS終端、wildcard DNS、DNS-01、Tailscale等のpreview ingressはCMS本体から分離する。
+Issue #32 Phase 1では、この2段階を維持したまま、`https://<site-id>.<preview-domain>/`をorigin rootとして使う任意の「Local Live Preview」の設定model、derived URL、Host validation、process lifecycle/port reservation契約を導入した。generator serverの実起動、reverse proxy、LiveReload、editor連携はPhase 2以降で実装する。旧path-prefix proxyは復活させない。TLS終端、wildcard DNS、DNS-01、Tailscale等のpreview ingressはCMS本体から分離する。
 
 ## 現行の決定
 
@@ -26,13 +26,13 @@ Editor
 
 ## Local Live Previewとの役割分担
 
-Issue #32の実装後も、previewは次の3段階として扱う。
+previewは次の3段階として扱う。
 
 1. **Markdown本文プレビュー**
    - generatorを実行しない
    - 編集入力を即時に安全表示する
    - theme/layout/shortcodeの再現は目的としない
-2. **Local Live Preview**（Issue #32、未実装）
+2. **Local Live Preview**（Issue #32。Phase 1基盤実装済み、runtime/proxyは未実装）
    - Hugo等のgenerator preview processを実際に起動する
    - `<site-id>.<preview-domain>`をsite自身のorigin rootとして利用する
    - theme/layout/shortcode/CSS/JS/LiveReloadを含む編集中の確認を目的とする
@@ -74,7 +74,7 @@ production branchへ直接commit/pushする従来Publishは使用しない。rea
 - production secretやproduction DB更新権限をpreview buildへ渡さない
 - UIはAccess未保護設定を明示的に警告する
 
-### 将来のLocal Live Preview
+### Local Live Preview
 
 Issue #32では、ローカルgenerator codeを再び実行するため、次を追加の境界とする。
 
@@ -83,7 +83,9 @@ Issue #32では、ローカルgenerator codeを再び実行するため、次を
 - generatorへ渡す環境変数をallowlistし、CMSのOAuth/session/provider secretを継承させない
 - generator portを直接公開せず、preview ingress経由でのみ到達させる
 - unknownな`<site-id>.<preview-domain>`は拒否する
-- previewをInternet公開することを必須とせず、Tailscale等のprivate network内だけで運用できる
+- wildcard DNSやHost validationを閲覧者認可として扱わない
+- preview ingressはTailscale等のprivate network内に置くか、Internet reachableな場合はCloudflare Access等の独立viewer authenticationを必須とする
+- CMS session cookieをpreview subdomainと共有しない
 - TLS証明書やDNS provider tokenをCMS自身が保持することを必須にしない
 
 ## ライフサイクルと競合
@@ -92,10 +94,10 @@ draft IDはbrowser sessionとsite/article pathの組み合わせごとに生成�
 
 preview更新は既存preview commitではなく、その時点のlocal production branchをbaseにして対象pathsだけを一時indexへ適用する。production branchが進んでnon-fast-forward更新になる場合は、前回commitを期待値とする`--force-with-lease`でdraft branchだけを更新し、失敗時はlocal draft refをrollbackする。commit SHAでdeploymentを照合するため、providerがbranch aliasを新しいbuildへ切り替えている途中でも誤ったpreviewを表示しない。
 
-Local Live Preview側の編集中stateをworking tree、shadow directory、worktreeのどこへ保持するかはIssue #32で決定する。少なくとも未保存入力がproduction branchのGit状態を意図せず破壊せず、site/draft間でstateが混在しない構成とする。
+Local Live Previewの未保存editor stateはproduction working treeやGit worktreeへ書かず、CMS管理領域の**shadow content workspace**へ保持する方針をIssue #32 Phase 1で確定した。初期実装では同一siteにつきactive Local Live Preview sessionを1つに制限し、別draft/tabの未保存stateを混在させない。詳細は[Local Live Preview設計](local-live-preview-design.md)を正とする。
 
 ## 移行
 
-`preview_url`、`hugo_server_bind`、`hugo_server_port`はIssue #30以前のpath-prefix型ローカルpreview用の旧設定であり、現行の本文/デプロイプpreviewでは使用しない。`/admin/preview/:site/*`、`POST /admin/api/build`、`POST /admin/api/build/restart`も廃止済みであり、Issue #32でもこれらをそのまま復活させない。
+`preview_url`、`hugo_server_bind`、`hugo_server_port`はIssue #30以前のpath-prefix型ローカルpreview用の旧設定であり、現行の本文/デプロイプpreviewおよび新Local Live Previewの公開URL/port管理には使用しない。`/admin/preview/:site/*`、`POST /admin/api/build`、`POST /admin/api/build/restart`も廃止済みであり、Issue #32でもこれらをそのまま復活させない。
 
-Issue #32のLocal Live Previewでは、`PREVIEW_DOMAIN`等から`https://<site-id>.<preview-domain>/`を生成する新しい設定契約を別途導入する予定であり、旧`preview_url`等との互換性を前提にしない。実装完了まではgenerator runtimeは明示的なbuild/content作成で引き続き使用できるが、CMS起動時にLocal Live Previewを自動起動する現行仕様は存在しない。
+Issue #32 Phase 1では、`LOCAL_LIVE_PREVIEW_ENABLED`、`PREVIEW_DOMAIN`、`PREVIEW_SCHEME`とsite単位の`preview.local_preview.enabled`を導入した。`https://<site-id>.<preview-domain>/`はderived valueとして生成し、旧`preview_url`等との互換性を前提にしない。Phase 2実装まではgenerator runtimeは明示的なbuild/content作成で引き続き使用できるが、CMS起動時にLocal Live Previewを自動起動する仕様はない。

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -186,7 +186,9 @@ sites:
     content_dir: content
     static_dir: static
     public_dir: public
-    hugo_server_port: "1314"
+    preview:
+      local_preview:
+        enabled: true
     snippet_paths:
       - .vscode/md.code-snippets
 
@@ -198,7 +200,9 @@ sites:
     content_dir: src
     static_dir: public-assets
     public_dir: _site
-    hugo_server_port: "1315"
+    preview:
+      local_preview:
+        enabled: false
     snippet_paths:
       - .vscode/md.code-snippets
 ```
@@ -244,7 +248,13 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 
 ### Preview
 
-プレビューは、保存前の編集内容を安全に表示する「本文プレビュー」と、外部buildでテーマを含めて確認する「デプロイプレビュー」に分かれます。CMSはHugo/Eleventyのpreview processやreverse proxyを起動しません。
+プレビューは次の3段階で扱います。
+
+1. **本文プレビュー**: generatorを実行せず、保存前のMarkdownをsanitizeして即時表示する
+2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
+3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
+
+Issue #32 Phase 1ではLocal Live Previewの設定model、derived URL、Host validation、process lifecycle/port reservation基盤まで実装済みです。generator serverの実起動、reverse proxy、LiveReload、editor連携はPhase 2以降で実装します。
 
 Site Registryでサイトごとに設定します。
 
@@ -254,6 +264,8 @@ sites:
     repo_path: D:/sites/techblog
     preview:
       markdown:
+        enabled: true
+      local_preview:
         enabled: true
       deployment:
         provider: cloudflare_pages
@@ -266,14 +278,24 @@ sites:
 
 `markdown.enabled`は既定で`true`です。本文プレビューはGFMをsanitizeして表示し、Hugo shortcode、layout、サイト固有CSS/JavaScriptは再現しません。relative imageは記事bundle、root-relative imageは`static_dir`から解決し、既存の許可済みmediaだけを認証付きrouteで表示します。
 
+`local_preview.enabled`を省略した場合は`LOCAL_LIVE_PREVIEW_ENABLED`を継承します。有効なsiteには`PREVIEW_SCHEME`、site ID、`PREVIEW_DOMAIN`から`preview.local_preview.url`をderived valueとして生成します。Local Live Previewを有効にするsite IDはlowercase DNS labelである必要があり、生成後の`<site-id>.<preview-domain>`全体も253文字以内の有効なDNS名でなければなりません。
+
+Local Live Previewのwildcard DNS、TLS、DNS-01、Tailscale、外部reverse proxyはpreview ingress側の責務です。**wildcard DNSやHost validationは閲覧者認可ではありません。** Local Live Preview ingressは必ず、Tailscale等のprivate network内に置くか、Internet reachableな場合はCloudflare Access等の独立viewer authenticationで保護してください。CMSのsession cookieをpreview subdomainへ共有して認証に使う設計にはしません。
+
+詳細は[Local Live Preview設定ガイド](local-live-preview.md)と[Local Live Preview設計](../architecture/local-live-preview-design.md)を参照してください。
+
 `deployment.provider`を省略したサイトでも編集と本文プレビューは利用できます。`cloudflare_pages`を使う場合、`account_id`、`project_name`、`token_env`が必須です。`token_env`はtoken値ではなく、tokenを格納した環境変数名です。token値はYAMLへ書かず、browserにも返りません。
 
-`access_protected: true`は、Cloudflare Accessを運用側で設定済みであることをCMSへ申告する値です。CMSがAccess policyを作成するわけではありません。`false`では未公開contentがpublic previewに出る可能性をUIで警告します。
+`deployment.access_protected: true`は、Cloudflare Accessを運用側で設定済みであることをCMSへ申告する値です。CMSがAccess policyを作成するわけではありません。`false`では未公開contentがpublic deployment previewに出る可能性をUIで警告します。
 
 単一サイトを環境変数だけで設定する場合は次を使用できます。
 
 ```env
 MARKDOWN_PREVIEW_ENABLED=true
+LOCAL_LIVE_PREVIEW_ENABLED=true
+PREVIEW_DOMAIN=preview.example.com
+PREVIEW_SCHEME=https
+
 PREVIEW_DEPLOYMENT_PROVIDER=cloudflare_pages
 CLOUDFLARE_PAGES_ACCOUNT_ID=0123456789abcdef0123456789abcdef
 CLOUDFLARE_PAGES_PROJECT_NAME=techblog
@@ -289,7 +311,7 @@ PREVIEW_STATE_DIR=./data/preview-deployments
 
 | 項目 | 必須 | 説明 |
 |---|---:|---|
-| `id` | はい | サイトID。UI、API、draft state分離で使用 |
+| `id` | はい | サイトID。UI、API、draft state分離で使用。Local Live Preview有効時はlowercase DNS label制約も適用 |
 | `name` | いいえ | UI表示名。未指定時は`id` |
 | `repo_path` | はい | 対象リポジトリ |
 | `generator` | いいえ | `hugo`または`eleventy` |
@@ -298,8 +320,9 @@ PREVIEW_STATE_DIR=./data/preview-deployments
 | `static_dir` | いいえ | 静的ファイルのルート。デフォルト`static` |
 | `public_dir` | いいえ | build出力先。デフォルト`public` |
 | `preview.markdown.enabled` | いいえ | 安全な本文プレビュー。デフォルト`true` |
+| `preview.local_preview.enabled` | いいえ | Local Live Preview。省略時は`LOCAL_LIVE_PREVIEW_ENABLED` |
 | `preview.deployment.provider` | いいえ | 空または`cloudflare_pages` |
-| `preview.deployment.access_protected` | いいえ | Access設定済みの申告。デフォルト`false` |
+| `preview.deployment.access_protected` | いいえ | Deployment PreviewのAccess設定済み申告。デフォルト`false` |
 | `preview.deployment.cloudflare_pages.*` | provider使用時 | `account_id`、`project_name`、`token_env` |
 | `snippet_paths` | いいえ | スニペットファイル。相対パスは`repo_path`基準 |
 
@@ -335,7 +358,7 @@ sites:
 
 #### `MAX_UPLOAD_SIZE_MB`
 
-アップロード可能な最大ファイルサイズ (MB単位)。デフォルト: `10`
+アップロード可能なファイルサイズ (MB単位)。デフォルト: `10`
 
 ```env
 # 50MBまで許可
@@ -368,7 +391,7 @@ STATIC_MEDIA_DIR=
 
 ### 廃止したローカルpreview設定
 
-`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`およびSite Registryの同名項目は旧ローカルpreview用です。移行期間中に読み込める場合があっても本文/デプロイプpreviewでは使用されず、新規設定には追加しないでください。
+`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`およびSite Registryの同名項目はIssue #30以前のpath-prefix型ローカルpreview用です。新しいLocal Live Previewの公開URLやport管理には使用しません。新規設定では`LOCAL_LIVE_PREVIEW_ENABLED`、`PREVIEW_DOMAIN`、`PREVIEW_SCHEME`、`preview.local_preview.enabled`を使用してください。
 
 ### Git設定
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,0 +1,171 @@
+# Local Live Preview設定ガイド
+
+> Issue #32 Phase 1時点では設定・URL生成・Host validation・process lifecycle契約まで実装済みです。generator serverの実起動、proxy、LiveReload、editor連携はPhase 2以降で実装します。
+
+## 基本設定
+
+Local Live PreviewのURLはsite IDと共通preview domainから自動生成します。
+
+```env
+LOCAL_LIVE_PREVIEW_ENABLED=true
+PREVIEW_DOMAIN=preview.example.com
+PREVIEW_SCHEME=https
+```
+
+`tech` siteなら次のURLになります。
+
+```text
+https://tech.preview.example.com/
+```
+
+`PREVIEW_DOMAIN`には`*.`、scheme、path、portを含めません。
+
+```text
+OK: preview.example.com
+NG: *.preview.example.com
+NG: https://preview.example.com
+NG: preview.example.com:443
+```
+
+`PREVIEW_SCHEME`は`http`または`https`だけを使用できます。
+
+## Site Registry
+
+`LOCAL_LIVE_PREVIEW_ENABLED`はsite全体の既定値です。site単位でoverrideできます。
+
+```yaml
+default_site: tech
+sites:
+  - id: tech
+    repo_path: /data/repos/tech-blog
+    generator: hugo
+    preview:
+      local_preview:
+        enabled: true
+
+  - id: daily
+    repo_path: /data/repos/daily-blog
+    generator: hugo
+    preview:
+      local_preview:
+        enabled: false
+```
+
+有効なsiteについて、`GET /admin/api/sites`のsite設定にはderived valueとして次のようなURLが含まれます。
+
+```json
+{
+  "preview": {
+    "local_preview": {
+      "enabled": true,
+      "url": "https://tech.preview.example.com/"
+    }
+  }
+}
+```
+
+`url`は`sites.yml`へ保存する値ではありません。
+
+## site ID制約
+
+Local Live Previewで有効にするsite IDは、そのままDNS labelになります。
+
+許可例:
+
+```text
+tech
+daily-blog
+blog2
+```
+
+拒否例:
+
+```text
+Tech
+foo.bar
+-tech
+tech-
+tech_blog
+```
+
+Local Live Previewを無効にしているsiteにはこのDNS label制約を追加しません。
+
+## wildcard DNS / TLS
+
+想定DNSは1レコードです。
+
+```text
+*.preview.example.com -> preview ingress
+```
+
+site追加ごとにDNS recordを追加する必要はありません。
+
+hugo-cms自身はTLS certificateやDNS provider credentialを管理しません。たとえば以下の構成を利用できます。
+
+- Tailscale内だけでpreview ingressへ到達可能にする
+- DNS-01 challengeで`*.preview.example.com`のwildcard certificateを取得する
+- Caddy / Traefik / NginxでTLS terminateする
+- 必要に応じてCloudflare等を利用する
+
+これらは外部ingressの責務です。
+
+## Host validation
+
+Phase 2ではingressから受けたHostをCMSのresolverへ渡します。
+
+`PREVIEW_DOMAIN=preview.example.com`の場合、次を許可します。
+
+```text
+tech.preview.example.com
+tech.preview.example.com:443
+```
+
+次は拒否します。
+
+```text
+preview.example.com
+foo.tech.preview.example.com
+unknown.preview.example.com
+tech.preview.example.com.evil.example
+foo.example.com
+```
+
+Hostからrepository path、generator command、internal portを作ることはありません。Site Registryに登録されたsite IDとのlookupだけに使用します。
+
+## 旧preview設定との違い
+
+`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`はIssue #30以前のpath-prefix preview用legacy設定です。新Local Live Previewの公開URL・port管理には使用しません。
+
+旧方式:
+
+```text
+/admin/preview/tech/...
+```
+
+新方式:
+
+```text
+https://tech.preview.example.com/...
+```
+
+root-relative assetやLiveReloadがsite自身のorigin rootで動作できることが新方式の重要な違いです。
+
+## 内部port
+
+Local Live Previewのgenerator processはPhase 2で`127.0.0.1`だけへbindします。外部URLには内部portを含めません。
+
+初期の自動予約範囲は次です。
+
+```text
+14100-14999
+```
+
+同一siteには同じ予約slotを返し、別siteへの重複割当を避けます。OS上で使用中のportをprobeし、generator bindに失敗した場合は別portでretryする処理をPhase 2で接続します。
+
+## 編集中データ
+
+Phase 3では未保存editor stateをproduction working treeへキー入力ごとに書かず、shadow content workspaceへ反映します。
+
+初期契約では同一siteのactive Local Live Preview sessionは1つに制限し、別tab/draftから同時更新された場合は混在させず競合として扱います。
+
+詳細は[Local Live Preview設計](../architecture/local-live-preview-design.md)を参照してください。

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -66,7 +66,7 @@ sites:
 
 `url`は`sites.yml`へ保存する値ではありません。
 
-## site ID制約
+## site ID / hostname制約
 
 Local Live Previewで有効にするsite IDは、そのままDNS labelになります。
 
@@ -90,6 +90,8 @@ tech_blog
 
 Local Live Previewを無効にしているsiteにはこのDNS label制約を追加しません。
 
+site ID単体だけでなく、`<site-id>.<preview-domain>`を連結したhostname全体も有効なDNS名で、253文字以内である必要があります。設定検証、URL生成、Host resolverは同じ制約を使用します。
+
 ## wildcard DNS / TLS
 
 想定DNSは1レコードです。
@@ -108,6 +110,19 @@ hugo-cms自身はTLS certificateやDNS provider credentialを管理しません�
 - 必要に応じてCloudflare等を利用する
 
 これらは外部ingressの責務です。
+
+## 閲覧者認可
+
+**wildcard DNSとHost validationは閲覧者認可ではありません。** Local Live Previewには未公開contentが含まれ、site repository由来のJavaScriptも実行され得るため、preview ingressは必ず独立したアクセス制御の内側に置いてください。
+
+次のいずれかを必須とします。
+
+- Tailscale等のprivate networkからのみ到達可能にする
+- Internet reachableにする場合はCloudflare Access等のpreview専用viewer authenticationで保護する
+
+CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使わないでください。preview site由来のJavaScriptへCMS sessionを露出させないためです。
+
+hugo-cmsは外部ingressの認証方式を自動検出・設定しません。この閲覧制御はdeployment時にoperatorが満たす契約です。
 
 ## Host validation
 
@@ -164,7 +179,7 @@ Local Live Previewのgenerator processはPhase 2で`127.0.0.1`だけへbindし�
 
 ## 編集中データ
 
-Phase 3では未保存editor stateをproduction working treeへキー入力ごとに書かず、shadow content workspaceへ反映します。
+Phase 1で、未保存editor stateはproduction working treeやGit worktreeへ書かず、**shadow content workspace**へ反映する方針を確定しました。workspaceの作成・同期・cleanup自体はPhase 3で実装します。
 
 初期契約では同一siteのactive Local Live Preview sessionは1つに制限し、別tab/draftから同時更新された場合は混在させず競合として扱います。
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ var (
 	SitesConfigPath  = ""
 	Sites            = []SiteConfig{}
 
-	// Hugo Server settings
+	// Hugo Server settings (legacy path-prefix preview settings; retained for compatibility)
 	HugoServerPort = "1314"
 	HugoServerBind = "127.0.0.1"
 
@@ -51,6 +51,9 @@ var (
 
 	// Preview settings
 	MarkdownPreviewEnabled           = true
+	LocalLivePreviewEnabled          = false
+	PreviewDomain                    = ""
+	PreviewScheme                    = "https"
 	PreviewDeploymentProvider        = ""
 	CloudflarePagesAccountID         = ""
 	CloudflarePagesProjectName       = ""
@@ -91,14 +94,23 @@ type SiteConfig struct {
 }
 
 type SitePreviewConfig struct {
-	Markdown   MarkdownPreviewConfig   `yaml:"markdown" json:"markdown"`
-	Deployment DeploymentPreviewConfig `yaml:"deployment" json:"deployment"`
+	Markdown     MarkdownPreviewConfig   `yaml:"markdown" json:"markdown"`
+	LocalPreview LocalPreviewConfig      `yaml:"local_preview" json:"local_preview"`
+	Deployment   DeploymentPreviewConfig `yaml:"deployment" json:"deployment"`
 }
 
 type MarkdownPreviewConfig struct {
 	// A pointer preserves the distinction between an omitted value (enabled by
 	// default) and an explicit false value in the site registry.
 	Enabled *bool `yaml:"enabled" json:"enabled,omitempty"`
+}
+
+type LocalPreviewConfig struct {
+	// Enabled inherits LOCAL_LIVE_PREVIEW_ENABLED when omitted from a registry
+	// entry. URL is derived from site ID, PREVIEW_SCHEME and PREVIEW_DOMAIN and
+	// is never persisted in sites.yml.
+	Enabled *bool  `yaml:"enabled" json:"enabled,omitempty"`
+	URL     string `yaml:"-" json:"url,omitempty"`
 }
 
 type DeploymentPreviewConfig struct {
@@ -169,6 +181,7 @@ func Init() error {
 	GitUserName = getEnv("GIT_USER_NAME", "Hugo CMS Bot")
 	GitBranch = getEnv("GIT_BRANCH", "main")
 	GitRemote = getEnv("GIT_REMOTE", "origin")
+
 	MarkdownPreviewEnabled = true
 	if markdownEnabled := os.Getenv("MARKDOWN_PREVIEW_ENABLED"); markdownEnabled != "" {
 		value, err := strconv.ParseBool(markdownEnabled)
@@ -178,6 +191,22 @@ func Init() error {
 			MarkdownPreviewEnabled = value
 		}
 	}
+
+	LocalLivePreviewEnabled = false
+	if localEnabled := os.Getenv("LOCAL_LIVE_PREVIEW_ENABLED"); localEnabled != "" {
+		value, err := strconv.ParseBool(localEnabled)
+		if err != nil {
+			slog.Warn("Invalid LOCAL_LIVE_PREVIEW_ENABLED value; defaulting to false", "value", localEnabled)
+		} else {
+			LocalLivePreviewEnabled = value
+		}
+	}
+	PreviewDomain = normalizePreviewDomain(getEnv("PREVIEW_DOMAIN", ""))
+	PreviewScheme = normalizePreviewScheme(getEnv("PREVIEW_SCHEME", "https"))
+	if err := validateLocalPreviewBaseSettings(LocalLivePreviewEnabled); err != nil {
+		return err
+	}
+
 	PreviewDeploymentProvider = strings.ToLower(strings.TrimSpace(getEnv("PREVIEW_DEPLOYMENT_PROVIDER", "")))
 	CloudflarePagesAccountID = strings.TrimSpace(getEnv("CLOUDFLARE_PAGES_ACCOUNT_ID", ""))
 	CloudflarePagesProjectName = strings.TrimSpace(getEnv("CLOUDFLARE_PAGES_PROJECT_NAME", ""))
@@ -305,7 +334,8 @@ func defaultSiteFromGlobals() SiteConfig {
 		StaticMediaDir:  StaticMediaDir,
 		SnippetPaths:    SnippetPaths,
 		Preview: SitePreviewConfig{
-			Markdown: MarkdownPreviewConfig{Enabled: boolPointer(MarkdownPreviewEnabled)},
+			Markdown:     MarkdownPreviewConfig{Enabled: boolPointer(MarkdownPreviewEnabled)},
+			LocalPreview: LocalPreviewConfig{Enabled: boolPointer(LocalLivePreviewEnabled)},
 			Deployment: DeploymentPreviewConfig{
 				Provider: PreviewDeploymentProvider,
 				CloudflarePages: CloudflarePagesConfig{
@@ -362,6 +392,15 @@ func normalizeSiteConfig(site SiteConfig) SiteConfig {
 	if site.Preview.Markdown.Enabled == nil {
 		site.Preview.Markdown.Enabled = boolPointer(true)
 	}
+	if site.Preview.LocalPreview.Enabled == nil {
+		site.Preview.LocalPreview.Enabled = boolPointer(LocalLivePreviewEnabled)
+	}
+	site.Preview.LocalPreview.URL = ""
+	if site.Preview.LocalPreview.Enabled != nil && *site.Preview.LocalPreview.Enabled {
+		if previewURL, err := LocalPreviewURL(site.ID); err == nil {
+			site.Preview.LocalPreview.URL = previewURL
+		}
+	}
 	if site.Preview.Deployment.Provider == "cloudflare_pages" && site.Preview.Deployment.CloudflarePages.APITokenEnv == "" {
 		site.Preview.Deployment.CloudflarePages.APITokenEnv = "CLOUDFLARE_API_TOKEN"
 	}
@@ -370,6 +409,12 @@ func normalizeSiteConfig(site SiteConfig) SiteConfig {
 }
 
 func validateSitePreviewConfig(site SiteConfig) error {
+	if site.Preview.LocalPreview.Enabled != nil && *site.Preview.LocalPreview.Enabled {
+		if err := validateLocalPreviewSite(site); err != nil {
+			return err
+		}
+	}
+
 	deployment := site.Preview.Deployment
 	switch deployment.Provider {
 	case "":
@@ -507,6 +552,7 @@ func ApplyRuntime(runtime SiteRuntime) {
 	StaticMediaDir = runtime.StaticMediaDir
 	SnippetPaths = append([]string(nil), runtime.SnippetPaths...)
 	MarkdownPreviewEnabled = runtime.MarkdownPreviewEnabled
+	LocalLivePreviewEnabled = runtime.LocalPreview.Enabled != nil && *runtime.LocalPreview.Enabled
 	PreviewDeploymentProvider = runtime.PreviewDeployment.Provider
 	CloudflarePagesAccountID = runtime.PreviewDeployment.CloudflarePages.AccountID
 	CloudflarePagesProjectName = runtime.PreviewDeployment.CloudflarePages.ProjectName

--- a/pkg/config/local_preview.go
+++ b/pkg/config/local_preview.go
@@ -32,23 +32,31 @@ func validateLocalPreviewBaseSettings(enabled bool) error {
 }
 
 func validateLocalPreviewSite(site SiteConfig) error {
-	if err := validateLocalPreviewBaseSettings(true); err != nil {
-		return err
-	}
-	if site.ID != strings.ToLower(site.ID) || !validDNSLabel(site.ID) {
-		return fmt.Errorf("local preview site id %q must be a lowercase DNS label", site.ID)
-	}
-	return nil
+	_, err := localPreviewHostname(site.ID)
+	return err
 }
 
-func LocalPreviewURL(siteID string) (string, error) {
+func localPreviewHostname(siteID string) (string, error) {
 	if err := validateLocalPreviewBaseSettings(true); err != nil {
 		return "", err
 	}
 	if siteID != strings.ToLower(siteID) || !validDNSLabel(siteID) {
 		return "", fmt.Errorf("local preview site id %q must be a lowercase DNS label", siteID)
 	}
-	return fmt.Sprintf("%s://%s.%s/", PreviewScheme, siteID, PreviewDomain), nil
+
+	hostname := siteID + "." + PreviewDomain
+	if !validDNSName(hostname) {
+		return "", fmt.Errorf("local preview hostname %q is not a valid DNS name", hostname)
+	}
+	return hostname, nil
+}
+
+func LocalPreviewURL(siteID string) (string, error) {
+	hostname, err := localPreviewHostname(siteID)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s://%s/", PreviewScheme, hostname), nil
 }
 
 // ResolveLocalPreviewHost maps an HTTP Host header to an enabled site. Only a
@@ -71,6 +79,11 @@ func ResolveLocalPreviewHost(host string) (SiteConfig, error) {
 	siteID := strings.TrimSuffix(hostname, suffix)
 	if siteID == "" || strings.Contains(siteID, ".") || !validDNSLabel(siteID) {
 		return SiteConfig{}, fmt.Errorf("host %q does not contain exactly one valid site label", hostname)
+	}
+
+	expectedHostname, err := localPreviewHostname(siteID)
+	if err != nil || hostname != expectedHostname {
+		return SiteConfig{}, fmt.Errorf("invalid local preview hostname %q", hostname)
 	}
 
 	site, ok := GetSite(siteID)

--- a/pkg/config/local_preview.go
+++ b/pkg/config/local_preview.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"strings"
+)
+
+func normalizePreviewDomain(value string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+}
+
+func normalizePreviewScheme(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func validateLocalPreviewBaseSettings(enabled bool) error {
+	if !enabled && PreviewDomain == "" {
+		return nil
+	}
+	if PreviewScheme != "http" && PreviewScheme != "https" {
+		return fmt.Errorf("PREVIEW_SCHEME must be http or https")
+	}
+	if PreviewDomain == "" {
+		return fmt.Errorf("PREVIEW_DOMAIN is required when local live preview is enabled")
+	}
+	if !validDNSName(PreviewDomain) {
+		return fmt.Errorf("PREVIEW_DOMAIN %q must be a DNS name without scheme, wildcard, path, or port", PreviewDomain)
+	}
+	return nil
+}
+
+func validateLocalPreviewSite(site SiteConfig) error {
+	if err := validateLocalPreviewBaseSettings(true); err != nil {
+		return err
+	}
+	if site.ID != strings.ToLower(site.ID) || !validDNSLabel(site.ID) {
+		return fmt.Errorf("local preview site id %q must be a lowercase DNS label", site.ID)
+	}
+	return nil
+}
+
+func LocalPreviewURL(siteID string) (string, error) {
+	if err := validateLocalPreviewBaseSettings(true); err != nil {
+		return "", err
+	}
+	if siteID != strings.ToLower(siteID) || !validDNSLabel(siteID) {
+		return "", fmt.Errorf("local preview site id %q must be a lowercase DNS label", siteID)
+	}
+	return fmt.Sprintf("%s://%s.%s/", PreviewScheme, siteID, PreviewDomain), nil
+}
+
+// ResolveLocalPreviewHost maps an HTTP Host header to an enabled site. Only a
+// single DNS label directly below PREVIEW_DOMAIN is accepted. The Host header
+// never controls repository paths, commands, or internal preview ports.
+func ResolveLocalPreviewHost(host string) (SiteConfig, error) {
+	hostname, err := normalizePreviewHost(host)
+	if err != nil {
+		return SiteConfig{}, err
+	}
+	if err := validateLocalPreviewBaseSettings(true); err != nil {
+		return SiteConfig{}, err
+	}
+
+	suffix := "." + PreviewDomain
+	if !strings.HasSuffix(hostname, suffix) {
+		return SiteConfig{}, fmt.Errorf("host %q is outside preview domain %q", hostname, PreviewDomain)
+	}
+
+	siteID := strings.TrimSuffix(hostname, suffix)
+	if siteID == "" || strings.Contains(siteID, ".") || !validDNSLabel(siteID) {
+		return SiteConfig{}, fmt.Errorf("host %q does not contain exactly one valid site label", hostname)
+	}
+
+	site, ok := GetSite(siteID)
+	if !ok {
+		return SiteConfig{}, fmt.Errorf("unknown local preview site %q", siteID)
+	}
+	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
+		return SiteConfig{}, fmt.Errorf("local preview is disabled for site %q", siteID)
+	}
+	return site, nil
+}
+
+func normalizePreviewHost(host string) (string, error) {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return "", fmt.Errorf("preview host is empty")
+	}
+	if strings.ContainsAny(host, "/\\@ \t\r\n") {
+		return "", fmt.Errorf("invalid preview host %q", host)
+	}
+
+	hostname := host
+	if strings.Contains(host, ":") {
+		parsedHost, port, err := net.SplitHostPort(host)
+		if err != nil || parsedHost == "" || port == "" {
+			return "", fmt.Errorf("invalid preview host %q", host)
+		}
+		hostname = parsedHost
+	}
+
+	hostname = strings.TrimSuffix(strings.ToLower(hostname), ".")
+	if !validDNSName(hostname) {
+		return "", fmt.Errorf("invalid preview hostname %q", hostname)
+	}
+	return hostname, nil
+}
+
+func validDNSName(name string) bool {
+	if len(name) == 0 || len(name) > 253 || strings.Contains(name, "*") {
+		return false
+	}
+	labels := strings.Split(name, ".")
+	if len(labels) < 2 {
+		return false
+	}
+	for _, label := range labels {
+		if !validDNSLabel(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func validDNSLabel(label string) bool {
+	if len(label) == 0 || len(label) > 63 {
+		return false
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return false
+	}
+	for _, r := range label {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/pkg/config/local_preview.go
+++ b/pkg/config/local_preview.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -93,9 +94,13 @@ func normalizePreviewHost(host string) (string, error) {
 
 	hostname := host
 	if strings.Contains(host, ":") {
-		parsedHost, port, err := net.SplitHostPort(host)
-		if err != nil || parsedHost == "" || port == "" {
+		parsedHost, portText, err := net.SplitHostPort(host)
+		if err != nil || parsedHost == "" || portText == "" {
 			return "", fmt.Errorf("invalid preview host %q", host)
+		}
+		port, err := strconv.Atoi(portText)
+		if err != nil || port < 1 || port > 65535 {
+			return "", fmt.Errorf("invalid preview host port %q", portText)
 		}
 		hostname = parsedHost
 	}

--- a/pkg/config/local_preview_test.go
+++ b/pkg/config/local_preview_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func preserveLocalPreviewGlobals(t *testing.T) {
+	t.Helper()
+	originalEnabled := LocalLivePreviewEnabled
+	originalDomain := PreviewDomain
+	originalScheme := PreviewScheme
+	originalSites := Sites
+	t.Cleanup(func() {
+		LocalLivePreviewEnabled = originalEnabled
+		PreviewDomain = originalDomain
+		PreviewScheme = originalScheme
+		Sites = originalSites
+	})
+}
+
+func TestLocalPreviewURL(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+
+	got, err := LocalPreviewURL("tech")
+	if err != nil {
+		t.Fatalf("LocalPreviewURL() error = %v", err)
+	}
+	if got != "https://tech.preview.example.com/" {
+		t.Fatalf("LocalPreviewURL() = %q", got)
+	}
+}
+
+func TestLocalPreviewURLRejectsInvalidSiteID(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+
+	for _, siteID := range []string{"Tech", "foo.bar", "-tech", "tech-", "tech_blog"} {
+		t.Run(siteID, func(t *testing.T) {
+			if _, err := LocalPreviewURL(siteID); err == nil {
+				t.Fatalf("LocalPreviewURL(%q) should fail", siteID)
+			}
+		})
+	}
+}
+
+func TestResolveLocalPreviewHost(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+	enabled := true
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}},
+	}
+
+	for _, host := range []string{
+		"tech.preview.example.com",
+		"TECH.PREVIEW.EXAMPLE.COM",
+		"tech.preview.example.com:443",
+		"tech.preview.example.com.",
+	} {
+		t.Run(host, func(t *testing.T) {
+			site, err := ResolveLocalPreviewHost(host)
+			if err != nil {
+				t.Fatalf("ResolveLocalPreviewHost(%q) error = %v", host, err)
+			}
+			if site.ID != "tech" {
+				t.Fatalf("site.ID = %q, want tech", site.ID)
+			}
+		})
+	}
+}
+
+func TestResolveLocalPreviewHostRejectsUntrustedHosts(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+	enabled := true
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}},
+	}
+
+	for _, host := range []string{
+		"preview.example.com",
+		"foo.tech.preview.example.com",
+		"tech.preview.example.com.evil.example",
+		"unknown.preview.example.com",
+		"tech.example.com",
+		"tech.preview.example.com/path",
+		"tech.preview.example.com@evil.example",
+	} {
+		t.Run(host, func(t *testing.T) {
+			if _, err := ResolveLocalPreviewHost(host); err == nil {
+				t.Fatalf("ResolveLocalPreviewHost(%q) should fail", host)
+			}
+		})
+	}
+}
+
+func TestResolveLocalPreviewHostRejectsDisabledSite(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+	disabled := false
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &disabled}}},
+	}
+
+	_, err := ResolveLocalPreviewHost("tech.preview.example.com")
+	if err == nil || !strings.Contains(err.Error(), "disabled") {
+		t.Fatalf("ResolveLocalPreviewHost() error = %v, want disabled error", err)
+	}
+}
+
+func TestNormalizeSiteConfigInheritsLocalPreviewDefault(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	LocalLivePreviewEnabled = true
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+
+	site := normalizeSiteConfig(SiteConfig{ID: "tech"})
+	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
+		t.Fatal("local preview should inherit enabled global default")
+	}
+	if site.Preview.LocalPreview.URL != "https://tech.preview.example.com/" {
+		t.Fatalf("local preview URL = %q", site.Preview.LocalPreview.URL)
+	}
+}
+
+func TestValidateLocalPreviewBaseSettings(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+
+	tests := []struct {
+		name   string
+		domain string
+		scheme string
+		wantOK bool
+	}{
+		{name: "https domain", domain: "preview.example.com", scheme: "https", wantOK: true},
+		{name: "http domain", domain: "preview.example.com", scheme: "http", wantOK: true},
+		{name: "missing domain", domain: "", scheme: "https"},
+		{name: "wildcard domain", domain: "*.preview.example.com", scheme: "https"},
+		{name: "domain with scheme", domain: "https://preview.example.com", scheme: "https"},
+		{name: "domain with port", domain: "preview.example.com:443", scheme: "https"},
+		{name: "invalid scheme", domain: "preview.example.com", scheme: "ftp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			PreviewDomain = normalizePreviewDomain(tt.domain)
+			PreviewScheme = normalizePreviewScheme(tt.scheme)
+			err := validateLocalPreviewBaseSettings(true)
+			if (err == nil) != tt.wantOK {
+				t.Fatalf("validateLocalPreviewBaseSettings() error = %v, wantOK %v", err, tt.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/config/local_preview_test.go
+++ b/pkg/config/local_preview_test.go
@@ -91,6 +91,9 @@ func TestResolveLocalPreviewHostRejectsUntrustedHosts(t *testing.T) {
 		"tech.example.com",
 		"tech.preview.example.com/path",
 		"tech.preview.example.com@evil.example",
+		"tech.preview.example.com:evil",
+		"tech.preview.example.com:0",
+		"tech.preview.example.com:65536",
 	} {
 		t.Run(host, func(t *testing.T) {
 			if _, err := ResolveLocalPreviewHost(host); err == nil {

--- a/pkg/config/local_preview_test.go
+++ b/pkg/config/local_preview_test.go
@@ -33,6 +33,29 @@ func TestLocalPreviewURL(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewURLRoundTripsThroughResolver(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "https"
+	enabled := true
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}},
+	}
+
+	previewURL, err := LocalPreviewURL("tech")
+	if err != nil {
+		t.Fatalf("LocalPreviewURL() error = %v", err)
+	}
+	host := strings.TrimSuffix(strings.TrimPrefix(previewURL, "https://"), "/")
+	site, err := ResolveLocalPreviewHost(host)
+	if err != nil {
+		t.Fatalf("ResolveLocalPreviewHost(%q) error = %v", host, err)
+	}
+	if site.ID != "tech" {
+		t.Fatalf("resolved site = %q, want tech", site.ID)
+	}
+}
+
 func TestLocalPreviewURLRejectsInvalidSiteID(t *testing.T) {
 	preserveLocalPreviewGlobals(t)
 	PreviewDomain = "preview.example.com"
@@ -44,6 +67,30 @@ func TestLocalPreviewURLRejectsInvalidSiteID(t *testing.T) {
 				t.Fatalf("LocalPreviewURL(%q) should fail", siteID)
 			}
 		})
+	}
+}
+
+func TestLocalPreviewURLRejectsOversizedCombinedHostname(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewScheme = "https"
+	PreviewDomain = strings.Join([]string{
+		strings.Repeat("a", 63),
+		strings.Repeat("b", 63),
+		strings.Repeat("c", 63),
+		strings.Repeat("d", 57),
+	}, ".")
+
+	if !validDNSName(PreviewDomain) {
+		t.Fatalf("test PREVIEW_DOMAIN length %d should be valid", len(PreviewDomain))
+	}
+	if _, err := LocalPreviewURL("tech"); err == nil {
+		t.Fatalf("combined hostname length %d should be rejected", len("tech."+PreviewDomain))
+	}
+
+	enabled := true
+	site := SiteConfig{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}}
+	if err := validateLocalPreviewSite(site); err == nil {
+		t.Fatal("validateLocalPreviewSite() should reject an oversized combined hostname")
 	}
 }
 

--- a/pkg/config/site_runtime.go
+++ b/pkg/config/site_runtime.go
@@ -29,6 +29,7 @@ type SiteRuntime struct {
 	GitBranch              string
 	GitRemote              string
 	MarkdownPreviewEnabled bool
+	LocalPreview           LocalPreviewConfig
 	PreviewDeployment      DeploymentPreviewConfig
 }
 
@@ -55,11 +56,19 @@ func NewSiteRuntime(site SiteConfig) SiteRuntime {
 		GitBranch:              GitBranch,
 		GitRemote:              GitRemote,
 		MarkdownPreviewEnabled: site.Preview.Markdown.Enabled == nil || *site.Preview.Markdown.Enabled,
+		LocalPreview:           site.Preview.LocalPreview,
 		PreviewDeployment:      site.Preview.Deployment,
 	}
 }
 
 func CurrentSiteRuntime() SiteRuntime {
+	localPreview := LocalPreviewConfig{Enabled: boolPointer(LocalLivePreviewEnabled)}
+	if LocalLivePreviewEnabled {
+		if previewURL, err := LocalPreviewURL(DefaultSiteID); err == nil {
+			localPreview.URL = previewURL
+		}
+	}
+
 	return SiteRuntime{
 		ID:                     DefaultSiteID,
 		Name:                   "Current",
@@ -82,6 +91,7 @@ func CurrentSiteRuntime() SiteRuntime {
 		GitBranch:              GitBranch,
 		GitRemote:              GitRemote,
 		MarkdownPreviewEnabled: MarkdownPreviewEnabled,
+		LocalPreview:           localPreview,
 		PreviewDeployment: DeploymentPreviewConfig{
 			Provider: PreviewDeploymentProvider,
 			CloudflarePages: CloudflarePagesConfig{
@@ -111,8 +121,9 @@ func (runtime SiteRuntime) SiteConfig() SiteConfig {
 		StaticMediaDir:  runtime.StaticMediaDir,
 		SnippetPaths:    append([]string(nil), runtime.SnippetPaths...),
 		Preview: SitePreviewConfig{
-			Markdown:   MarkdownPreviewConfig{Enabled: boolPointer(runtime.MarkdownPreviewEnabled)},
-			Deployment: runtime.PreviewDeployment,
+			Markdown:     MarkdownPreviewConfig{Enabled: boolPointer(runtime.MarkdownPreviewEnabled)},
+			LocalPreview: runtime.LocalPreview,
+			Deployment:   runtime.PreviewDeployment,
 		},
 	}
 }

--- a/pkg/services/local_preview_lifecycle.go
+++ b/pkg/services/local_preview_lifecycle.go
@@ -1,0 +1,164 @@
+package services
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const (
+	LocalPreviewBindAddress       = "127.0.0.1"
+	DefaultLocalPreviewPortMin    = 14100
+	DefaultLocalPreviewPortMax    = 14999
+)
+
+type LocalPreviewProcessState string
+
+const (
+	LocalPreviewStopped  LocalPreviewProcessState = "stopped"
+	LocalPreviewStarting LocalPreviewProcessState = "starting"
+	LocalPreviewReady    LocalPreviewProcessState = "ready"
+	LocalPreviewFailed   LocalPreviewProcessState = "failed"
+	LocalPreviewStopping LocalPreviewProcessState = "stopping"
+)
+
+type LocalPreviewProcessSlot struct {
+	SiteID string
+	Port   int
+	State  LocalPreviewProcessState
+	Error  string
+}
+
+// LocalPreviewLifecycle reserves internal loopback ports and records process
+// state. It deliberately does not start generator processes; Phase 2 will own
+// command construction, readiness checks, proxying, and retry on bind races.
+type LocalPreviewLifecycle struct {
+	mu        sync.Mutex
+	portMin   int
+	portMax   int
+	nextPort  int
+	bySite    map[string]LocalPreviewProcessSlot
+	portOwner map[int]string
+}
+
+func NewLocalPreviewLifecycle(portMin, portMax int) (*LocalPreviewLifecycle, error) {
+	if portMin < 1 || portMax > 65535 || portMin > portMax {
+		return nil, fmt.Errorf("invalid local preview port range %d-%d", portMin, portMax)
+	}
+	return &LocalPreviewLifecycle{
+		portMin:   portMin,
+		portMax:   portMax,
+		nextPort:  portMin,
+		bySite:    make(map[string]LocalPreviewProcessSlot),
+		portOwner: make(map[int]string),
+	}, nil
+}
+
+func NewDefaultLocalPreviewLifecycle() *LocalPreviewLifecycle {
+	lifecycle, err := NewLocalPreviewLifecycle(DefaultLocalPreviewPortMin, DefaultLocalPreviewPortMax)
+	if err != nil {
+		panic(err)
+	}
+	return lifecycle
+}
+
+// Reserve returns one stable slot per site. portAvailable is a Phase 2 hook for
+// probing loopback availability; a nil callback treats every unreserved port as
+// available. A child-process bind failure must release/re-reserve and retry.
+func (l *LocalPreviewLifecycle) Reserve(siteID string, portAvailable func(int) bool) (LocalPreviewProcessSlot, error) {
+	siteID = strings.TrimSpace(siteID)
+	if siteID == "" {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("site id is required")
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if slot, ok := l.bySite[siteID]; ok {
+		return slot, nil
+	}
+
+	capacity := l.portMax - l.portMin + 1
+	for checked := 0; checked < capacity; checked++ {
+		port := l.nextPort
+		l.nextPort++
+		if l.nextPort > l.portMax {
+			l.nextPort = l.portMin
+		}
+		if _, reserved := l.portOwner[port]; reserved {
+			continue
+		}
+		if portAvailable != nil && !portAvailable(port) {
+			continue
+		}
+
+		slot := LocalPreviewProcessSlot{SiteID: siteID, Port: port, State: LocalPreviewStopped}
+		l.bySite[siteID] = slot
+		l.portOwner[port] = siteID
+		return slot, nil
+	}
+
+	return LocalPreviewProcessSlot{}, fmt.Errorf("no local preview ports available in range %d-%d", l.portMin, l.portMax)
+}
+
+func (l *LocalPreviewLifecycle) Get(siteID string) (LocalPreviewProcessSlot, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	slot, ok := l.bySite[siteID]
+	return slot, ok
+}
+
+func (l *LocalPreviewLifecycle) Transition(siteID string, next LocalPreviewProcessState, processErr error) (LocalPreviewProcessSlot, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	slot, ok := l.bySite[siteID]
+	if !ok {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview slot for site %q is not reserved", siteID)
+	}
+	if !validLocalPreviewTransition(slot.State, next) {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("invalid local preview transition %s -> %s for site %q", slot.State, next, siteID)
+	}
+
+	slot.State = next
+	if processErr != nil {
+		slot.Error = processErr.Error()
+	} else if next != LocalPreviewFailed {
+		slot.Error = ""
+	}
+	l.bySite[siteID] = slot
+	return slot, nil
+}
+
+func (l *LocalPreviewLifecycle) Release(siteID string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	slot, ok := l.bySite[siteID]
+	if !ok {
+		return nil
+	}
+	if slot.State != LocalPreviewStopped && slot.State != LocalPreviewFailed {
+		return fmt.Errorf("cannot release local preview slot for site %q while state is %s", siteID, slot.State)
+	}
+	delete(l.bySite, siteID)
+	delete(l.portOwner, slot.Port)
+	return nil
+}
+
+func validLocalPreviewTransition(current, next LocalPreviewProcessState) bool {
+	switch current {
+	case LocalPreviewStopped:
+		return next == LocalPreviewStarting
+	case LocalPreviewStarting:
+		return next == LocalPreviewReady || next == LocalPreviewFailed || next == LocalPreviewStopping
+	case LocalPreviewReady:
+		return next == LocalPreviewFailed || next == LocalPreviewStopping
+	case LocalPreviewFailed:
+		return next == LocalPreviewStarting || next == LocalPreviewStopped
+	case LocalPreviewStopping:
+		return next == LocalPreviewStopped || next == LocalPreviewFailed
+	default:
+		return false
+	}
+}

--- a/pkg/services/local_preview_lifecycle_test.go
+++ b/pkg/services/local_preview_lifecycle_test.go
@@ -1,0 +1,110 @@
+package services
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLocalPreviewLifecycleReservesStablePorts(t *testing.T) {
+	lifecycle, err := NewLocalPreviewLifecycle(15000, 15001)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+
+	available := func(port int) bool { return port != 15000 }
+	first, err := lifecycle.Reserve("tech", available)
+	if err != nil {
+		t.Fatalf("Reserve(tech) error = %v", err)
+	}
+	if first.Port != 15001 || first.State != LocalPreviewStopped {
+		t.Fatalf("first slot = %#v, want port 15001 stopped", first)
+	}
+
+	again, err := lifecycle.Reserve("tech", available)
+	if err != nil {
+		t.Fatalf("Reserve(tech) second error = %v", err)
+	}
+	if again.Port != first.Port {
+		t.Fatalf("second reservation port = %d, want stable %d", again.Port, first.Port)
+	}
+
+	if _, err := lifecycle.Reserve("daily", available); err == nil {
+		t.Fatal("Reserve(daily) should fail when no usable port remains")
+	}
+
+	if err := lifecycle.Release("tech"); err != nil {
+		t.Fatalf("Release(tech) error = %v", err)
+	}
+	second, err := lifecycle.Reserve("daily", available)
+	if err != nil {
+		t.Fatalf("Reserve(daily) after release error = %v", err)
+	}
+	if second.Port != 15001 {
+		t.Fatalf("daily port = %d, want reused 15001", second.Port)
+	}
+}
+
+func TestLocalPreviewLifecycleTransitions(t *testing.T) {
+	lifecycle, err := NewLocalPreviewLifecycle(15100, 15100)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+	if _, err := lifecycle.Reserve("tech", nil); err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+
+	starting, err := lifecycle.Transition("tech", LocalPreviewStarting, nil)
+	if err != nil || starting.State != LocalPreviewStarting {
+		t.Fatalf("starting transition = %#v, %v", starting, err)
+	}
+	ready, err := lifecycle.Transition("tech", LocalPreviewReady, nil)
+	if err != nil || ready.State != LocalPreviewReady {
+		t.Fatalf("ready transition = %#v, %v", ready, err)
+	}
+	if _, err := lifecycle.Transition("tech", LocalPreviewStarting, nil); err == nil {
+		t.Fatal("ready -> starting should be rejected")
+	}
+	stopping, err := lifecycle.Transition("tech", LocalPreviewStopping, nil)
+	if err != nil || stopping.State != LocalPreviewStopping {
+		t.Fatalf("stopping transition = %#v, %v", stopping, err)
+	}
+	stopped, err := lifecycle.Transition("tech", LocalPreviewStopped, nil)
+	if err != nil || stopped.State != LocalPreviewStopped {
+		t.Fatalf("stopped transition = %#v, %v", stopped, err)
+	}
+	if err := lifecycle.Release("tech"); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
+func TestLocalPreviewLifecycleRecordsFailure(t *testing.T) {
+	lifecycle, err := NewLocalPreviewLifecycle(15200, 15200)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+	if _, err := lifecycle.Reserve("tech", nil); err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	if _, err := lifecycle.Transition("tech", LocalPreviewStarting, nil); err != nil {
+		t.Fatalf("starting error = %v", err)
+	}
+
+	failed, err := lifecycle.Transition("tech", LocalPreviewFailed, errors.New("bind failed"))
+	if err != nil {
+		t.Fatalf("failed transition error = %v", err)
+	}
+	if failed.Error != "bind failed" {
+		t.Fatalf("failed.Error = %q", failed.Error)
+	}
+	if err := lifecycle.Release("tech"); err != nil {
+		t.Fatalf("failed slot should be releasable: %v", err)
+	}
+}
+
+func TestNewLocalPreviewLifecycleRejectsInvalidRange(t *testing.T) {
+	for _, tc := range [][2]int{{0, 10}, {10, 9}, {1, 70000}} {
+		if _, err := NewLocalPreviewLifecycle(tc[0], tc[1]); err == nil {
+			t.Fatalf("range %d-%d should fail", tc[0], tc[1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of #32 for wildcard-subdomain Local Live Preview.

- add `LOCAL_LIVE_PREVIEW_ENABLED`, `PREVIEW_DOMAIN`, and `PREVIEW_SCHEME`
- add per-site `preview.local_preview.enabled` override and derived preview URL
- add strict Host -> Site Registry resolver for `<site-id>.<preview-domain>`
- require enabled preview site IDs to be lowercase DNS labels
- add Local Preview process lifecycle state/port reservation contract
- choose shadow content workspace instead of mutating the production working tree or using Git worktrees for unsaved editor state
- document wildcard DNS/TLS/Tailscale as external preview-ingress responsibilities
- add configuration, Host validation, lifecycle, and port allocation tests

## Scope

This PR intentionally does **not** start Hugo/Eleventy preview servers yet. Reverse proxying, LiveReload/WebSocket forwarding, readiness checks, bind retry, and UI integration remain Phase 2/3 work.

The old `/admin/preview/:site/*` path-prefix proxy is not restored.

Closes the Phase 1 checklist items of #32; #32 itself should remain open for later phases.