### PR TITLE
feat: implement Phase 2 Hugo local Live Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Hugoサイト用のセルフホスト型ヘッドレスCMSです。GitHub OAuth�
 
 - 🔐 **GitHub OAuth認証** - 安全なログインとユーザー制限
 - 📝 **本文プレビュー** - 編集中のMarkdownをsanitizeして即座に確認
+- 🌐 **Local Live Preview** - site別hostnameでHugo theme/layout/shortcode/CSS/JS/LiveReloadを確認
 - 🚀 **デプロイプレビュー** - draft branchを外部providerでbuildし、公開前に特定commitを確認
 - 🖼️ **メディア管理** - ドラッグ&ドロップでの画像アップロード
 - 🔄 **Gitワークフロー** - 変更の同期・公開をワンクリックで
 - ⚡ **高速キャッシュ** - 並列処理による記事一覧の高速表示
 - 🛡️ **セキュリティ** - CSRF保護、パストラバーサル対策、入力検証
 
-> Issue #32 Phase 1で、`https://<site-id>.<preview-domain>/`形式のLocal Live Preview向け設定、URL生成、Host validation、process lifecycle/port reservation基盤を追加しています。Hugo/Eleventy preview serverの実起動、proxy、LiveReload、editor連携はPhase 2以降です。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
+> Issue #32 Phase 2で、Hugo Local Live Previewのlazy process起動、loopback port管理、`https://<site-id>.<preview-domain>/`からのreverse proxy、redirect補正、LiveReload/WebSocket中継まで追加しています。Phase 2では保存済みrepository contentを表示し、未保存editor入力のshadow workspace反映はPhase 3で追加します。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
 
 ## クイックスタート
 
@@ -148,7 +149,7 @@ appは非rootで動作し、bind mountしたrepoを`chown`しません。mise to
 
 - [ドキュメント一覧](docs/README.md) - 目的別の索引
 - [設定ガイド](docs/guides/configuration.md) - 詳細な設定オプション
-- [Local Live Preview設定ガイド](docs/guides/local-live-preview.md) - wildcard subdomain、閲覧制御、Host validation
+- [Local Live Preview設定ガイド](docs/guides/local-live-preview.md) - wildcard subdomain、閲覧制御、Host validation、Hugo runtime/proxy
 - [Docker + mise デプロイガイド](docs/guides/docker-mise-deployment.md) - secret-free bootstrapと非root appによる推奨デプロイ
 - [CMS設定](docs/reference/cms-config.md) - コレクションとフィールドの設定
 - [現行アーキテクチャ](docs/architecture/current-architecture.md) - 現在のシステム構成
@@ -170,6 +171,7 @@ hugo-cms/
 │   ├── handlers/        # HTTPハンドラー
 │   │   ├── api.go       # 記事API
 │   │   ├── auth.go      # 認証・CSRF
+│   │   ├── local_preview.go # preview hostname ingress
 │   │   ├── media.go     # メディアAPI
 │   │   ├── health.go    # ヘルスチェック
 │   │   └── errors.go    # エラーレスポンス
@@ -181,7 +183,8 @@ hugo-cms/
 │       ├── git.go       # Git操作
 │       ├── generator.go # ジェネレーター共通インターフェース
 │       ├── hugo_adapter.go # Hugoアダプター
-│       ├── process_manager.go # プレビュープロセス管理
+│       ├── local_preview_lifecycle.go # preview state/port reservation
+│       ├── local_preview_manager.go # Hugo preview process/proxy管理
 │       └── media.go     # メディアファイル管理
 ├── docs/
 │   ├── guides/          # 設定・デプロイ手順

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -2,7 +2,9 @@
 
 ## ステータス
 
-Issue #32 Phase 1で設計・設定契約を確定し、設定model、derived URL、Host validation、process lifecycle/port reservationの基盤まで実装済み。Phase 1ではgenerator processの実起動、reverse proxy、LiveReload中継、editorからshadow workspaceへの書き込みはまだ実装しない。
+Issue #32 Phase 1で設計・設定契約を確定し、設定model、derived URL、Host validation、process lifecycle/port reservationの基盤を実装した。
+
+Phase 2ではHugoを対象に、generator processのlazy start/stop、readiness、loopback port retry、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継まで実装する。未保存editor stateをshadow workspaceへ反映する処理はPhase 3の責務として分離する。
 
 Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えず、第3のpreview段階として追加する。
 
@@ -44,7 +46,7 @@ wildcard DNSやHost validationは閲覧者認可ではない。Local Live Previe
 
 CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使わない。preview側で実行されるsite由来JavaScriptへCMS sessionを露出させないためである。
 
-hugo-cmsは外部ingressの認証方式そのものを実装・検出しないため、この要件はoperatorが満たすdeployment contractとする。Phase 2の実装でも「hostnameを知っているだけで閲覧可能」なpublic ingressを推奨構成として扱わない。
+hugo-cmsは外部ingressの認証方式そのものを実装・検出しないため、この要件はoperatorが満たすdeployment contractとする。preview hostnameのrequestはCMS session middlewareより前で処理し、preview contentへadmin sessionを渡さない。
 
 ## 設定契約
 
@@ -85,7 +87,7 @@ Site RegistryをAPIへ返す際、Local Live Previewが有効ならderived value
 
 ## Host routing
 
-Phase 2のpreview ingress routeはHTTP `Host`を`ResolveLocalPreviewHost`へ渡し、Site Registryに登録済みかつLocal Live Previewが有効なsiteだけへ解決する。
+HTTP `Host`を`ResolveLocalPreviewHost`へ渡し、Site Registryに登録済みかつLocal Live Previewが有効なsiteだけへ解決する。
 
 許可例:
 
@@ -104,11 +106,11 @@ unknown.preview.example.com
 tech.example.com
 ```
 
-Hostからrepository path、generator command、internal portを生成してはならない。Hostから得られる値はSite Registry lookup keyだけとする。
+preview namespaceに属するがinvalid/unknownなHostはCMS admin routeへfall throughさせず404相当で拒否する。Hostからrepository path、generator command、internal portを生成してはならない。Hostから得られる値はSite Registry lookup keyだけとする。
 
 ## Generator process lifecycle
 
-Phase 2ではLocal Live Preview専用managerを追加し、次のstate machineを使う。
+`LocalPreviewManager`がPhase 1のstate machineを実processへ接続する。
 
 ```text
 stopped
@@ -125,18 +127,38 @@ failed
   -> stopped
 ```
 
-Phase 1では`LocalPreviewLifecycle`がstateと内部port reservationだけを管理する。generator processの起動、終了待ち、readiness、proxyはPhase 2で実装する。
-
 ### 起動契約
 
 - Local Live Previewは設定だけでCMS起動時に全siteを起動しない
-- 最初のpreview requestまたは明示的なUI操作でlazy startする
+- 最初のpreview requestでlazy startする
 - Host validationとSite Registry lookupが成功する前にprocessを起動しない
+- Phase 2のruntime実装対象はHugoのみとする
 - generator processは`127.0.0.1`へだけbindする
 - generator portをhost/public interfaceへ直接公開しない
-- child processへ渡す環境変数はallowlistする
+- child processへ渡す環境変数は既存generator allowlistを使用する
 - CMSのOAuth/session/provider secretは継承させない
 - CMS shutdown時には起動済みprocessを停止し、終了を待つ
+- processが異常終了した場合は`failed`へ遷移し、次requestで再起動できる
+
+Hugoは概ね次相当で起動する。
+
+```text
+hugo server
+  --source .
+  --contentDir <content_dir>
+  --bind 127.0.0.1
+  --port <internal-port>
+  --baseURL https://<site-id>.<preview-domain>/
+  --appendPort=false
+  --liveReloadPort 443
+  --renderToMemory
+  --buildDrafts
+  --buildFuture
+  --watch
+  --noHTTPCache
+```
+
+HTTP previewでは`--liveReloadPort 80`を使用する。外部preview URLへinternal portを露出させない。
 
 ### port allocation
 
@@ -148,9 +170,26 @@ managerが内部rangeからsiteごとにportを予約する。
 14100-14999
 ```
 
-Phase 1のallocatorは同一siteに安定した予約を返し、別siteとの重複を防ぐ。Phase 2では予約候補についてloopback bind可能性を確認してからprocessを起動する。
+予約候補はloopback bind可能性をprobeしてからprocessを起動する。probeとchild process bindの間のraceで起動に失敗した場合はslotを解放し、別portで有限回retryする。port番号は外部URLへ現れないため、retryしてもbrowser側URLは変化しない。
 
-port availability確認とchild process bindの間には競合余地があるため、実際のbindに失敗した場合はそのslotを解放し、別portを予約して有限回retryする。port番号を外部URLへ露出させないため、retryしてもbrowser側URLは変化しない。
+## Reverse proxy / LiveReload
+
+preview requestはpath prefixを追加・除去せず、そのままHugoへproxyする。
+
+```text
+https://tech.preview.example.com/css/main.css
+  -> http://127.0.0.1:<internal-port>/css/main.css
+```
+
+これによりroot-relative CSS/JS/imageはsite自身のorigin root `/` のまま扱える。
+
+proxyは次を行う。
+
+- external Hostをupstream requestにも保持する
+- `X-Forwarded-Host` / `X-Forwarded-Proto`をCMS側で再構成する
+- internal `127.0.0.1:<port>` / `localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換える
+- unrelatedなexternal redirectは書き換えない
+- HTTP Upgradeを透過し、Hugo LiveReloadのWebSocketを通す
 
 ## 編集中state: shadow content workspace
 
@@ -171,7 +210,7 @@ Git worktreeをLocal Live Previewの基本方式にはしない。
 
 初期実装ではsiteの`content_dir`をshadow workspaceへmirrorし、editorの未保存変更はshadow側の記事だけへ適用する。generatorのsource、layout、theme、config、static/assets等は登録済みrepositoryを基準にする。
 
-Hugoはcontent directoryを別pathへ切り替えられるため、Phase 3でHugo adapterがshadow content directoryをpreview commandへ渡す。generatorごとに同じ方式が使えない場合はadapter内で別方式を実装し、CMS共通層へgenerator固有path処理を漏らさない。
+Phase 2時点のHugo processは保存済みrepository contentを使用する。Phase 3でshadow content directoryをpreview commandへ渡し、editor変更をdebounce反映する。
 
 shadow workspaceのrootはCMS管理領域に置き、site IDやarticle pathを直接filesystem pathとして連結せず既存のpath validationと同等の境界を設ける。
 
@@ -181,32 +220,26 @@ shadow workspaceのrootはCMS管理領域に置き、site IDやarticle pathを�
 
 将来、複数sessionを同一hostnameで安全にroutingする仕組みを導入する場合のみ、この制約を緩和する。
 
-## Phase 2への契約
-
-Phase 2は以下を実装する。
-
-- generator preview command生成
-- lazy start/stop/restart
-- lifecycle stateとprocess実体の接続
-- loopback port probe + bind failure retry
-- hostnameから内部processへのreverse proxy
-- redirect/`Location`処理
-- WebSocket / Hugo LiveReload中継
-- root-relative CSS/JS/imageの確認
-- UIへready/failed状態とLocal Preview URLを公開
-
-旧`/admin/preview/:site/*` path-prefix proxyは再導入しない。
-
 ## Phase 3への契約
 
 Phase 3は以下を実装する。
 
 - shadow content workspace作成/同期/cleanup
 - editor変更のdebounce反映
-- generator watcherによる再build
+- Hugo watcherによる再build
 - 保存操作とshadow stateの同期
 - 同一site concurrent preview sessionの競合拒否
 - abnormal shutdown後のstale workspace cleanup
+
+## Phase 4への契約
+
+Phase 4は以下を実装する。
+
+- Local Live Preview表示/新規tab導線
+- starting/ready/failed状態表示
+- private network/Tailscale運用例
+- wildcard DNS / TLS ingress構成例
+- Deployment Previewとの役割差のUI明記
 
 ## セキュリティ要点
 
@@ -217,6 +250,7 @@ Phase 3は以下を実装する。
 - Local Live Preview無効siteは起動しない
 - Host値をcommand/path/portへ直接変換しない
 - generatorは明示的に登録されたrepositoryだけで実行する
+- generator child environmentはallowlistし、CMS secretを渡さない
 - internal generator serverはloopback bindのみ
 - TLS/DNS credentialをCMSへ要求しない
 - Local Live Previewはrepository内generator codeを実行するため、Markdown本文プレビューより広いtrust boundaryである

--- a/docs/architecture/preview-deployment-design.md
+++ b/docs/architecture/preview-deployment-design.md
@@ -2,9 +2,11 @@
 
 ## ステータス
 
-現在の実装では、Hugo CMSのプレビューをCMS内の安全な「本文プレビュー」と、外部providerが生成する「デプロイプレビュー」に分離している。Issue #30で旧`/admin/preview/:site/*` path-prefix proxyとローカルgenerator preview processを廃止したため、現時点ではCMSプロセスはHugo/Eleventyのpreview serverを常駐起動しない。
+現在のHugo CMSは、CMS内の安全な「本文プレビュー」、site別hostnameでHugoを動かす「Local Live Preview」、外部providerが生成する「デプロイプレビュー」の3段階を持つ。
 
-Issue #32 Phase 1では、この2段階を維持したまま、`https://<site-id>.<preview-domain>/`をorigin rootとして使う任意の「Local Live Preview」の設定model、derived URL、Host validation、process lifecycle/port reservation契約を導入した。generator serverの実起動、reverse proxy、LiveReload、editor連携はPhase 2以降で実装する。旧path-prefix proxyは復活させない。TLS終端、wildcard DNS、DNS-01、Tailscale等のpreview ingressはCMS本体から分離する。
+Issue #30で旧`/admin/preview/:site/*` path-prefix proxyとローカルgenerator preview processを廃止したが、Issue #32ではpath prefixを復活させず、`https://<site-id>.<preview-domain>/`をorigin rootとする方式でLocal Live Previewを再導入する。
+
+Phase 1で設定model、derived URL、Host validation、process lifecycle/port reservation契約を導入し、Phase 2でHugo preview processのlazy start/stop、loopback port retry、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継を実装する。未保存editor stateのshadow workspace連携はPhase 3で実装する。TLS終端、wildcard DNS、DNS-01、Tailscale等のpreview ingressはCMS本体から分離する。
 
 ## 現行の決定
 
@@ -32,11 +34,12 @@ previewは次の3段階として扱う。
    - generatorを実行しない
    - 編集入力を即時に安全表示する
    - theme/layout/shortcodeの再現は目的としない
-2. **Local Live Preview**（Issue #32。Phase 1基盤実装済み、runtime/proxyは未実装）
-   - Hugo等のgenerator preview processを実際に起動する
+2. **Local Live Preview**（Issue #32 Phase 2でHugo runtime/proxyを実装）
+   - Hugo preview processを実際に起動する
    - `<site-id>.<preview-domain>`をsite自身のorigin rootとして利用する
-   - theme/layout/shortcode/CSS/JS/LiveReloadを含む編集中の確認を目的とする
+   - theme/layout/shortcode/CSS/JS/LiveReloadを確認する
    - remote commit/pushを要求しない
+   - Phase 2では保存済みrepository contentを表示し、未保存editor入力はPhase 3でshadow workspaceへ反映する
 3. **Deployment Preview**
    - 明示操作でdraft branchをcommit/pushする
    - 外部providerでbuildし、特定commitの本番同等表示を確認する
@@ -76,17 +79,25 @@ production branchへ直接commit/pushする従来Publishは使用しない。rea
 
 ### Local Live Preview
 
-Issue #32では、ローカルgenerator codeを再び実行するため、次を追加の境界とする。
-
 - Site Registryでallowlistされたsiteだけを起動対象にする
+- preview namespaceに属するinvalid/unknown HostはCMS admin routeへfall throughさせず404相当で拒否する
 - Host値から任意repository path、port、commandを生成しない
 - generatorへ渡す環境変数をallowlistし、CMSのOAuth/session/provider secretを継承させない
-- generator portを直接公開せず、preview ingress経由でのみ到達させる
-- unknownな`<site-id>.<preview-domain>`は拒否する
+- generator portを`127.0.0.1`だけへbindし、preview ingress経由でのみ到達させる
 - wildcard DNSやHost validationを閲覧者認可として扱わない
 - preview ingressはTailscale等のprivate network内に置くか、Internet reachableな場合はCloudflare Access等の独立viewer authenticationを必須とする
-- CMS session cookieをpreview subdomainと共有しない
+- preview hostname requestはCMS session middlewareより前で処理し、CMS session cookieをpreview subdomainへ共有しない
 - TLS証明書やDNS provider tokenをCMS自身が保持することを必須にしない
+
+## Local Live Preview process / proxy
+
+Hugo processは最初のpreview requestでlazy startし、内部portはCMSが`14100-14999`から予約する。port利用可否をloopbackでprobeしたあとに起動し、bind race等でstartupに失敗した場合はslotを解放して別portで有限回retryする。
+
+Hugoにはexternal preview URLを`--baseURL`として渡し、`--appendPort=false`を使う。HTTPS previewではLiveReload portを443、HTTP previewでは80に固定し、internal portをbrowserへ露出させない。`--renderToMemory`、draft/future content、watchを有効にする。
+
+reverse proxyはpath prefixを加えずrequest pathをそのままHugoへ渡す。root-relative `/css/...`、`/js/...`、`/images/...`はsite自身のorigin rootから取得される。内部`127.0.0.1:<port>`または`localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換え、外部redirectは保持する。HTTP Upgradeを透過してHugo LiveReloadのWebSocketを通す。
+
+CMS shutdown時には起動済みHugo processを停止する。異常終了したprocessはfailed状態となり、次のrequestで再起動可能とする。
 
 ## ライフサイクルと競合
 
@@ -94,10 +105,10 @@ draft IDはbrowser sessionとsite/article pathの組み合わせごとに生成�
 
 preview更新は既存preview commitではなく、その時点のlocal production branchをbaseにして対象pathsだけを一時indexへ適用する。production branchが進んでnon-fast-forward更新になる場合は、前回commitを期待値とする`--force-with-lease`でdraft branchだけを更新し、失敗時はlocal draft refをrollbackする。commit SHAでdeploymentを照合するため、providerがbranch aliasを新しいbuildへ切り替えている途中でも誤ったpreviewを表示しない。
 
-Local Live Previewの未保存editor stateはproduction working treeやGit worktreeへ書かず、CMS管理領域の**shadow content workspace**へ保持する方針をIssue #32 Phase 1で確定した。初期実装では同一siteにつきactive Local Live Preview sessionを1つに制限し、別draft/tabの未保存stateを混在させない。詳細は[Local Live Preview設計](local-live-preview-design.md)を正とする。
+Local Live Previewの未保存editor stateはproduction working treeやGit worktreeへ書かず、CMS管理領域の**shadow content workspace**へ保持する方針をIssue #32 Phase 1で確定した。初期実装では同一siteにつきactive Local Live Preview sessionを1つに制限し、別draft/tabの未保存stateを混在させない。workspace作成・同期・cleanupはPhase 3で実装する。詳細は[Local Live Preview設計](local-live-preview-design.md)を正とする。
 
 ## 移行
 
-`preview_url`、`hugo_server_bind`、`hugo_server_port`はIssue #30以前のpath-prefix型ローカルpreview用の旧設定であり、現行の本文/デプロイプpreviewおよび新Local Live Previewの公開URL/port管理には使用しない。`/admin/preview/:site/*`、`POST /admin/api/build`、`POST /admin/api/build/restart`も廃止済みであり、Issue #32でもこれらをそのまま復活させない。
+`preview_url`、`hugo_server_bind`、`hugo_server_port`はIssue #30以前のpath-prefix型ローカルpreview用の旧設定であり、現行の本文/デプロイプpreviewおよび新Local Live Previewの公開URL/port管理には使用しない。`/admin/preview/:site/*`、`POST /admin/api/build`、`POST /admin/api/build/restart`も廃止済みであり、Issue #32でもこれらを復活させない。
 
-Issue #32 Phase 1では、`LOCAL_LIVE_PREVIEW_ENABLED`、`PREVIEW_DOMAIN`、`PREVIEW_SCHEME`とsite単位の`preview.local_preview.enabled`を導入した。`https://<site-id>.<preview-domain>/`はderived valueとして生成し、旧`preview_url`等との互換性を前提にしない。Phase 2実装まではgenerator runtimeは明示的なbuild/content作成で引き続き使用できるが、CMS起動時にLocal Live Previewを自動起動する仕様はない。
+新Local Live Previewは`LOCAL_LIVE_PREVIEW_ENABLED`、`PREVIEW_DOMAIN`、`PREVIEW_SCHEME`とsite単位の`preview.local_preview.enabled`を使用する。`https://<site-id>.<preview-domain>/`はderived valueとして生成し、旧`preview_url`等との互換性を前提にしない。CMS起動時に全siteのLocal Live Previewを自動起動せず、最初のpreview requestでlazy startする。

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,6 +1,6 @@
 # Local Live Preview設定ガイド
 
-> Issue #32 Phase 1時点では設定・URL生成・Host validation・process lifecycle契約まで実装済みです。generator serverの実起動、proxy、LiveReload、editor連携はPhase 2以降で実装します。
+> Issue #32 Phase 2では、Hugo preview processのlazy start/stop、loopback port allocation、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継まで実装します。未保存editor stateをshadow workspaceへ反映する処理はPhase 3で実装します。
 
 ## 基本設定
 
@@ -124,9 +124,7 @@ CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使�
 
 hugo-cmsは外部ingressの認証方式を自動検出・設定しません。この閲覧制御はdeployment時にoperatorが満たす契約です。
 
-## Host validation
-
-Phase 2ではingressから受けたHostをCMSのresolverへ渡します。
+## Host validation / routing
 
 `PREVIEW_DOMAIN=preview.example.com`の場合、次を許可します。
 
@@ -135,17 +133,85 @@ tech.preview.example.com
 tech.preview.example.com:443
 ```
 
-次は拒否します。
+次はpreview namespaceとして受け取ってもsiteへ解決せず404相当で拒否します。
 
 ```text
 preview.example.com
 foo.tech.preview.example.com
 unknown.preview.example.com
+tech.preview.example.com:evil
+```
+
+次はpreview namespace外なので通常のCMS routingへ進みます。
+
+```text
+cms.example.com
 tech.preview.example.com.evil.example
-foo.example.com
 ```
 
 Hostからrepository path、generator command、internal portを作ることはありません。Site Registryに登録されたsite IDとのlookupだけに使用します。
+
+preview hostnameのrequestはCMS session middlewareより前で処理されるため、CMS admin cookieをpreview siteへ渡しません。
+
+## Hugo process
+
+Phase 2のLocal Live Preview runtimeはHugoを対象にします。最初のpreview requestが来た時点でsiteごとのHugo serverをlazy startします。CMS起動時に全siteを常駐起動しません。
+
+概ね次のflagsを使用します。
+
+```text
+hugo server
+  --source .
+  --contentDir <content_dir>
+  --bind 127.0.0.1
+  --port <internal-port>
+  --baseURL https://tech.preview.example.com/
+  --appendPort=false
+  --liveReloadPort 443
+  --renderToMemory
+  --buildDrafts
+  --buildFuture
+  --watch
+  --noHTTPCache
+```
+
+HTTP previewでは`--liveReloadPort 80`を使用します。
+
+Hugo serverは`127.0.0.1`だけへbindし、外部からinternal portへ直接接続させません。CMS shutdown時には起動済みprocessを停止します。異常終了したprocessはfailed状態となり、次のpreview requestで再起動できます。
+
+child processのenvironmentは既存generator allowlistを使うため、`SESSION_SECRET`、GitHub OAuth secret、deployment provider token等をそのまま継承しません。
+
+## 内部port
+
+初期の自動予約範囲は次です。
+
+```text
+14100-14999
+```
+
+managerは候補portがloopbackで利用可能かprobeしてからHugoを起動します。probeとHugo bindの間にraceがあり得るため、起動失敗時はslotを解放し、別portで有限回retryします。
+
+内部portはpreview URLに現れません。
+
+## Reverse proxy / asset / redirect
+
+preview requestにはpath prefixを付けません。
+
+```text
+https://tech.preview.example.com/css/main.css
+```
+
+は内部では次へproxyされます。
+
+```text
+http://127.0.0.1:<internal-port>/css/main.css
+```
+
+そのため、`/css/...`、`/images/...`、`/js/...`のようなroot-relative URLを旧path-prefix方式のようにrewriteする必要がありません。
+
+Hugoが内部`127.0.0.1:<port>`または`localhost:<port>`を指すabsolute `Location`を返した場合だけ、CMSが外部preview originへ書き換えます。外部siteへのredirectは変更しません。
+
+HTTP Upgradeもproxyするため、Hugo LiveReloadのWebSocketを同じpreview hostnameで利用できます。
 
 ## 旧preview設定との違い
 
@@ -165,21 +231,11 @@ https://tech.preview.example.com/...
 
 root-relative assetやLiveReloadがsite自身のorigin rootで動作できることが新方式の重要な違いです。
 
-## 内部port
-
-Local Live Previewのgenerator processはPhase 2で`127.0.0.1`だけへbindします。外部URLには内部portを含めません。
-
-初期の自動予約範囲は次です。
-
-```text
-14100-14999
-```
-
-同一siteには同じ予約slotを返し、別siteへの重複割当を避けます。OS上で使用中のportをprobeし、generator bindに失敗した場合は別portでretryする処理をPhase 2で接続します。
-
 ## 編集中データ
 
-Phase 1で、未保存editor stateはproduction working treeやGit worktreeへ書かず、**shadow content workspace**へ反映する方針を確定しました。workspaceの作成・同期・cleanup自体はPhase 3で実装します。
+Phase 1で、未保存editor stateはproduction working treeやGit worktreeへ書かず、**shadow content workspace**へ反映する方針を確定しました。
+
+Phase 2のHugo processは保存済みrepository contentを表示します。workspaceの作成・同期・cleanupとeditor debounce連携はPhase 3で実装します。
 
 初期契約では同一siteのactive Local Live Preview sessionは1つに制限し、別tab/draftから同時更新された場合は混在させず競合として扱います。
 

--- a/main.go
+++ b/main.go
@@ -200,17 +200,23 @@ func main() {
 	<-quit
 	slog.Info("Shutting down server...")
 
-	previewCtx, cancelPreview := context.WithTimeout(context.Background(), 3*time.Second)
-	if err := services.DefaultLocalPreviewManager().Shutdown(previewCtx); err != nil {
-		slog.Error("Failed to stop local preview processes cleanly", "error", err)
-	}
-	cancelPreview()
+	previewManager := services.DefaultLocalPreviewManager()
+	// Reject any new lazy preview starts immediately. Existing preview requests
+	// may finish while the HTTP server drains, then all child processes are
+	// stopped after no new HTTP requests can be accepted.
+	previewManager.BeginShutdown()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
 		slog.Error("Server forced to shutdown", "error", err)
 	}
+	cancel()
+
+	previewCtx, cancelPreview := context.WithTimeout(context.Background(), 3*time.Second)
+	if err := previewManager.Shutdown(previewCtx); err != nil {
+		slog.Error("Failed to stop local preview processes cleanly", "error", err)
+	}
+	cancelPreview()
 
 	slog.Info("Server exiting")
 }

--- a/main.go
+++ b/main.go
@@ -46,6 +46,11 @@ func SetupRouter() (*gin.Engine, error) {
 	appURL := config.GetAppURL()
 	r := gin.Default()
 
+	// Preview hostname traffic must be handled before the CMS session middleware.
+	// Viewer authentication is enforced by the external preview ingress rather
+	// than by sharing the CMS admin cookie with repository-generated JavaScript.
+	r.Use(handlers.LocalPreviewIngress(services.DefaultLocalPreviewManager()))
+
 	// Determine if we are running on HTTPS
 	isSecure := strings.HasPrefix(appURL, "https://")
 
@@ -194,6 +199,12 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	slog.Info("Shutting down server...")
+
+	previewCtx, cancelPreview := context.WithTimeout(context.Background(), 3*time.Second)
+	if err := services.DefaultLocalPreviewManager().Shutdown(previewCtx); err != nil {
+		slog.Error("Failed to stop local preview processes cleanly", "error", err)
+	}
+	cancelPreview()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/config/local_preview.go
+++ b/pkg/config/local_preview.go
@@ -59,6 +59,31 @@ func LocalPreviewURL(siteID string) (string, error) {
 	return fmt.Sprintf("%s://%s/", PreviewScheme, hostname), nil
 }
 
+// IsLocalPreviewHostCandidate reports whether a Host value belongs to the
+// configured preview namespace. It is intentionally broader than
+// ResolveLocalPreviewHost: malformed or unknown hosts under PREVIEW_DOMAIN are
+// still classified as preview traffic so they fail closed instead of falling
+// through to the CMS admin application.
+func IsLocalPreviewHostCandidate(host string) bool {
+	if PreviewDomain == "" {
+		return false
+	}
+
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	hostname := host
+	if parsedHost, _, err := net.SplitHostPort(host); err == nil {
+		hostname = parsedHost
+	} else if index := strings.LastIndex(host, ":"); index >= 0 {
+		// Preserve fail-closed behavior for malformed ports such as :evil.
+		hostname = host[:index]
+	}
+	hostname = strings.TrimSuffix(hostname, ".")
+	return hostname == PreviewDomain || strings.HasSuffix(hostname, "."+PreviewDomain)
+}
+
 // ResolveLocalPreviewHost maps an HTTP Host header to an enabled site. Only a
 // single DNS label directly below PREVIEW_DOMAIN is accepted. The Host header
 // never controls repository paths, commands, or internal preview ports.

--- a/pkg/config/local_preview.go
+++ b/pkg/config/local_preview.go
@@ -88,11 +88,11 @@ func IsLocalPreviewHostCandidate(host string) bool {
 // single DNS label directly below PREVIEW_DOMAIN is accepted. The Host header
 // never controls repository paths, commands, or internal preview ports.
 func ResolveLocalPreviewHost(host string) (SiteConfig, error) {
-	hostname, err := normalizePreviewHost(host)
-	if err != nil {
+	if err := validateLocalPreviewBaseSettings(true); err != nil {
 		return SiteConfig{}, err
 	}
-	if err := validateLocalPreviewBaseSettings(true); err != nil {
+	hostname, err := normalizePreviewHost(host)
+	if err != nil {
 		return SiteConfig{}, err
 	}
 
@@ -139,6 +139,13 @@ func normalizePreviewHost(host string) (string, error) {
 		port, err := strconv.Atoi(portText)
 		if err != nil || port < 1 || port > 65535 {
 			return "", fmt.Errorf("invalid preview host port %q", portText)
+		}
+		expectedPort := "443"
+		if PreviewScheme == "http" {
+			expectedPort = "80"
+		}
+		if portText != expectedPort {
+			return "", fmt.Errorf("local preview host port %q does not match %s default port %s", portText, PreviewScheme, expectedPort)
 		}
 		hostname = parsedHost
 	}

--- a/pkg/config/local_preview_test.go
+++ b/pkg/config/local_preview_test.go
@@ -94,6 +94,33 @@ func TestLocalPreviewURLRejectsOversizedCombinedHostname(t *testing.T) {
 	}
 }
 
+func TestIsLocalPreviewHostCandidate(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{host: "tech.preview.example.com", want: true},
+		{host: "tech.preview.example.com:443", want: true},
+		{host: "tech.preview.example.com:evil", want: true},
+		{host: "preview.example.com", want: true},
+		{host: "foo.tech.preview.example.com", want: true},
+		{host: "cms.example.com", want: false},
+		{host: "tech.preview.example.com.evil.example", want: false},
+		{host: "preview.example.com.evil", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			if got := IsLocalPreviewHostCandidate(tt.host); got != tt.want {
+				t.Fatalf("IsLocalPreviewHostCandidate(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveLocalPreviewHost(t *testing.T) {
 	preserveLocalPreviewGlobals(t)
 	PreviewDomain = "preview.example.com"

--- a/pkg/config/local_preview_test.go
+++ b/pkg/config/local_preview_test.go
@@ -148,6 +148,46 @@ func TestResolveLocalPreviewHost(t *testing.T) {
 	}
 }
 
+func TestResolveLocalPreviewHostAllowsHTTPDefaultPort(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	PreviewScheme = "http"
+	enabled := true
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}},
+	}
+
+	if _, err := ResolveLocalPreviewHost("tech.preview.example.com:80"); err != nil {
+		t.Fatalf("ResolveLocalPreviewHost() error = %v", err)
+	}
+}
+
+func TestResolveLocalPreviewHostRejectsNonStandardPort(t *testing.T) {
+	preserveLocalPreviewGlobals(t)
+	PreviewDomain = "preview.example.com"
+	enabled := true
+	Sites = []SiteConfig{
+		{ID: "tech", Preview: SitePreviewConfig{LocalPreview: LocalPreviewConfig{Enabled: &enabled}}},
+	}
+
+	for _, tt := range []struct {
+		scheme string
+		host   string
+	}{
+		{scheme: "https", host: "tech.preview.example.com:8443"},
+		{scheme: "https", host: "tech.preview.example.com:80"},
+		{scheme: "http", host: "tech.preview.example.com:8080"},
+		{scheme: "http", host: "tech.preview.example.com:443"},
+	} {
+		t.Run(tt.scheme+"/"+tt.host, func(t *testing.T) {
+			PreviewScheme = tt.scheme
+			if _, err := ResolveLocalPreviewHost(tt.host); err == nil {
+				t.Fatalf("ResolveLocalPreviewHost(%q) should reject non-standard port for %s", tt.host, tt.scheme)
+			}
+		})
+	}
+}
+
 func TestResolveLocalPreviewHostRejectsUntrustedHosts(t *testing.T) {
 	preserveLocalPreviewGlobals(t)
 	PreviewDomain = "preview.example.com"

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"hugo-cms/pkg/config"
+	"hugo-cms/pkg/services"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// LocalPreviewIngress routes requests in the configured preview hostname
+// namespace before the CMS session/auth middleware runs. Viewer authentication
+// belongs to the external preview ingress (for example Tailscale or Cloudflare
+// Access); the CMS admin session cookie is deliberately not reused here.
+func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !config.IsLocalPreviewHostCandidate(c.Request.Host) {
+			return
+		}
+
+		site, err := config.ResolveLocalPreviewHost(c.Request.Host)
+		if err != nil {
+			slog.Warn("Rejected local preview host", "host", c.Request.Host, "error", err)
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+		if manager == nil {
+			slog.Error("Local preview manager is not configured", "site", site.ID)
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+
+		if err := manager.Proxy(c.Writer, c.Request, site); err != nil {
+			slog.Error("Local preview proxy failed", "site", site.ID, "error", err)
+			if !c.Writer.Written() {
+				c.AbortWithStatus(http.StatusBadGateway)
+			} else {
+				c.Abort()
+			}
+			return
+		}
+		c.Abort()
+	}
+}

--- a/pkg/handlers/local_preview_test.go
+++ b/pkg/handlers/local_preview_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"hugo-cms/pkg/config"
+	"hugo-cms/pkg/services"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestLocalPreviewIngressFailsClosedForUnknownPreviewHost(t *testing.T) {
+	originalDomain := config.PreviewDomain
+	originalScheme := config.PreviewScheme
+	originalSites := config.Sites
+	t.Cleanup(func() {
+		config.PreviewDomain = originalDomain
+		config.PreviewScheme = originalScheme
+		config.Sites = originalSites
+	})
+
+	config.PreviewDomain = "preview.example.com"
+	config.PreviewScheme = "https"
+	config.Sites = nil
+
+	lifecycle, err := services.NewLocalPreviewLifecycle(14100, 14100)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+	manager := services.NewLocalPreviewManager(lifecycle)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(LocalPreviewIngress(manager))
+	router.GET("/health", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	previewRequest := httptest.NewRequest(http.MethodGet, "http://unknown.preview.example.com/health", nil)
+	previewRequest.Host = "unknown.preview.example.com"
+	previewResponse := httptest.NewRecorder()
+	router.ServeHTTP(previewResponse, previewRequest)
+	if previewResponse.Code != http.StatusNotFound {
+		t.Fatalf("unknown preview host status = %d, want 404", previewResponse.Code)
+	}
+
+	cmsRequest := httptest.NewRequest(http.MethodGet, "http://cms.example.com/health", nil)
+	cmsRequest.Host = "cms.example.com"
+	cmsResponse := httptest.NewRecorder()
+	router.ServeHTTP(cmsResponse, cmsRequest)
+	if cmsResponse.Code != http.StatusOK {
+		t.Fatalf("normal CMS host status = %d, want 200", cmsResponse.Code)
+	}
+}

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -24,6 +24,8 @@ const (
 	localPreviewStderrLimit           = 64 << 10
 )
 
+var errLocalPreviewShuttingDown = errors.New("local preview manager is shutting down")
+
 type localPreviewCommandFactory func(context.Context, config.SiteRuntime, int, string) (*exec.Cmd, error)
 
 type managedLocalPreviewProcess struct {
@@ -111,9 +113,10 @@ func (b *cappedBuffer) String() string {
 type LocalPreviewManager struct {
 	lifecycle *LocalPreviewLifecycle
 
-	mu        sync.Mutex
-	processes map[string]*managedLocalPreviewProcess
-	siteLocks map[string]*sync.Mutex
+	mu           sync.Mutex
+	processes    map[string]*managedLocalPreviewProcess
+	siteLocks    map[string]*sync.Mutex
+	shuttingDown bool
 
 	commandFactory localPreviewCommandFactory
 	startupTimeout time.Duration
@@ -140,6 +143,18 @@ var defaultLocalPreviewManager = NewLocalPreviewManager(nil)
 
 func DefaultLocalPreviewManager() *LocalPreviewManager {
 	return defaultLocalPreviewManager
+}
+
+func (m *LocalPreviewManager) BeginShutdown() {
+	m.mu.Lock()
+	m.shuttingDown = true
+	m.mu.Unlock()
+}
+
+func (m *LocalPreviewManager) isShuttingDown() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.shuttingDown
 }
 
 func (m *LocalPreviewManager) siteLock(siteID string) *sync.Mutex {
@@ -182,6 +197,9 @@ func (m *LocalPreviewManager) Status(siteID string) (LocalPreviewProcessSlot, bo
 }
 
 func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewProcessSlot, error) {
+	if m.isShuttingDown() {
+		return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
+	}
 	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
 		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", site.ID)
 	}
@@ -204,6 +222,10 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 	lock.Lock()
 	defer lock.Unlock()
 
+	if m.isShuttingDown() {
+		return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
+	}
+
 	if slot, ok := m.lifecycle.Get(site.ID); ok {
 		process := m.process(site.ID)
 		switch slot.State {
@@ -224,6 +246,10 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 
 	var lastErr error
 	for attempt := 1; attempt <= m.startAttempts; attempt++ {
+		if m.isShuttingDown() {
+			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
+		}
+
 		slot, err := m.lifecycle.Reserve(site.ID, localPreviewPortAvailable)
 		if err != nil {
 			return LocalPreviewProcessSlot{}, err
@@ -238,6 +264,10 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 			m.cleanupFailedSlotLocked(site.ID, process, err)
 			continue
 		}
+		if m.isShuttingDown() {
+			m.cleanupFailedSlotLocked(site.ID, process, errLocalPreviewShuttingDown)
+			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
+		}
 
 		if err := m.waitUntilReady(process, slot.Port); err != nil {
 			lastErr = err
@@ -249,6 +279,10 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 		if err != nil {
 			m.cleanupFailedSlotLocked(site.ID, process, err)
 			return LocalPreviewProcessSlot{}, err
+		}
+		if m.isShuttingDown() {
+			m.cleanupFailedSlotLocked(site.ID, process, errLocalPreviewShuttingDown)
+			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 		}
 		if process.exited() {
 			lastErr = process.processError()
@@ -433,6 +467,7 @@ func (m *LocalPreviewManager) Stop(ctx context.Context, siteID string) error {
 
 func (m *LocalPreviewManager) Shutdown(ctx context.Context) error {
 	m.mu.Lock()
+	m.shuttingDown = true
 	siteIDs := make([]string, 0, len(m.processes))
 	for siteID := range m.processes {
 		siteIDs = append(siteIDs, siteID)
@@ -565,6 +600,7 @@ func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL strin
 		"--renderToMemory",
 		"--buildDrafts",
 		"--buildFuture",
+		"--buildExpired",
 		"--watch",
 		"--noHTTPCache",
 	}, nil

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -1,0 +1,566 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hugo-cms/pkg/config"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultLocalPreviewStartupTimeout = 15 * time.Second
+	defaultLocalPreviewProbeInterval  = 50 * time.Millisecond
+	defaultLocalPreviewStartAttempts  = 3
+	localPreviewStderrLimit           = 64 << 10
+)
+
+type localPreviewCommandFactory func(context.Context, config.SiteRuntime, int, string) (*exec.Cmd, error)
+
+type managedLocalPreviewProcess struct {
+	cmd    *exec.Cmd
+	cancel context.CancelFunc
+	done   chan struct{}
+	stderr *cappedBuffer
+
+	mu      sync.RWMutex
+	waitErr error
+}
+
+func (p *managedLocalPreviewProcess) setWaitErr(err error) {
+	p.mu.Lock()
+	p.waitErr = err
+	p.mu.Unlock()
+}
+
+func (p *managedLocalPreviewProcess) processError() error {
+	p.mu.RLock()
+	err := p.waitErr
+	p.mu.RUnlock()
+	if err == nil {
+		err = errors.New("local preview process exited")
+	}
+	if p.stderr == nil {
+		return err
+	}
+	stderr := strings.TrimSpace(p.stderr.String())
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, stderr)
+}
+
+func (p *managedLocalPreviewProcess) exited() bool {
+	select {
+	case <-p.done:
+		return true
+	default:
+		return false
+	}
+}
+
+type cappedBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	max int
+}
+
+func newCappedBuffer(max int) *cappedBuffer {
+	return &cappedBuffer{max: max}
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	originalLen := len(p)
+	if b.max <= 0 {
+		return originalLen, nil
+	}
+	if len(p) >= b.max {
+		b.buf = append(b.buf[:0], p[len(p)-b.max:]...)
+		return originalLen, nil
+	}
+	if overflow := len(b.buf) + len(p) - b.max; overflow > 0 {
+		copy(b.buf, b.buf[overflow:])
+		b.buf = b.buf[:len(b.buf)-overflow]
+	}
+	b.buf = append(b.buf, p...)
+	return originalLen, nil
+}
+
+func (b *cappedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.buf...))
+}
+
+// LocalPreviewManager owns Hugo preview child processes and connects the
+// Phase 1 lifecycle contract to lazy startup, readiness probing and proxying.
+// It intentionally does not own TLS or viewer authentication; those remain
+// preview-ingress responsibilities.
+type LocalPreviewManager struct {
+	lifecycle *LocalPreviewLifecycle
+
+	mu        sync.Mutex
+	processes map[string]*managedLocalPreviewProcess
+	siteLocks map[string]*sync.Mutex
+
+	commandFactory localPreviewCommandFactory
+	startupTimeout time.Duration
+	probeInterval  time.Duration
+	startAttempts  int
+}
+
+func NewLocalPreviewManager(lifecycle *LocalPreviewLifecycle) *LocalPreviewManager {
+	if lifecycle == nil {
+		lifecycle = NewDefaultLocalPreviewLifecycle()
+	}
+	return &LocalPreviewManager{
+		lifecycle:      lifecycle,
+		processes:      make(map[string]*managedLocalPreviewProcess),
+		siteLocks:      make(map[string]*sync.Mutex),
+		commandFactory: hugoLocalPreviewCommand,
+		startupTimeout: defaultLocalPreviewStartupTimeout,
+		probeInterval:  defaultLocalPreviewProbeInterval,
+		startAttempts:  defaultLocalPreviewStartAttempts,
+	}
+}
+
+var defaultLocalPreviewManager = NewLocalPreviewManager(nil)
+
+func DefaultLocalPreviewManager() *LocalPreviewManager {
+	return defaultLocalPreviewManager
+}
+
+func (m *LocalPreviewManager) siteLock(siteID string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lock, ok := m.siteLocks[siteID]
+	if !ok {
+		lock = &sync.Mutex{}
+		m.siteLocks[siteID] = lock
+	}
+	return lock
+}
+
+func (m *LocalPreviewManager) process(siteID string) *managedLocalPreviewProcess {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.processes[siteID]
+}
+
+func (m *LocalPreviewManager) setProcess(siteID string, process *managedLocalPreviewProcess) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if process == nil {
+		delete(m.processes, siteID)
+		return
+	}
+	m.processes[siteID] = process
+}
+
+func (m *LocalPreviewManager) removeProcessIfCurrent(siteID string, process *managedLocalPreviewProcess) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.processes[siteID] == process {
+		delete(m.processes, siteID)
+	}
+}
+
+func (m *LocalPreviewManager) Status(siteID string) (LocalPreviewProcessSlot, bool) {
+	return m.lifecycle.Get(siteID)
+}
+
+func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewProcessSlot, error) {
+	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", site.ID)
+	}
+	if !strings.EqualFold(strings.TrimSpace(site.Generator), "hugo") {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview currently supports Hugo only, got %q", site.Generator)
+	}
+
+	previewURL := strings.TrimSpace(site.Preview.LocalPreview.URL)
+	if previewURL == "" {
+		var err error
+		previewURL, err = config.LocalPreviewURL(site.ID)
+		if err != nil {
+			return LocalPreviewProcessSlot{}, err
+		}
+	}
+	runtime := config.NewSiteRuntime(site)
+
+	lock := m.siteLock(site.ID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if slot, ok := m.lifecycle.Get(site.ID); ok {
+		process := m.process(site.ID)
+		switch slot.State {
+		case LocalPreviewReady:
+			if process != nil && !process.exited() {
+				return slot, nil
+			}
+			_, _ = m.lifecycle.Transition(site.ID, LocalPreviewFailed, errors.New("local preview process is not running"))
+		case LocalPreviewFailed:
+			// Cleanup below before allocating another port.
+		case LocalPreviewStopped:
+			// Release the stale reservation below.
+		case LocalPreviewStarting, LocalPreviewStopping:
+			return LocalPreviewProcessSlot{}, fmt.Errorf("local preview for site %q is unexpectedly %s", site.ID, slot.State)
+		}
+		m.cleanupFailedSlotLocked(site.ID, process, nil)
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= m.startAttempts; attempt++ {
+		slot, err := m.lifecycle.Reserve(site.ID, localPreviewPortAvailable)
+		if err != nil {
+			return LocalPreviewProcessSlot{}, err
+		}
+		if _, err := m.lifecycle.Transition(site.ID, LocalPreviewStarting, nil); err != nil {
+			return LocalPreviewProcessSlot{}, err
+		}
+
+		process, err := m.startProcess(runtime, slot.Port, previewURL)
+		if err != nil {
+			lastErr = err
+			m.cleanupFailedSlotLocked(site.ID, process, err)
+			continue
+		}
+
+		if err := m.waitUntilReady(process, slot.Port); err != nil {
+			lastErr = err
+			m.cleanupFailedSlotLocked(site.ID, process, err)
+			continue
+		}
+
+		readySlot, err := m.lifecycle.Transition(site.ID, LocalPreviewReady, nil)
+		if err != nil {
+			m.cleanupFailedSlotLocked(site.ID, process, err)
+			return LocalPreviewProcessSlot{}, err
+		}
+		if process.exited() {
+			lastErr = process.processError()
+			m.cleanupFailedSlotLocked(site.ID, process, lastErr)
+			continue
+		}
+		return readySlot, nil
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("local preview failed to start")
+	}
+	return LocalPreviewProcessSlot{}, fmt.Errorf("failed to start local preview for site %q after %d attempts: %w", site.ID, m.startAttempts, lastErr)
+}
+
+func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int, previewURL string) (*managedLocalPreviewProcess, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd, err := m.commandFactory(ctx, runtime, port, previewURL)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	stderr := newCappedBuffer(localPreviewStderrLimit)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	process := &managedLocalPreviewProcess{
+		cmd:    cmd,
+		cancel: cancel,
+		done:   make(chan struct{}),
+		stderr: stderr,
+	}
+	m.setProcess(runtime.ID, process)
+
+	go func() {
+		process.setWaitErr(cmd.Wait())
+		close(process.done)
+		m.handleProcessExit(runtime.ID, process)
+	}()
+
+	return process, nil
+}
+
+func (m *LocalPreviewManager) waitUntilReady(process *managedLocalPreviewProcess, port int) error {
+	deadline := time.NewTimer(m.startupTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(m.probeInterval)
+	defer ticker.Stop()
+
+	address := net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(port))
+	for {
+		select {
+		case <-process.done:
+			return process.processError()
+		case <-deadline.C:
+			return fmt.Errorf("local preview did not become ready within %s", m.startupTimeout)
+		case <-ticker.C:
+			conn, err := net.DialTimeout("tcp", address, 250*time.Millisecond)
+			if err != nil {
+				continue
+			}
+			_ = conn.Close()
+			select {
+			case <-process.done:
+				return process.processError()
+			default:
+				return nil
+			}
+		}
+	}
+}
+
+func (m *LocalPreviewManager) cleanupFailedSlotLocked(siteID string, process *managedLocalPreviewProcess, processErr error) {
+	if process != nil {
+		process.cancel()
+		select {
+		case <-process.done:
+		case <-time.After(time.Second):
+			if process.cmd.Process != nil {
+				_ = process.cmd.Process.Kill()
+			}
+			select {
+			case <-process.done:
+			case <-time.After(time.Second):
+			}
+		}
+		m.removeProcessIfCurrent(siteID, process)
+	}
+
+	slot, ok := m.lifecycle.Get(siteID)
+	if !ok {
+		return
+	}
+	if processErr == nil {
+		processErr = errors.New("local preview process is not running")
+	}
+	switch slot.State {
+	case LocalPreviewStarting, LocalPreviewReady, LocalPreviewStopping:
+		_, _ = m.lifecycle.Transition(siteID, LocalPreviewFailed, processErr)
+	}
+	if slot, ok = m.lifecycle.Get(siteID); ok && slot.State == LocalPreviewFailed {
+		_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+	}
+	_ = m.lifecycle.Release(siteID)
+}
+
+func (m *LocalPreviewManager) handleProcessExit(siteID string, process *managedLocalPreviewProcess) {
+	lock := m.siteLock(siteID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if m.process(siteID) != process {
+		return
+	}
+	m.removeProcessIfCurrent(siteID, process)
+
+	slot, ok := m.lifecycle.Get(siteID)
+	if !ok {
+		return
+	}
+	switch slot.State {
+	case LocalPreviewReady:
+		_, _ = m.lifecycle.Transition(siteID, LocalPreviewFailed, process.processError())
+	case LocalPreviewStopping:
+		_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+	}
+}
+
+func (m *LocalPreviewManager) Stop(ctx context.Context, siteID string) error {
+	lock := m.siteLock(siteID)
+	lock.Lock()
+	defer lock.Unlock()
+
+	process := m.process(siteID)
+	slot, ok := m.lifecycle.Get(siteID)
+	if !ok {
+		return nil
+	}
+
+	if process == nil {
+		if slot.State == LocalPreviewFailed {
+			_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+		}
+		return m.lifecycle.Release(siteID)
+	}
+
+	if slot.State == LocalPreviewStarting || slot.State == LocalPreviewReady {
+		if _, err := m.lifecycle.Transition(siteID, LocalPreviewStopping, nil); err != nil {
+			return err
+		}
+	}
+	process.cancel()
+
+	select {
+	case <-process.done:
+	case <-ctx.Done():
+		if process.cmd.Process != nil {
+			_ = process.cmd.Process.Kill()
+		}
+		return fmt.Errorf("stopping local preview for site %q: %w", siteID, ctx.Err())
+	}
+	m.removeProcessIfCurrent(siteID, process)
+
+	if current, exists := m.lifecycle.Get(siteID); exists {
+		switch current.State {
+		case LocalPreviewStopping:
+			_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+		case LocalPreviewFailed:
+			_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+		}
+	}
+	return m.lifecycle.Release(siteID)
+}
+
+func (m *LocalPreviewManager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	siteIDs := make([]string, 0, len(m.processes))
+	for siteID := range m.processes {
+		siteIDs = append(siteIDs, siteID)
+	}
+	m.mu.Unlock()
+
+	var errs []error
+	for _, siteID := range siteIDs {
+		if err := m.Stop(ctx, siteID); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (m *LocalPreviewManager) Proxy(w http.ResponseWriter, r *http.Request, site config.SiteConfig) error {
+	slot, err := m.EnsureReady(site)
+	if err != nil {
+		return err
+	}
+	proxy, err := newLocalPreviewReverseProxy(site, slot.Port)
+	if err != nil {
+		return err
+	}
+	proxy.ServeHTTP(w, r)
+	return nil
+}
+
+func newLocalPreviewReverseProxy(site config.SiteConfig, port int) (*httputil.ReverseProxy, error) {
+	previewURL := strings.TrimSpace(site.Preview.LocalPreview.URL)
+	if previewURL == "" {
+		var err error
+		previewURL, err = config.LocalPreviewURL(site.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	external, err := url.Parse(previewURL)
+	if err != nil || external.Scheme == "" || external.Host == "" {
+		return nil, fmt.Errorf("invalid local preview URL %q", previewURL)
+	}
+	target, _ := url.Parse("http://" + net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(port)))
+
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(request *httputil.ProxyRequest) {
+			request.SetURL(target)
+			request.Out.Host = request.In.Host
+			request.SetXForwarded()
+			request.Out.Header.Set("X-Forwarded-Proto", external.Scheme)
+			request.Out.Header.Set("X-Forwarded-Host", external.Host)
+		},
+		ModifyResponse: func(response *http.Response) error {
+			location := response.Header.Get("Location")
+			if location == "" {
+				return nil
+			}
+			parsed, err := url.Parse(location)
+			if err != nil || parsed.Host == "" {
+				return nil
+			}
+			if !isInternalLocalPreviewHost(parsed.Host, port) {
+				return nil
+			}
+			parsed.Scheme = external.Scheme
+			parsed.Host = external.Host
+			response.Header.Set("Location", parsed.String())
+			return nil
+		},
+		ErrorHandler: func(writer http.ResponseWriter, _ *http.Request, proxyErr error) {
+			http.Error(writer, "local preview upstream unavailable: "+proxyErr.Error(), http.StatusBadGateway)
+		},
+	}
+	return proxy, nil
+}
+
+func isInternalLocalPreviewHost(host string, port int) bool {
+	hostname, portText, err := net.SplitHostPort(host)
+	if err != nil || portText != strconv.Itoa(port) {
+		return false
+	}
+	return hostname == LocalPreviewBindAddress || strings.EqualFold(hostname, "localhost")
+}
+
+func localPreviewPortAvailable(port int) bool {
+	listener, err := net.Listen("tcp", net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = listener.Close()
+	return true
+}
+
+func hugoLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime, port int, previewURL string) (*exec.Cmd, error) {
+	args, err := hugoLocalPreviewArgs(runtime, port, previewURL)
+	if err != nil {
+		return nil, err
+	}
+	return generatorCommandContext(ctx, runtime, "hugo", args...), nil
+}
+
+func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL string) ([]string, error) {
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("invalid local preview port %d", port)
+	}
+	parsed, err := url.Parse(previewURL)
+	if err != nil || parsed.Hostname() == "" || parsed.Port() != "" {
+		return nil, fmt.Errorf("invalid local preview URL %q", previewURL)
+	}
+
+	liveReloadPort := 0
+	switch parsed.Scheme {
+	case "https":
+		liveReloadPort = 443
+	case "http":
+		liveReloadPort = 80
+	default:
+		return nil, fmt.Errorf("unsupported local preview scheme %q", parsed.Scheme)
+	}
+
+	return []string{
+		"server",
+		"--source", ".",
+		"--contentDir", runtime.ContentDir,
+		"--bind", LocalPreviewBindAddress,
+		"--port", strconv.Itoa(port),
+		"--baseURL", previewURL,
+		"--appendPort=false",
+		"--liveReloadPort", strconv.Itoa(liveReloadPort),
+		"--renderToMemory",
+		"--buildDrafts",
+		"--buildFuture",
+		"--watch",
+		"--noHTTPCache",
+	}, nil
+}

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"hugo-cms/pkg/config"
-	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -185,7 +185,8 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
 		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", site.ID)
 	}
-	if !strings.EqualFold(strings.TrimSpace(site.Generator), "hugo") {
+	generator := strings.TrimSpace(site.Generator)
+	if generator != "" && !strings.EqualFold(generator, "hugo") {
 		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview currently supports Hugo only, got %q", site.Generator)
 	}
 
@@ -272,7 +273,10 @@ func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int,
 	}
 
 	stderr := newCappedBuffer(localPreviewStderrLimit)
-	cmd.Stdout = io.Discard
+	// Hugo may emit useful startup/build diagnostics to either stream. Keep the
+	// bounded tail of both without allowing child output to grow memory without
+	// limit or leak CMS secrets through the browser response.
+	cmd.Stdout = stderr
 	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		cancel()
@@ -498,7 +502,8 @@ func newLocalPreviewReverseProxy(site config.SiteConfig, port int) (*httputil.Re
 			return nil
 		},
 		ErrorHandler: func(writer http.ResponseWriter, _ *http.Request, proxyErr error) {
-			http.Error(writer, "local preview upstream unavailable: "+proxyErr.Error(), http.StatusBadGateway)
+			slog.Error("Local preview upstream error", "site", site.ID, "error", proxyErr)
+			http.Error(writer, "local preview upstream unavailable", http.StatusBadGateway)
 		},
 	}
 	return proxy, nil

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"hugo-cms/pkg/config"
 	"io"
@@ -36,6 +37,7 @@ func TestHugoLocalPreviewArgs(t *testing.T) {
 		"--renderToMemory",
 		"--buildDrafts",
 		"--buildFuture",
+		"--buildExpired",
 		"--watch",
 		"--noHTTPCache",
 	}
@@ -159,6 +161,37 @@ func TestLocalPreviewManagerStopReleasesSlot(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewManagerBeginShutdownRejectsNewStarts(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	manager.BeginShutdown()
+
+	if _, err := manager.EnsureReady(site); !errors.Is(err, errLocalPreviewShuttingDown) {
+		t.Fatalf("EnsureReady() error = %v, want shutting down", err)
+	}
+	if _, ok := manager.Status(site.ID); ok {
+		t.Fatal("EnsureReady() should not reserve a slot after BeginShutdown")
+	}
+}
+
+func TestLocalPreviewManagerShutdownRejectsRestart(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	if _, err := manager.EnsureReady(site); err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := manager.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if _, ok := manager.Status(site.ID); ok {
+		t.Fatal("Shutdown() should release the lifecycle slot")
+	}
+	if _, err := manager.EnsureReady(site); !errors.Is(err, errLocalPreviewShuttingDown) {
+		t.Fatalf("EnsureReady() after Shutdown error = %v, want shutting down", err)
+	}
+}
+
 func newTestLocalPreviewManager(t *testing.T) (*LocalPreviewManager, config.SiteConfig) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -180,9 +213,9 @@ func newTestLocalPreviewManager(t *testing.T) (*LocalPreviewManager, config.Site
 
 	enabled := true
 	site := config.SiteConfig{
-		ID:        "tech",
-		Generator: "hugo",
-		RepoPath:  ".",
+		ID:         "tech",
+		Generator:  "hugo",
+		RepoPath:   ".",
 		ContentDir: "content",
 		Preview: config.SitePreviewConfig{
 			LocalPreview: config.LocalPreviewConfig{

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -1,0 +1,257 @@
+package services
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"hugo-cms/pkg/config"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHugoLocalPreviewArgs(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: "content"}
+	got, err := hugoLocalPreviewArgs(runtime, 14123, "https://tech.preview.example.com/")
+	if err != nil {
+		t.Fatalf("hugoLocalPreviewArgs() error = %v", err)
+	}
+	want := []string{
+		"server",
+		"--source", ".",
+		"--contentDir", "content",
+		"--bind", "127.0.0.1",
+		"--port", "14123",
+		"--baseURL", "https://tech.preview.example.com/",
+		"--appendPort=false",
+		"--liveReloadPort", "443",
+		"--renderToMemory",
+		"--buildDrafts",
+		"--buildFuture",
+		"--watch",
+		"--noHTTPCache",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("hugoLocalPreviewArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestHugoLocalPreviewArgsUsesHTTPReloadPort(t *testing.T) {
+	args, err := hugoLocalPreviewArgs(config.SiteRuntime{ContentDir: "content"}, 14123, "http://tech.preview.example.com/")
+	if err != nil {
+		t.Fatalf("hugoLocalPreviewArgs() error = %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--liveReloadPort 80") {
+		t.Fatalf("args = %q, want live reload port 80", joined)
+	}
+}
+
+func TestHugoLocalPreviewArgsRejectsURLPort(t *testing.T) {
+	if _, err := hugoLocalPreviewArgs(config.SiteRuntime{ContentDir: "content"}, 14123, "https://tech.preview.example.com:8443/"); err == nil {
+		t.Fatal("hugoLocalPreviewArgs() should reject an external URL port")
+	}
+}
+
+func TestLocalPreviewManagerEnsureReadyAndProxy(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	defer shutdownTestLocalPreviewManager(t, manager)
+
+	slot, err := manager.EnsureReady(site)
+	if err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+	if slot.State != LocalPreviewReady {
+		t.Fatalf("slot.State = %q, want ready", slot.State)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "http://tech.preview.example.com/css/main.css", nil)
+	request.Host = "tech.preview.example.com"
+	response := httptest.NewRecorder()
+	if err := manager.Proxy(response, request, site); err != nil {
+		t.Fatalf("Proxy() error = %v", err)
+	}
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", response.Code, response.Body.String())
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, "path=/css/main.css") {
+		t.Fatalf("proxy changed root-relative path: %q", body)
+	}
+	if !strings.Contains(body, "host=tech.preview.example.com") {
+		t.Fatalf("proxy did not preserve external host: %q", body)
+	}
+	if !strings.Contains(body, "proto=http") {
+		t.Fatalf("proxy did not set external scheme: %q", body)
+	}
+}
+
+func TestLocalPreviewProxyRewritesInternalLocation(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	defer shutdownTestLocalPreviewManager(t, manager)
+
+	request := httptest.NewRequest(http.MethodGet, "http://tech.preview.example.com/redirect", nil)
+	request.Host = "tech.preview.example.com"
+	response := httptest.NewRecorder()
+	if err := manager.Proxy(response, request, site); err != nil {
+		t.Fatalf("Proxy() error = %v", err)
+	}
+	if response.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", response.Code)
+	}
+	if got := response.Header().Get("Location"); got != "http://tech.preview.example.com/target" {
+		t.Fatalf("Location = %q", got)
+	}
+}
+
+func TestLocalPreviewProxyPassesUpgrade(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	defer shutdownTestLocalPreviewManager(t, manager)
+
+	outer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := manager.Proxy(w, r, site); err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+		}
+	}))
+	defer outer.Close()
+
+	address := strings.TrimPrefix(outer.URL, "http://")
+	conn, err := net.DialTimeout("tcp", address, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Dial() error = %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := fmt.Fprintf(conn, "GET /_livereload HTTP/1.1\r\nHost: tech.preview.example.com\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n"); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+	response, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("ReadResponse() error = %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("status = %d, want 101", response.StatusCode)
+	}
+}
+
+func TestLocalPreviewManagerStopReleasesSlot(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+
+	if _, err := manager.EnsureReady(site); err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := manager.Stop(ctx, site.ID); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if _, ok := manager.Status(site.ID); ok {
+		t.Fatal("Stop() should release the lifecycle slot")
+	}
+}
+
+func newTestLocalPreviewManager(t *testing.T) (*LocalPreviewManager, config.SiteConfig) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("find free port: %v", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	lifecycle, err := NewLocalPreviewLifecycle(port, port)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+	manager := NewLocalPreviewManager(lifecycle)
+	manager.commandFactory = testLocalPreviewCommand
+	manager.startAttempts = 1
+	manager.startupTimeout = 5 * time.Second
+	manager.probeInterval = 10 * time.Millisecond
+
+	enabled := true
+	site := config.SiteConfig{
+		ID:        "tech",
+		Generator: "hugo",
+		RepoPath:  ".",
+		ContentDir: "content",
+		Preview: config.SitePreviewConfig{
+			LocalPreview: config.LocalPreviewConfig{
+				Enabled: &enabled,
+				URL:     "http://tech.preview.example.com/",
+			},
+		},
+	}
+	return manager, site
+}
+
+func shutdownTestLocalPreviewManager(t *testing.T, manager *LocalPreviewManager) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := manager.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+}
+
+func testLocalPreviewCommand(ctx context.Context, _ config.SiteRuntime, port int, _ string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestLocalPreviewHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		"HUGO_CMS_LOCAL_PREVIEW_HELPER=1",
+		"HUGO_CMS_LOCAL_PREVIEW_PORT="+strconv.Itoa(port),
+	)
+	return cmd, nil
+}
+
+func TestLocalPreviewHelperProcess(t *testing.T) {
+	if os.Getenv("HUGO_CMS_LOCAL_PREVIEW_HELPER") != "1" {
+		return
+	}
+	port, err := strconv.Atoi(os.Getenv("HUGO_CMS_LOCAL_PREVIEW_PORT"))
+	if err != nil {
+		os.Exit(2)
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		os.Exit(3)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			hijacker, ok := w.(http.Hijacker)
+			if !ok {
+				os.Exit(4)
+			}
+			conn, rw, err := hijacker.Hijack()
+			if err != nil {
+				os.Exit(5)
+			}
+			_, _ = rw.WriteString("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n")
+			_ = rw.Flush()
+			_, _ = io.Copy(conn, conn)
+			_ = conn.Close()
+			return
+		}
+		if r.URL.Path == "/redirect" {
+			w.Header().Set("Location", "http://127.0.0.1:"+strconv.Itoa(port)+"/target")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		_, _ = fmt.Fprintf(w, "path=%s host=%s proto=%s forwarded-host=%s", r.URL.Path, r.Host, r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-Host"))
+	})
+
+	server := &http.Server{Handler: handler}
+	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+		os.Exit(6)
+	}
+	os.Exit(0)
+}

--- a/pkg/services/local_preview_shutdown_test.go
+++ b/pkg/services/local_preview_shutdown_test.go
@@ -1,0 +1,61 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"hugo-cms/pkg/config"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestLocalPreviewManagerShutdownCatchesStartupAfterSnapshot(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+
+	factoryEntered := make(chan struct{})
+	releaseFactory := make(chan struct{})
+	manager.commandFactory = func(ctx context.Context, runtime config.SiteRuntime, port int, previewURL string) (*exec.Cmd, error) {
+		close(factoryEntered)
+		<-releaseFactory
+		return testLocalPreviewCommand(ctx, runtime, port, previewURL)
+	}
+
+	ensureDone := make(chan error, 1)
+	go func() {
+		_, err := manager.EnsureReady(site)
+		ensureDone <- err
+	}()
+
+	select {
+	case <-factoryEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EnsureReady() did not reach command factory")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	if err := manager.Shutdown(shutdownCtx); err != nil {
+		cancel()
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	cancel()
+
+	// At this point Shutdown has already taken its process snapshot while the
+	// startup is still between slot reservation and process registration.
+	close(releaseFactory)
+
+	select {
+	case err := <-ensureDone:
+		if !errors.Is(err, errLocalPreviewShuttingDown) {
+			t.Fatalf("EnsureReady() error = %v, want shutting down", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("EnsureReady() did not finish after shutdown")
+	}
+
+	if _, ok := manager.Status(site.ID); ok {
+		t.Fatal("startup racing with Shutdown() left a lifecycle slot behind")
+	}
+	if process := manager.process(site.ID); process != nil {
+		t.Fatal("startup racing with Shutdown() left a child process behind")
+	}
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of #32 for Hugo Local Live Preview.

- lazily start one Hugo preview process per enabled site
- reserve/probe loopback ports and retry startup on bind/start failures
- run Hugo with external preview `baseURL`, `--appendPort=false`, `--renderToMemory`, drafts/future/expired content, and proxy-aware LiveReload port
- proxy `<site-id>.<preview-domain>` requests to the matching loopback process without path-prefix rewriting
- preserve root-relative asset paths and external Host
- rewrite internal `Location` redirects back to the external preview origin
- pass HTTP Upgrade/WebSocket traffic for Hugo LiveReload
- route preview-host traffic before the CMS session middleware so the admin cookie is not shared with preview content
- fail closed for invalid/unknown hosts inside the preview namespace instead of falling through to CMS routes
- accept only the standard external port for the configured preview scheme (`443` for HTTPS, `80` for HTTP); non-standard ports are intentionally unsupported
- prevent lazy preview startup once shutdown begins, drain the HTTP server, then stop all child preview processes
- retain bounded Hugo stdout/stderr diagnostics server-side without exposing upstream internals to the browser
- add process/proxy/redirect/Upgrade/fail-closed/shutdown-race tests using a child test HTTP server

## Security boundary

Viewer authentication remains an external preview-ingress responsibility as decided in Phase 1. Tailscale/private-network ingress is valid; Internet-reachable ingress must use an independent control such as Cloudflare Access. CMS admin session cookies are not reused on preview subdomains.

## Scope

This PR targets **Hugo** only. Phase 3 owns shadow-content workspace/editor debounce integration, so this phase serves the repository's saved content and validates the full-site process/proxy/LiveReload path.

The automated tests verify process lifecycle, root-path proxy semantics, redirect handling, WebSocket Upgrade, fail-closed hostname routing, standard-port enforcement, and the shutdown/startup race without requiring Hugo in the CI runner. The environment-specific smoke test with the actual blog repositories and chosen wildcard/Tailscale ingress remains tracked in #32.

Merged; #32 remains open for Phase 3/4 and the environment-specific acceptance checks.