### PR TITLE
feat: implement Phase 3 Local Live Preview shadow workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hugoサイト用のセルフホスト型ヘッドレスCMSです。GitHub OAuth�
 - ⚡ **高速キャッシュ** - 並列処理による記事一覧の高速表示
 - 🛡️ **セキュリティ** - CSRF保護、パストラバーサル対策、入力検証
 
-> Issue #32 Phase 2で、Hugo Local Live Previewのlazy process起動、loopback port管理、`https://<site-id>.<preview-domain>/`からのreverse proxy、redirect補正、LiveReload/WebSocket中継まで追加しています。Phase 2では保存済みrepository contentを表示し、未保存editor入力のshadow workspace反映はPhase 3で追加します。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
+> Issue #32では、Phase 1/2でsite別hostnameのHugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。content配下のmedia upload/deleteもactive workspaceへ同期します。Local Previewを開く/停止するUIや状態表示はPhase 4で追加します。旧`/admin/preview/:site/*` path-prefix proxyは復活させません。
 
 ## クイックスタート
 
@@ -111,7 +111,7 @@ appは非rootで動作し、bind mountしたrepoを`chown`しません。mise to
 | 環境変数 | 説明 | デフォルト |
 |----------|------|-----------|
 | `GITHUB_CLIENT_ID` | GitHub OAuth Client ID | (必須) |
-| `GITHUB_CLIENT_SECRET` | GitHub OAuth Client Secret | (必須) |
+| `GITHUB_CLIENT_SECRET` | GitHub Client Secret | (必須) |
 | `SESSION_SECRET` | セッション暗号化キー | (自動生成・非推奨) |
 | `ALLOWED_GITHUB_USERS` | 許可するGitHubユーザー名(カンマ区切り) | (必須) |
 | `ALLOW_ALL_GITHUB_USERS` | 全GitHubユーザーを許可する開発用設定 | `false` |
@@ -149,7 +149,7 @@ appは非rootで動作し、bind mountしたrepoを`chown`しません。mise to
 
 - [ドキュメント一覧](docs/README.md) - 目的別の索引
 - [設定ガイド](docs/guides/configuration.md) - 詳細な設定オプション
-- [Local Live Preview設定ガイド](docs/guides/local-live-preview.md) - wildcard subdomain、閲覧制御、Host validation、Hugo runtime/proxy
+- [Local Live Preview設定ガイド](docs/guides/local-live-preview.md) - wildcard subdomain、閲覧制御、Hugo runtime、shadow workspace
 - [Docker + mise デプロイガイド](docs/guides/docker-mise-deployment.md) - secret-free bootstrapと非root appによる推奨デプロイ
 - [CMS設定](docs/reference/cms-config.md) - コレクションとフィールドの設定
 - [現行アーキテクチャ](docs/architecture/current-architecture.md) - 現在のシステム構成
@@ -172,6 +172,7 @@ hugo-cms/
 │   │   ├── api.go       # 記事API
 │   │   ├── auth.go      # 認証・CSRF
 │   │   ├── local_preview.go # preview hostname ingress
+│   │   ├── local_preview_content.go # shadow content update/release API
 │   │   ├── media.go     # メディアAPI
 │   │   ├── health.go    # ヘルスチェック
 │   │   └── errors.go    # エラーレスポンス
@@ -185,6 +186,7 @@ hugo-cms/
 │       ├── hugo_adapter.go # Hugoアダプター
 │       ├── local_preview_lifecycle.go # preview state/port reservation
 │       ├── local_preview_manager.go # Hugo preview process/proxy管理
+│       ├── local_preview_workspace.go # ephemeral shadow content管理
 │       └── media.go     # メディアファイル管理
 ├── docs/
 │   ├── guides/          # 設定・デプロイ手順
@@ -196,7 +198,7 @@ hugo-cms/
 │   └── js/
 │       ├── app.js       # メインアプリケーション
 │       ├── api.js       # APIクライアント
-│       ├── editor.js    # Markdownエディタ
+│       ├── editor.js    # Markdownエディタ/preview debounce
 │       └── ui.js        # UI操作
 ├── templates/           # HTMLテンプレート
 └── repo/                # Hugoサイト (デフォルト)

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -2,18 +2,21 @@
 
 ## ステータス
 
-Issue #32 Phase 1で設計・設定契約を確定し、設定model、derived URL、Host validation、process lifecycle/port reservationの基盤を実装した。
+Issue #32のLocal Live Previewは段階的に実装している。
 
-Phase 2ではHugoを対象に、generator processのlazy start/stop、readiness、loopback port retry、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継まで実装する。未保存editor stateをshadow workspaceへ反映する処理はPhase 3の責務として分離する。
+- Phase 1 (#33): 設定model、derived URL、Host validation、process lifecycle/port reservation
+- Phase 2 (#34): Hugo lazy start/stop、loopback port、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継
+- Phase 3: **shadow content workspace + editor debounce連携**
+- Phase 4: UI/運用導線
 
-Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えず、第3のpreview段階として追加する。
+Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えない。
 
 ```text
 Markdown本文プレビュー
-  -> generatorを実行しない即時確認
+  -> generatorを実行しない安全な即時確認
 
 Local Live Preview
-  -> 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
+  -> Hugo/theme/layout/shortcode/CSS/JSを使う編集中確認
 
 Deployment Preview
   -> remote buildした特定commitを公開前に最終確認
@@ -31,26 +34,18 @@ tech  -> https://tech.preview.example.com/
 daily -> https://daily.preview.example.com/
 ```
 
-DNSは`*.preview.example.com`のwildcardを想定し、site追加ごとのDNS変更を要求しない。
-
-TLS、wildcard certificate、DNS-01 challenge、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。
+DNSは`*.preview.example.com`のwildcardを想定する。TLS、wildcard certificate、DNS-01、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。
 
 ### 閲覧者認可
 
-wildcard DNSやHost validationは閲覧者認可ではない。Local Live Previewは未公開contentとrepository由来のJavaScriptを配信し得るため、**preview ingressは必ずCMSとは独立した閲覧制御の内側に置く**。
+wildcard DNSやHost validationは閲覧者認可ではない。Local Live Previewは未公開contentとrepository由来JavaScriptを配信し得るため、preview ingressは次のいずれかで保護する。
 
-許容する運用は次のいずれかとする。
+- Tailscale等のprivate networkからのみ到達可能にする
+- Internet reachableの場合はCloudflare Access等のpreview専用viewer authenticationを使う
 
-- Tailscale等のprivate networkからのみpreview ingressへ到達可能にする
-- Internet reachableにする場合は、Cloudflare Access等のpreview専用viewer authenticationを必須にする
-
-CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使わない。preview側で実行されるsite由来JavaScriptへCMS sessionを露出させないためである。
-
-hugo-cmsは外部ingressの認証方式そのものを実装・検出しないため、この要件はoperatorが満たすdeployment contractとする。preview hostnameのrequestはCMS session middlewareより前で処理し、preview contentへadmin sessionを渡さない。
+CMS session cookieを`*.preview.example.com`へ共有しない。preview hostname requestはCMS session middlewareより前で処理する。
 
 ## 設定契約
-
-全体既定値:
 
 ```env
 LOCAL_LIVE_PREVIEW_ENABLED=false
@@ -58,7 +53,7 @@ PREVIEW_DOMAIN=preview.example.com
 PREVIEW_SCHEME=https
 ```
 
-Site Registryでは全体既定値をoverrideできる。
+Site Registryではsite単位でoverrideできる。
 
 ```yaml
 sites:
@@ -70,82 +65,40 @@ sites:
         enabled: true
 ```
 
-`preview.local_preview.enabled`を省略した場合は`LOCAL_LIVE_PREVIEW_ENABLED`を継承する。
+有効siteのIDはlowercase DNS labelでなければならない。`<site-id>.<preview-domain>`全体も253文字以内の有効なDNS名である必要がある。
 
-Local Live Previewを有効にするsite IDはDNS labelとしてそのままhostnameへ使用するため、次を必須とする。
-
-- lowercase ASCII
-- `a-z`、`0-9`、`-`のみ
-- 先頭・末尾の`-`は禁止
-- 1〜63文字
-
-`PREVIEW_DOMAIN`はscheme、`*.`、path、portを含まないDNS名だけを受け付ける。`PREVIEW_SCHEME`は`http`または`https`だけを許可する。
-
-さらに`<site-id>.<preview-domain>`を連結したhostname全体がDNS名として有効で、253文字以内であることを必須とする。設定検証、URL生成、Host resolverは同じ制約を使用する。
-
-Site RegistryをAPIへ返す際、Local Live Previewが有効ならderived valueとして`preview.local_preview.url`を返す。URLはYAMLへ永続化しない。
+HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを受け付ける。non-standard external portは初期契約ではサポートしない。
 
 ## Host routing
 
 HTTP `Host`を`ResolveLocalPreviewHost`へ渡し、Site Registryに登録済みかつLocal Live Previewが有効なsiteだけへ解決する。
 
-許可例:
+preview namespaceに属するinvalid/unknown HostはCMS admin routeへfall throughさせず拒否する。Hostからrepository path、generator command、internal portを生成しない。
+
+## Hugo process lifecycle
+
+`LocalPreviewManager`がsiteごとのHugo processを管理する。
 
 ```text
-tech.preview.example.com
-tech.preview.example.com:443
+stopped -> starting -> ready -> stopping -> stopped
+                 \-> failed <-/
 ```
 
-拒否例:
-
-```text
-preview.example.com
-foo.tech.preview.example.com
-tech.preview.example.com.evil.example
-unknown.preview.example.com
-tech.example.com
-```
-
-preview namespaceに属するがinvalid/unknownなHostはCMS admin routeへfall throughさせず404相当で拒否する。Hostからrepository path、generator command、internal portを生成してはならない。Hostから得られる値はSite Registry lookup keyだけとする。
-
-## Generator process lifecycle
-
-`LocalPreviewManager`がPhase 1のstate machineを実processへ接続する。
-
-```text
-stopped
-  -> starting
-  -> ready
-  -> stopping
-  -> stopped
-
-starting/ready/stopping
-  -> failed
-
-failed
-  -> starting
-  -> stopped
-```
-
-### 起動契約
-
-- Local Live Previewは設定だけでCMS起動時に全siteを起動しない
-- 最初のpreview requestでlazy startする
-- Host validationとSite Registry lookupが成功する前にprocessを起動しない
-- Phase 2のruntime実装対象はHugoのみとする
-- generator processは`127.0.0.1`へだけbindする
-- generator portをhost/public interfaceへ直接公開しない
-- child processへ渡す環境変数は既存generator allowlistを使用する
-- CMSのOAuth/session/provider secretは継承させない
-- CMS shutdown時には起動済みprocessを停止し、終了を待つ
-- processが異常終了した場合は`failed`へ遷移し、次requestで再起動できる
+- 最初のpreview requestでlazy start
+- `127.0.0.1`だけへbind
+- internal port rangeは`14100-14999`
+- OS上のport availabilityをprobeし、bind/start raceでは有限回retry
+- child environmentはgenerator allowlistのみ
+- CMS shutdown開始後は新規lazy startを拒否
+- HTTP server drain後にchild processを停止
+- 異常終了後は次requestで再起動可能
 
 Hugoは概ね次相当で起動する。
 
 ```text
 hugo server
   --source .
-  --contentDir <content_dir>
+  --contentDir <content-dir>
   --bind 127.0.0.1
   --port <internal-port>
   --baseURL https://<site-id>.<preview-domain>/
@@ -154,82 +107,127 @@ hugo server
   --renderToMemory
   --buildDrafts
   --buildFuture
+  --buildExpired
   --watch
   --noHTTPCache
 ```
 
-HTTP previewでは`--liveReloadPort 80`を使用する。外部preview URLへinternal portを露出させない。
-
-### port allocation
-
-旧`hugo_server_port`のようなsiteごとの手動port指定をLocal Live Previewの標準契約にはしない。
-
-managerが内部rangeからsiteごとにportを予約する。
-
-```text
-14100-14999
-```
-
-予約候補はloopback bind可能性をprobeしてからprocessを起動する。probeとchild process bindの間のraceで起動に失敗した場合はslotを解放し、別portで有限回retryする。port番号は外部URLへ現れないため、retryしてもbrowser側URLは変化しない。
-
 ## Reverse proxy / LiveReload
 
-preview requestはpath prefixを追加・除去せず、そのままHugoへproxyする。
+preview requestはpathを書き換えずHugoへproxyする。
 
 ```text
 https://tech.preview.example.com/css/main.css
   -> http://127.0.0.1:<internal-port>/css/main.css
 ```
 
-これによりroot-relative CSS/JS/imageはsite自身のorigin root `/` のまま扱える。
+proxyはexternal Hostを保持し、`X-Forwarded-Host` / `X-Forwarded-Proto`を再構成する。内部`127.0.0.1:<port>` / `localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換える。HTTP Upgradeを透過してLiveReload WebSocketを通す。
 
-proxyは次を行う。
+## Phase 3: shadow content workspace
 
-- external Hostをupstream requestにも保持する
-- `X-Forwarded-Host` / `X-Forwarded-Proto`をCMS側で再構成する
-- internal `127.0.0.1:<port>` / `localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換える
-- unrelatedなexternal redirectは書き換えない
-- HTTP Upgradeを透過し、Hugo LiveReloadのWebSocketを通す
+### 目的
 
-## 編集中state: shadow content workspace
+editorの250ms debounce更新をproduction working treeへ直接書かず、CMS管理の一時content directoryへ反映する。
 
-### 決定
+```text
+Editor input
+  -> 250ms debounce
+  -> POST /admin/api/preview/local
+  -> shadow content directory
+  -> Hugo watcher
+  -> rebuild / LiveReload
+```
 
-Local Live Previewの未保存編集はproduction repositoryのworking treeへキー入力ごとに書き込まず、**shadow content workspace**へ反映する。
+既存の3秒autosaveは保存機能として残るが、Local Live Previewの更新経路自体はGit working treeへ書かない。
 
-Git worktreeをLocal Live Previewの基本方式にはしない。
+### workspace構成
 
-理由:
+初回update時にsiteの`content_dir`全体を一時directoryへmirrorする。
 
-- Live Previewはcommit/branchを必要としない編集UI機能であり、Git ref/index操作を増やす必要がない
-- Deployment Previewはすでにtemporary index + draft branchというGit境界を持っており、Live PreviewまでGit lifecycleへ結合しない方が責務が明確
-- 保存済みworking treeと未保存editor stateを分離できる
-- preview破棄時に一時directoryを削除するだけでcleanupできる
+```text
+OS temporary directory/
+  <site-id>/
+    <local-preview-session-id>/
+      content/
+        ... mirrored site content ...
+```
 
-### workspaceの内容
+Hugoのworking directory/source rootは元repositoryのまま維持するため、次は元repoから使用する。
 
-初期実装ではsiteの`content_dir`をshadow workspaceへmirrorし、editorの未保存変更はshadow側の記事だけへ適用する。generatorのsource、layout、theme、config、static/assets等は登録済みrepositoryを基準にする。
+- Hugo config
+- theme / layout
+- static
+- assets
+- modules
 
-Phase 2時点のHugo processは保存済みrepository contentを使用する。Phase 3でshadow content directoryをpreview commandへ渡し、editor変更をdebounce反映する。
+`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。これにより未保存contentとrepositoryのsite構造を分離する。
 
-shadow workspaceのrootはCMS管理領域に置き、site IDやarticle pathを直接filesystem pathとして連結せず既存のpath validationと同等の境界を設ける。
+workspaceは`PREVIEW_STATE_DIR`へ永続化しない。CMS processごとのephemeral stateであり、session releaseまたはCMS shutdown時に削除する。
 
-### 同一siteの複数editor
+### update ordering
 
-`<site-id>.<preview-domain>`はsiteごとに1つのhostnameなので、初期実装では**同一siteにつきactive Local Live Preview sessionを1つ**に制限する。別draft/tabから同時にshadow stateを更新しようとした場合は混在させず競合として拒否する。
+browserはLocal Preview専用session IDと単調増加`revision`を送る。
 
-将来、複数sessionを同一hostnameで安全にroutingする仕組みを導入する場合のみ、この制約を緩和する。
+- `revision == 0`は拒否
+- server側の現在revision以下のupdateはno-op
+- HTTP response順が逆転しても古いrequestは新しい内容を上書きしない
+- 対象記事はatomic replacementする
 
-## Phase 3への契約
+### session競合
 
-Phase 3は以下を実装する。
+初期実装では**同一siteにつきactive Local Live Preview sessionは1つ**とする。
 
-- shadow content workspace作成/同期/cleanup
-- editor変更のdebounce反映
-- Hugo watcherによる再build
-- 保存操作とshadow stateの同期
-- 同一site concurrent preview sessionの競合拒否
-- abnormal shutdown後のstale workspace cleanup
+- 同じsiteを別tab/sessionからupdate -> `409 Conflict`
+- active sessionと異なるarticle path -> conflict
+- 別siteは独立workspaceを持てる
+- stale tabは別tabのworkspaceをreleaseできない
+
+site/article切替では、browserがin-flight update完了を待ってからreleaseする。serverはHugo processを先に停止し、その後shadow directoryを削除する。
+
+### filesystem境界
+
+- article pathは既存`SafeJoin`境界で検証
+- shadow content copyではsymlinkを拒否
+- regular fileだけをmirror
+- target articleはtemporary fileからreplace
+- production contentはLocal Preview updateによって変更しない
+
+### 現時点の制約
+
+初回mirror後に**content directory内へ新規作成されたpage resource**（例: article bundleへ後からuploadした画像）は自動mirrorしない。既存resourceは初回mirrorに含まれる。Phase 3はまずeditor本文/front matterの未保存反映を対象とし、必要ならmedia upload/delete連携を後続で追加する。
+
+また、Hugo Modulesで`content`をcustom mountしているsiteはlegacy `contentDir`とは異なる解決経路を使う場合がある。実blog repositoryでのsmoke test後、必要ならmount-awareな方式を追加する。
+
+## API
+
+### editor state update
+
+```text
+POST /admin/api/preview/local
+```
+
+主なrequest fields:
+
+```json
+{
+  "draft_id": "<local-preview-session-id>",
+  "revision": 12,
+  "path": "posts/example.md",
+  "frontmatter": {"title": "Draft"},
+  "body": "editing...",
+  "format": "yaml"
+}
+```
+
+初回updateでworkspaceを作成した場合、保存済みcontentを使っていた既存Hugo processを一度停止する。次のpreview hostname requestがshadow `contentDir`でHugoをlazy startする。その後のupdateは同じdirectoryを書き換えるためHugo watcherが再buildする。
+
+### release
+
+```text
+POST /admin/api/preview/local/release
+```
+
+release時はHugo process停止後にworkspaceを削除する。次のpreview requestはactive shadow sessionがなければ保存済みrepository contentを使用する。
 
 ## Phase 4への契約
 
@@ -246,11 +244,8 @@ Phase 4は以下を実装する。
 - wildcard DNSはauthorizationではない
 - preview ingressにはprivate networkまたは独立viewer authenticationを必須とする
 - CMS session cookieをpreview subdomainと共有しない
-- unknown site IDは404相当で拒否する
-- Local Live Preview無効siteは起動しない
-- Host値をcommand/path/portへ直接変換しない
-- generatorは明示的に登録されたrepositoryだけで実行する
-- generator child environmentはallowlistし、CMS secretを渡さない
+- unknown site IDは拒否
+- generator child environmentはallowlist
 - internal generator serverはloopback bindのみ
 - TLS/DNS credentialをCMSへ要求しない
 - Local Live Previewはrepository内generator codeを実行するため、Markdown本文プレビューより広いtrust boundaryである

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -2,14 +2,14 @@
 
 ## ステータス
 
-Issue #32のLocal Live Previewは段階的に実装している。
+Issue #32のLocal Live Previewは段階的に実装する。
 
 - Phase 1 (#33): 設定model、derived URL、Host validation、process lifecycle/port reservation
 - Phase 2 (#34): Hugo lazy start/stop、loopback port、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継
-- Phase 3: **shadow content workspace + editor debounce連携**
+- Phase 3 (#35): shadow content workspace + editor debounce + content resource同期
 - Phase 4: UI/運用導線
 
-Local Live Previewは既存のMarkdown本文プレビュー、Deployment Previewを置き換えない。
+Local Live PreviewはMarkdown本文プレビューとDeployment Previewを置き換えず、両者の中間を担う。
 
 ```text
 Markdown本文プレビュー
@@ -22,9 +22,9 @@ Deployment Preview
   -> remote buildした特定commitを公開前に最終確認
 ```
 
-## URLとingress境界
+## URL / ingress / viewer authentication
 
-Local Live Previewはpath prefixではなくsiteごとのhostnameをorigin rootとして使用する。
+Local Live Previewはpath prefixではなくsiteごとのhostnameをorigin rootとして使う。
 
 ```text
 PREVIEW_DOMAIN=preview.example.com
@@ -34,26 +34,17 @@ tech  -> https://tech.preview.example.com/
 daily -> https://daily.preview.example.com/
 ```
 
-DNSは`*.preview.example.com`のwildcardを想定する。TLS、wildcard certificate、DNS-01、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。
+DNSは`*.preview.example.com`のwildcardを想定する。TLS、DNS-01、Cloudflare、Tailscale、Caddy/Traefik/Nginx等はpreview ingressの責務であり、hugo-cmsへ証明書秘密鍵やDNS provider credentialを持たせることを必須にしない。
 
-### 閲覧者認可
+wildcard DNSやHost validationは閲覧者認可ではない。preview ingressはTailscale等のprivate network内に置くか、Internet reachableならCloudflare Access等の独立viewer authenticationで保護する。CMS session cookieはpreview subdomainへ共有しない。
 
-wildcard DNSやHost validationは閲覧者認可ではない。Local Live Previewは未公開contentとrepository由来JavaScriptを配信し得るため、preview ingressは次のいずれかで保護する。
-
-- Tailscale等のprivate networkからのみ到達可能にする
-- Internet reachableの場合はCloudflare Access等のpreview専用viewer authenticationを使う
-
-CMS session cookieを`*.preview.example.com`へ共有しない。preview hostname requestはCMS session middlewareより前で処理する。
-
-## 設定契約
+## 設定 / Host routing
 
 ```env
 LOCAL_LIVE_PREVIEW_ENABLED=false
 PREVIEW_DOMAIN=preview.example.com
 PREVIEW_SCHEME=https
 ```
-
-Site Registryではsite単位でoverrideできる。
 
 ```yaml
 sites:
@@ -65,15 +56,9 @@ sites:
         enabled: true
 ```
 
-有効siteのIDはlowercase DNS labelでなければならない。`<site-id>.<preview-domain>`全体も253文字以内の有効なDNS名である必要がある。
+有効site IDはlowercase DNS labelで、`<site-id>.<preview-domain>`全体も253文字以内の有効DNS名でなければならない。
 
-HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを受け付ける。non-standard external portは初期契約ではサポートしない。
-
-## Host routing
-
-HTTP `Host`を`ResolveLocalPreviewHost`へ渡し、Site Registryに登録済みかつLocal Live Previewが有効なsiteだけへ解決する。
-
-preview namespaceに属するinvalid/unknown HostはCMS admin routeへfall throughさせず拒否する。Hostからrepository path、generator command、internal portを生成しない。
+HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを許可する。preview namespace内のinvalid/unknown HostはCMS admin routeへfall throughさせない。HostはSite Registry lookupにだけ使い、repository path、command、internal portへ変換しない。
 
 ## Hugo process lifecycle
 
@@ -84,10 +69,10 @@ stopped -> starting -> ready -> stopping -> stopped
                  \-> failed <-/
 ```
 
-- 最初のpreview requestでlazy start
+- preview hostnameへの最初のrequestでlazy start
 - `127.0.0.1`だけへbind
 - internal port rangeは`14100-14999`
-- OS上のport availabilityをprobeし、bind/start raceでは有限回retry
+- port probe後のbind raceでは有限回retry
 - child environmentはgenerator allowlistのみ
 - CMS shutdown開始後は新規lazy startを拒否
 - HTTP server drain後にchild processを停止
@@ -121,13 +106,13 @@ https://tech.preview.example.com/css/main.css
   -> http://127.0.0.1:<internal-port>/css/main.css
 ```
 
-proxyはexternal Hostを保持し、`X-Forwarded-Host` / `X-Forwarded-Proto`を再構成する。内部`127.0.0.1:<port>` / `localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換える。HTTP Upgradeを透過してLiveReload WebSocketを通す。
+external Hostを保持し、`X-Forwarded-Host` / `X-Forwarded-Proto`を再構成する。内部loopbackを指すabsolute `Location`だけをexternal preview originへ書き換え、HTTP Upgradeを透過してLiveReload WebSocketを通す。
 
 ## Phase 3: shadow content workspace
 
 ### 目的
 
-editorの250ms debounce更新をproduction working treeへ直接書かず、CMS管理の一時content directoryへ反映する。
+editorの約250ms debounce更新をproduction working treeへ直接書かず、CMS管理の一時content directoryへ反映する。
 
 ```text
 Editor input
@@ -138,11 +123,11 @@ Editor input
   -> rebuild / LiveReload
 ```
 
-既存の3秒autosaveは保存機能として残るが、Local Live Previewの更新経路自体はGit working treeへ書かない。
+既存の3秒autosaveは保存機能として残るが、Local Live Previewのupdate経路自体はGit working tree/index/refへ書かない。
 
-### workspace構成
+### workspace
 
-初回update時にsiteの`content_dir`全体を一時directoryへmirrorする。
+初回update時にsiteの`content_dir`全体をOS temporary directoryへmirrorする。
 
 ```text
 OS temporary directory/
@@ -152,51 +137,49 @@ OS temporary directory/
         ... mirrored site content ...
 ```
 
-Hugoのworking directory/source rootは元repositoryのまま維持するため、次は元repoから使用する。
+Hugoのworking directory/source rootは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。
 
-- Hugo config
-- theme / layout
-- static
-- assets
-- modules
+workspaceは`PREVIEW_STATE_DIR`へ永続化しない。session releaseまたはCMS shutdown時に削除する。
 
-`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。これにより未保存contentとrepositoryのsite構造を分離する。
-
-workspaceは`PREVIEW_STATE_DIR`へ永続化しない。CMS processごとのephemeral stateであり、session releaseまたはCMS shutdown時に削除する。
-
-### update ordering
+### editor update ordering
 
 browserはLocal Preview専用session IDと単調増加`revision`を送る。
 
 - `revision == 0`は拒否
-- server側の現在revision以下のupdateはno-op
-- HTTP response順が逆転しても古いrequestは新しい内容を上書きしない
-- 対象記事はatomic replacementする
+- serverの現在revision以下のupdateはno-op
+- response順が逆転しても古いrequestは新しい内容を上書きしない
+- 対象記事はtemporary fileからreplaceする
+
+### content resource同期
+
+初回mirrorにはarticle bundle内のpage resourceも含まれる。workspace作成後にCMS media APIでcontent directory配下へupload/deleteしたresourceは、active shadow workspaceへ同じ変更を同期する。
+
+static配下はHugoが元repositoryを直接参照するためshadow同期しない。media本体の保存が成功した後にpreview-only同期が失敗した場合、media APIを失敗扱いにはせずserver logへ残す。
 
 ### session競合
 
 初期実装では**同一siteにつきactive Local Live Preview sessionは1つ**とする。
 
-- 同じsiteを別tab/sessionからupdate -> `409 Conflict`
+- 同一siteへの別tab/session update -> `409 Conflict`
 - active sessionと異なるarticle path -> conflict
-- 別siteは独立workspaceを持てる
+- 別siteは独立workspaceを利用可能
 - stale tabは別tabのworkspaceをreleaseできない
 
-site/article切替では、browserがin-flight update完了を待ってからreleaseする。serverはHugo processを先に停止し、その後shadow directoryを削除する。
+article/site切替ではbrowserがin-flight update完了を待ってreleaseする。serverはHugo processを先に停止し、その後shadow directoryを削除する。
+
+ブラウザtabを切替操作なしで閉じた場合の確実なlease解放はPhase 4の停止UI/lease運用で扱う。それまではCMS shutdownで全workspaceをcleanupする。
 
 ### filesystem境界
 
-- article pathは既存`SafeJoin`境界で検証
-- shadow content copyではsymlinkを拒否
+- article/resource pathは既存`SafeJoin`境界で検証
+- shadow initial copyではsymlinkを拒否
 - regular fileだけをmirror
-- target articleはtemporary fileからreplace
 - production contentはLocal Preview updateによって変更しない
+- site IDとsession IDは事前validation済みの値だけをworkspace pathに使用する
 
-### 現時点の制約
+### Hugo Modules
 
-初回mirror後に**content directory内へ新規作成されたpage resource**（例: article bundleへ後からuploadした画像）は自動mirrorしない。既存resourceは初回mirrorに含まれる。Phase 3はまずeditor本文/front matterの未保存反映を対象とし、必要ならmedia upload/delete連携を後続で追加する。
-
-また、Hugo Modulesで`content`をcustom mountしているsiteはlegacy `contentDir`とは異なる解決経路を使う場合がある。実blog repositoryでのsmoke test後、必要ならmount-awareな方式を追加する。
+Hugo Modulesで`content`をcustom mountしているsiteはlegacy `contentDir`とは異なる解決経路を使う場合がある。実blog repositoryでのsmoke test後、必要ならmount-aware方式を追加する。
 
 ## API
 
@@ -205,8 +188,6 @@ site/article切替では、browserがin-flight update完了を待ってからrel
 ```text
 POST /admin/api/preview/local
 ```
-
-主なrequest fields:
 
 ```json
 {
@@ -219,7 +200,7 @@ POST /admin/api/preview/local
 }
 ```
 
-初回updateでworkspaceを作成した場合、保存済みcontentを使っていた既存Hugo processを一度停止する。次のpreview hostname requestがshadow `contentDir`でHugoをlazy startする。その後のupdateは同じdirectoryを書き換えるためHugo watcherが再buildする。
+初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存Hugo processを一度停止する。次のpreview hostname requestでshadow `contentDir`を使ってlazy startし、その後はHugo watcherが変更を拾う。
 
 ### release
 
@@ -227,14 +208,13 @@ POST /admin/api/preview/local
 POST /admin/api/preview/local/release
 ```
 
-release時はHugo process停止後にworkspaceを削除する。次のpreview requestはactive shadow sessionがなければ保存済みrepository contentを使用する。
+release時はHugo process停止後にworkspaceを削除する。active shadow sessionがなければ次のpreview requestは保存済みrepository contentを使う。
 
 ## Phase 4への契約
 
-Phase 4は以下を実装する。
-
-- Local Live Preview表示/新規tab導線
-- starting/ready/failed状態表示
+- Local Live Previewを開く/新規tab導線
+- starting / ready / failed状態表示
+- Local Previewの明示停止とstale session recovery/lease方針
 - private network/Tailscale運用例
 - wildcard DNS / TLS ingress構成例
 - Deployment Previewとの役割差のUI明記

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32 Phase 1ではLocal Live Previewの設定model、derived URL、Host validation、process lifecycle/port reservation基盤まで実装済みです。generator serverの実起動、reverse proxy、LiveReload、editor連携はPhase 2以降で実装します。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。明示的なopen/stop UIと状態表示はPhase 4で追加します。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,6 +1,6 @@
 # Local Live Preview設定ガイド
 
-> Issue #32 Phase 2では、Hugo preview processのlazy start/stop、loopback port allocation、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継まで実装します。未保存editor stateをshadow workspaceへ反映する処理はPhase 3で実装します。
+> Issue #32ではPhase 1/2までmainへmerge済みです。Phase 3では、editorの未保存内容をproduction working treeとは別のshadow content workspaceへdebounce反映し、Hugo watcher/LiveReloadへつなぎます。
 
 ## 基本設定
 
@@ -18,20 +18,9 @@ PREVIEW_SCHEME=https
 https://tech.preview.example.com/
 ```
 
-`PREVIEW_DOMAIN`には`*.`、scheme、path、portを含めません。
-
-```text
-OK: preview.example.com
-NG: *.preview.example.com
-NG: https://preview.example.com
-NG: preview.example.com:443
-```
-
-`PREVIEW_SCHEME`は`http`または`https`だけを使用できます。
+`PREVIEW_DOMAIN`には`*.`、scheme、path、portを含めません。`PREVIEW_SCHEME`は`http`または`https`だけを使用できます。
 
 ## Site Registry
-
-`LOCAL_LIVE_PREVIEW_ENABLED`はsite全体の既定値です。site単位でoverrideできます。
 
 ```yaml
 default_site: tech
@@ -51,80 +40,34 @@ sites:
         enabled: false
 ```
 
-有効なsiteについて、`GET /admin/api/sites`のsite設定にはderived valueとして次のようなURLが含まれます。
+`preview.local_preview.enabled`を省略すると`LOCAL_LIVE_PREVIEW_ENABLED`を継承します。有効siteの`GET /admin/api/sites`にはderived `preview.local_preview.url`が含まれます。URLはSite Registryへ永続化しません。
 
-```json
-{
-  "preview": {
-    "local_preview": {
-      "enabled": true,
-      "url": "https://tech.preview.example.com/"
-    }
-  }
-}
-```
+## hostname制約
 
-`url`は`sites.yml`へ保存する値ではありません。
+Local Live Previewで有効にするsite IDはlowercase DNS labelとして有効でなければなりません。`<site-id>.<preview-domain>`全体も253文字以内の有効なDNS名である必要があります。
 
-## site ID / hostname制約
+HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを許可します。non-standard external portはサポートしません。
 
-Local Live Previewで有効にするsite IDは、そのままDNS labelになります。
+## wildcard DNS / TLS / viewer authentication
 
-許可例:
-
-```text
-tech
-daily-blog
-blog2
-```
-
-拒否例:
-
-```text
-Tech
-foo.bar
--tech
-tech-
-tech_blog
-```
-
-Local Live Previewを無効にしているsiteにはこのDNS label制約を追加しません。
-
-site ID単体だけでなく、`<site-id>.<preview-domain>`を連結したhostname全体も有効なDNS名で、253文字以内である必要があります。設定検証、URL生成、Host resolverは同じ制約を使用します。
-
-## wildcard DNS / TLS
-
-想定DNSは1レコードです。
+想定DNS:
 
 ```text
 *.preview.example.com -> preview ingress
 ```
 
-site追加ごとにDNS recordを追加する必要はありません。
-
-hugo-cms自身はTLS certificateやDNS provider credentialを管理しません。たとえば以下の構成を利用できます。
+hugo-cms自身はTLS certificateやDNS provider credentialを管理しません。たとえば次の運用を利用できます。
 
 - Tailscale内だけでpreview ingressへ到達可能にする
-- DNS-01 challengeで`*.preview.example.com`のwildcard certificateを取得する
+- DNS-01で`*.preview.example.com`のwildcard certificateを取得する
 - Caddy / Traefik / NginxでTLS terminateする
-- 必要に応じてCloudflare等を利用する
+- 必要に応じてCloudflareを利用する
 
-これらは外部ingressの責務です。
+**wildcard DNSとHost validationは閲覧者認可ではありません。** preview ingressはprivate network内に置くか、Internet reachableならCloudflare Access等の独立viewer authenticationで保護してください。
 
-## 閲覧者認可
+CMS session cookieを`*.preview.example.com`へ共有して認証に使わないでください。
 
-**wildcard DNSとHost validationは閲覧者認可ではありません。** Local Live Previewには未公開contentが含まれ、site repository由来のJavaScriptも実行され得るため、preview ingressは必ず独立したアクセス制御の内側に置いてください。
-
-次のいずれかを必須とします。
-
-- Tailscale等のprivate networkからのみ到達可能にする
-- Internet reachableにする場合はCloudflare Access等のpreview専用viewer authenticationで保護する
-
-CMSの既存session cookieを`*.preview.example.com`へ共有して認証に使わないでください。preview site由来のJavaScriptへCMS sessionを露出させないためです。
-
-hugo-cmsは外部ingressの認証方式を自動検出・設定しません。この閲覧制御はdeployment時にoperatorが満たす契約です。
-
-## Host validation / routing
+## Host routing
 
 `PREVIEW_DOMAIN=preview.example.com`の場合、次を許可します。
 
@@ -133,36 +76,26 @@ tech.preview.example.com
 tech.preview.example.com:443
 ```
 
-次はpreview namespaceとして受け取ってもsiteへ解決せず404相当で拒否します。
+次はpreview namespaceとしてfail closedします。
 
 ```text
 preview.example.com
 foo.tech.preview.example.com
 unknown.preview.example.com
+tech.preview.example.com:8443
 tech.preview.example.com:evil
 ```
 
-次はpreview namespace外なので通常のCMS routingへ進みます。
-
-```text
-cms.example.com
-tech.preview.example.com.evil.example
-```
-
-Hostからrepository path、generator command、internal portを作ることはありません。Site Registryに登録されたsite IDとのlookupだけに使用します。
-
-preview hostnameのrequestはCMS session middlewareより前で処理されるため、CMS admin cookieをpreview siteへ渡しません。
+Hostからrepository path、generator command、internal portを作ることはありません。Site Registry lookupだけに使用します。
 
 ## Hugo process
 
-Phase 2のLocal Live Preview runtimeはHugoを対象にします。最初のpreview requestが来た時点でsiteごとのHugo serverをlazy startします。CMS起動時に全siteを常駐起動しません。
-
-概ね次のflagsを使用します。
+最初のpreview hostname requestでsiteごとのHugo serverをlazy startします。
 
 ```text
 hugo server
   --source .
-  --contentDir <content_dir>
+  --contentDir <content-dir>
   --bind 127.0.0.1
   --port <internal-port>
   --baseURL https://tech.preview.example.com/
@@ -171,72 +104,99 @@ hugo server
   --renderToMemory
   --buildDrafts
   --buildFuture
+  --buildExpired
   --watch
   --noHTTPCache
 ```
 
-HTTP previewでは`--liveReloadPort 80`を使用します。
+Hugoは`127.0.0.1`だけへbindします。内部portは`14100-14999`から自動予約し、起動raceでは別portで有限回retryします。child environmentは既存generator allowlistを使用し、CMS secretを継承しません。
 
-Hugo serverは`127.0.0.1`だけへbindし、外部からinternal portへ直接接続させません。CMS shutdown時には起動済みprocessを停止します。異常終了したprocessはfailed状態となり、次のpreview requestで再起動できます。
+CMS shutdown開始後は新規preview processを起動せず、HTTP serverをdrainしてからchild processを停止します。
 
-child processのenvironmentは既存generator allowlistを使うため、`SESSION_SECRET`、GitHub OAuth secret、deployment provider token等をそのまま継承しません。
+## Reverse proxy / LiveReload
 
-## 内部port
-
-初期の自動予約範囲は次です。
-
-```text
-14100-14999
-```
-
-managerは候補portがloopbackで利用可能かprobeしてからHugoを起動します。probeとHugo bindの間にraceがあり得るため、起動失敗時はslotを解放し、別portで有限回retryします。
-
-内部portはpreview URLに現れません。
-
-## Reverse proxy / asset / redirect
-
-preview requestにはpath prefixを付けません。
+preview requestはpath prefixを書き換えません。
 
 ```text
 https://tech.preview.example.com/css/main.css
+  -> http://127.0.0.1:<internal-port>/css/main.css
 ```
 
-は内部では次へproxyされます。
+内部upstreamを指すabsolute `Location`だけを外部preview originへ補正します。HTTP Upgradeも透過するため、Hugo LiveReload WebSocketを同じhostnameで利用できます。
+
+## Phase 3: 未保存editor内容
+
+### 動作
+
+Local Live Previewが有効なsiteでは、editor変更を約250ms debounceして次のAPIへ送ります。
 
 ```text
-http://127.0.0.1:<internal-port>/css/main.css
+POST /admin/api/preview/local
 ```
 
-そのため、`/css/...`、`/images/...`、`/js/...`のようなroot-relative URLを旧path-prefix方式のようにrewriteする必要がありません。
+初回update時にrepositoryの`content_dir`をOS temporary directoryへmirrorし、対象記事だけshadow側へ反映します。
 
-Hugoが内部`127.0.0.1:<port>`または`localhost:<port>`を指すabsolute `Location`を返した場合だけ、CMSが外部preview originへ書き換えます。外部siteへのredirectは変更しません。
+```text
+Editor
+  -> 250ms debounce
+  -> shadow content workspace
+  -> Hugo watcher
+  -> rebuild / LiveReload
+```
 
-HTTP Upgradeもproxyするため、Hugo LiveReloadのWebSocketを同じpreview hostnameで利用できます。
+Hugoのsource rootは元repositoryのままなので、theme/layout/config/static/assetsは通常どおり元repoを利用します。`--contentDir`だけshadow directoryのabsolute pathへ切り替えます。
 
-## 旧preview設定との違い
+既存の3秒autosaveは保存機能として残りますが、250msのLocal Preview update経路はproduction working treeへ書き込みません。
 
-`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`はIssue #30以前のpath-prefix preview用legacy設定です。新Local Live Previewの公開URL・port管理には使用しません。
+### revision
 
-旧方式:
+各Local Preview updateには単調増加`revision`を付けます。network responseの順序が逆転しても、serverは現在revision以下の古いupdateを適用しません。
+
+### tab / draft競合
+
+初期実装では同一siteにつきactive Local Live Preview sessionは1つです。
+
+別tabから同じsiteを編集し始めた場合、後から来たsessionは`409 Conflict`となり、既存workspaceを上書きしません。別siteは独立して利用できます。
+
+### article/site切替
+
+記事またはsiteを切り替える際は、in-flight update完了を待ってからLocal Preview sessionをreleaseします。
+
+releaseは次の順で行います。
+
+```text
+Hugo process stop
+  -> shadow workspace delete
+```
+
+これによりHugo watcherが参照中のdirectoryを先に削除しません。
+
+CMS shutdownでもHugo child停止後にtemporary workspaceをcleanupします。
+
+### workspaceの永続性
+
+shadow workspaceは`PREVIEW_STATE_DIR`へ保存しません。CMS process単位のephemeral temporary directoryです。Git branch/ref/indexも使用しません。
+
+### page resourceの注意
+
+workspace作成時点のcontent directoryはresource画像等も含めてmirrorされます。ただしworkspace作成後にarticle bundleへ新規upload/deleteしたpage resourceはPhase 3初期実装では自動同期しません。必要性を実環境で確認後、media API連携として追加します。
+
+Hugo Modulesでcontentをcustom mountしているsiteも実blog repositoryでのsmoke test対象です。必要ならmount-awareなpreview方式を追加します。
+
+## 旧preview方式との違い
+
+旧設定`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`はIssue #30以前のpath-prefix preview用です。新Local Live Previewには使用しません。
+
+旧:
 
 ```text
 /admin/preview/tech/...
 ```
 
-新方式:
+新:
 
 ```text
 https://tech.preview.example.com/...
 ```
-
-root-relative assetやLiveReloadがsite自身のorigin rootで動作できることが新方式の重要な違いです。
-
-## 編集中データ
-
-Phase 1で、未保存editor stateはproduction working treeやGit worktreeへ書かず、**shadow content workspace**へ反映する方針を確定しました。
-
-Phase 2のHugo processは保存済みrepository contentを表示します。workspaceの作成・同期・cleanupとeditor debounce連携はPhase 3で実装します。
-
-初期契約では同一siteのactive Local Live Preview sessionは1つに制限し、別tab/draftから同時更新された場合は混在させず競合として扱います。
 
 詳細は[Local Live Preview設計](../architecture/local-live-preview-design.md)を参照してください。

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,10 +1,8 @@
 # Local Live Preview設定ガイド
 
-> Issue #32ではPhase 1/2までmainへmerge済みです。Phase 3では、editorの未保存内容をproduction working treeとは別のshadow content workspaceへdebounce反映し、Hugo watcher/LiveReloadへつなぎます。
+> Issue #32ではPhase 1/2がmainへmerge済みです。Phase 3 (#35)では、editorの未保存内容をproduction working treeとは別のshadow content workspaceへdebounce反映し、Hugo watcher/LiveReloadへつなぎます。
 
 ## 基本設定
-
-Local Live PreviewのURLはsite IDと共通preview domainから自動生成します。
 
 ```env
 LOCAL_LIVE_PREVIEW_ENABLED=true
@@ -12,13 +10,13 @@ PREVIEW_DOMAIN=preview.example.com
 PREVIEW_SCHEME=https
 ```
 
-`tech` siteなら次のURLになります。
+`tech` siteならpreview URLは次になります。
 
 ```text
 https://tech.preview.example.com/
 ```
 
-`PREVIEW_DOMAIN`には`*.`、scheme、path、portを含めません。`PREVIEW_SCHEME`は`http`または`https`だけを使用できます。
+`PREVIEW_DOMAIN`には`*.`、scheme、path、portを含めません。`PREVIEW_SCHEME`は`http`または`https`だけです。
 
 ## Site Registry
 
@@ -31,22 +29,11 @@ sites:
     preview:
       local_preview:
         enabled: true
-
-  - id: daily
-    repo_path: /data/repos/daily-blog
-    generator: hugo
-    preview:
-      local_preview:
-        enabled: false
 ```
 
-`preview.local_preview.enabled`を省略すると`LOCAL_LIVE_PREVIEW_ENABLED`を継承します。有効siteの`GET /admin/api/sites`にはderived `preview.local_preview.url`が含まれます。URLはSite Registryへ永続化しません。
+`preview.local_preview.enabled`を省略すると`LOCAL_LIVE_PREVIEW_ENABLED`を継承します。有効siteの`GET /admin/api/sites`にはderived `preview.local_preview.url`が含まれます。
 
-## hostname制約
-
-Local Live Previewで有効にするsite IDはlowercase DNS labelとして有効でなければなりません。`<site-id>.<preview-domain>`全体も253文字以内の有効なDNS名である必要があります。
-
-HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを許可します。non-standard external portはサポートしません。
+有効site IDはlowercase DNS labelで、`<site-id>.<preview-domain>`全体も253文字以内の有効DNS名である必要があります。
 
 ## wildcard DNS / TLS / viewer authentication
 
@@ -56,27 +43,20 @@ HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけ�
 *.preview.example.com -> preview ingress
 ```
 
-hugo-cms自身はTLS certificateやDNS provider credentialを管理しません。たとえば次の運用を利用できます。
+TLS certificate、DNS-01、Cloudflare、Tailscale、Caddy/Traefik/Nginx等は外部preview ingressの責務です。
 
-- Tailscale内だけでpreview ingressへ到達可能にする
-- DNS-01で`*.preview.example.com`のwildcard certificateを取得する
-- Caddy / Traefik / NginxでTLS terminateする
-- 必要に応じてCloudflareを利用する
-
-**wildcard DNSとHost validationは閲覧者認可ではありません。** preview ingressはprivate network内に置くか、Internet reachableならCloudflare Access等の独立viewer authenticationで保護してください。
-
-CMS session cookieを`*.preview.example.com`へ共有して認証に使わないでください。
+**wildcard DNSとHost validationは閲覧者認可ではありません。** Tailscale等のprivate network内に置くか、Internet reachableならCloudflare Access等の独立viewer authenticationで保護してください。CMS session cookieをpreview subdomainへ共有しません。
 
 ## Host routing
 
-`PREVIEW_DOMAIN=preview.example.com`の場合、次を許可します。
+HTTPSでは次を許可します。
 
 ```text
 tech.preview.example.com
 tech.preview.example.com:443
 ```
 
-次はpreview namespaceとしてfail closedします。
+次はfail closedします。
 
 ```text
 preview.example.com
@@ -86,11 +66,11 @@ tech.preview.example.com:8443
 tech.preview.example.com:evil
 ```
 
-Hostからrepository path、generator command、internal portを作ることはありません。Site Registry lookupだけに使用します。
+HTTP設定ではport省略または`:80`だけを許可します。HostはSite Registry lookupにだけ使います。
 
 ## Hugo process
 
-最初のpreview hostname requestでsiteごとのHugo serverをlazy startします。
+最初のpreview hostname requestでHugo serverをlazy startします。
 
 ```text
 hugo server
@@ -109,32 +89,30 @@ hugo server
   --noHTTPCache
 ```
 
-Hugoは`127.0.0.1`だけへbindします。内部portは`14100-14999`から自動予約し、起動raceでは別portで有限回retryします。child environmentは既存generator allowlistを使用し、CMS secretを継承しません。
+内部portは`14100-14999`から予約します。Hugoはloopbackだけへbindし、child environmentはgenerator allowlistを使います。
 
 CMS shutdown開始後は新規preview processを起動せず、HTTP serverをdrainしてからchild processを停止します。
 
 ## Reverse proxy / LiveReload
 
-preview requestはpath prefixを書き換えません。
+path prefixは追加しません。
 
 ```text
 https://tech.preview.example.com/css/main.css
   -> http://127.0.0.1:<internal-port>/css/main.css
 ```
 
-内部upstreamを指すabsolute `Location`だけを外部preview originへ補正します。HTTP Upgradeも透過するため、Hugo LiveReload WebSocketを同じhostnameで利用できます。
+内部upstreamを指すabsolute `Location`だけを外部preview originへ補正し、HTTP Upgradeを透過してLiveReload WebSocketを通します。
 
 ## Phase 3: 未保存editor内容
 
-### 動作
-
-Local Live Previewが有効なsiteでは、editor変更を約250ms debounceして次のAPIへ送ります。
+Local Live Previewが有効なsiteでは、editor変更を約250ms debounceして次へ送ります。
 
 ```text
 POST /admin/api/preview/local
 ```
 
-初回update時にrepositoryの`content_dir`をOS temporary directoryへmirrorし、対象記事だけshadow側へ反映します。
+初回update時にrepositoryの`content_dir`をOS temporary directoryへmirrorします。
 
 ```text
 Editor
@@ -144,59 +122,64 @@ Editor
   -> rebuild / LiveReload
 ```
 
-Hugoのsource rootは元repositoryのままなので、theme/layout/config/static/assetsは通常どおり元repoを利用します。`--contentDir`だけshadow directoryのabsolute pathへ切り替えます。
+Hugoのsource rootは元repositoryのままです。theme/layout/config/static/assets/modulesは元repoを利用し、`--contentDir`だけshadow directoryのabsolute pathへ切り替えます。
 
-既存の3秒autosaveは保存機能として残りますが、250msのLocal Preview update経路はproduction working treeへ書き込みません。
+既存の3秒autosaveは保存機能として残りますが、Local Previewの250ms update経路はproduction working tree/Git index/refへ書き込みません。
 
 ### revision
 
-各Local Preview updateには単調増加`revision`を付けます。network responseの順序が逆転しても、serverは現在revision以下の古いupdateを適用しません。
+各updateには単調増加`revision`を付けます。serverは現在revision以下の古いrequestをno-opにするため、network順序が逆転しても古い本文で上書きされません。
+
+### article bundle resource
+
+workspace作成時点のcontent resourceは初回mirrorに含まれます。その後CMS media APIでcontent directory配下へupload/deleteした画像等もactive shadow workspaceへ同期します。
+
+static配下は元repositoryをHugoが直接参照するためshadow同期しません。media本体の保存成功後にpreview同期だけ失敗した場合は、media操作を失敗扱いにせずserver logへ記録します。
 
 ### tab / draft競合
 
-初期実装では同一siteにつきactive Local Live Preview sessionは1つです。
+初期実装では同一siteにつきactive Local Live Preview sessionは1つです。別tab/sessionから同siteを更新すると`409 Conflict`となり、既存workspaceを上書きしません。別siteは独立して利用できます。
 
-別tabから同じsiteを編集し始めた場合、後から来たsessionは`409 Conflict`となり、既存workspaceを上書きしません。別siteは独立して利用できます。
+### article/site切替とcleanup
 
-### article/site切替
-
-記事またはsiteを切り替える際は、in-flight update完了を待ってからLocal Preview sessionをreleaseします。
-
-releaseは次の順で行います。
+article/site切替時はin-flight update完了を待ってsessionをreleaseします。
 
 ```text
 Hugo process stop
   -> shadow workspace delete
 ```
 
-これによりHugo watcherが参照中のdirectoryを先に削除しません。
+CMS shutdownでもHugo child停止後にtemporary workspaceを削除します。workspaceは`PREVIEW_STATE_DIR`へ永続化しません。
 
-CMS shutdownでもHugo child停止後にtemporary workspaceをcleanupします。
+ブラウザtabを切替操作なしで閉じた場合の確実なreleaseはPhase 4の明示停止/lease recoveryで扱います。
 
-### workspaceの永続性
+### Hugo Modules
 
-shadow workspaceは`PREVIEW_STATE_DIR`へ保存しません。CMS process単位のephemeral temporary directoryです。Git branch/ref/indexも使用しません。
+Hugo Modulesで`content`をcustom mountしているsiteは実blog repositoryでsmoke testしてください。必要ならmount-awareなpreview方式を追加します。
 
-### page resourceの注意
+## API
 
-workspace作成時点のcontent directoryはresource画像等も含めてmirrorされます。ただしworkspace作成後にarticle bundleへ新規upload/deleteしたpage resourceはPhase 3初期実装では自動同期しません。必要性を実環境で確認後、media API連携として追加します。
+editor update:
 
-Hugo Modulesでcontentをcustom mountしているsiteも実blog repositoryでのsmoke test対象です。必要ならmount-awareなpreview方式を追加します。
+```text
+POST /admin/api/preview/local
+```
+
+release:
+
+```text
+POST /admin/api/preview/local/release
+```
+
+両方とも既存admin auth + CSRF境界の内側です。
 
 ## 旧preview方式との違い
 
-旧設定`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`はIssue #30以前のpath-prefix preview用です。新Local Live Previewには使用しません。
-
-旧:
+`PREVIEW_URL`、`HUGO_SERVER_PORT`、`HUGO_SERVER_BIND`はIssue #30以前のpath-prefix preview用legacy設定で、新Local Live Previewには使用しません。
 
 ```text
-/admin/preview/tech/...
-```
-
-新:
-
-```text
-https://tech.preview.example.com/...
+旧: /admin/preview/tech/...
+新: https://tech.preview.example.com/...
 ```
 
 詳細は[Local Live Preview設計](../architecture/local-live-preview-design.md)を参照してください。

--- a/main.go
+++ b/main.go
@@ -120,6 +120,8 @@ func SetupRouter() (*gin.Engine, error) {
 			{
 				api.GET("/csrf-token", handlers.GetCSRFToken) // Endpoint to get CSRF token
 				api.POST("/preview/markdown", handlers.RenderMarkdownPreview)
+				api.POST("/preview/local", handlers.UpdateLocalPreviewContent)
+				api.POST("/preview/local/release", handlers.ReleaseLocalPreviewContent)
 				api.POST("/preview/deployments", handlers.UpdateDeploymentPreview)
 				api.GET("/preview/deployments/:draft_id", handlers.GetDeploymentPreview)
 				api.POST("/preview/deployments/:draft_id/retry", handlers.RetryDeploymentPreview)
@@ -173,6 +175,11 @@ func main() {
 		slog.Error("Invalid generator configuration", "error", err)
 		os.Exit(1)
 	}
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		slog.Error("Failed to initialize local preview workspace", "error", err)
+		os.Exit(1)
+	}
 
 	appURL := config.GetAppURL()
 	slog.Info("Starting server",
@@ -217,6 +224,11 @@ func main() {
 		slog.Error("Failed to stop local preview processes cleanly", "error", err)
 	}
 	cancelPreview()
+
+	// Child Hugo processes are stopped before removing their contentDir.
+	if err := workspaceManager.Shutdown(); err != nil {
+		slog.Error("Failed to remove local preview shadow workspace", "error", err)
+	}
 
 	slog.Info("Server exiting")
 }

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -31,6 +31,18 @@ func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc 
 			return
 		}
 
+		// Phase 3 keeps unsaved editor content outside the production working
+		// tree. If this site has an active shadow workspace, point Hugo's
+		// contentDir at it while leaving configuration/theme/layout/static files
+		// rooted in the original repository.
+		if workspaceManager, workspaceErr := services.DefaultLocalPreviewWorkspaceManager(); workspaceErr == nil {
+			if workspace, ok := workspaceManager.Active(site.ID); ok {
+				site.ContentDir = workspace.ContentDir
+			}
+		} else {
+			slog.Warn("Local preview shadow workspace unavailable; serving saved content", "site", site.ID, "error", workspaceErr)
+		}
+
 		if err := manager.Proxy(c.Writer, c.Request, site); err != nil {
 			slog.Error("Local preview proxy failed", "site", site.ID, "error", err)
 			if !c.Writer.Written() {

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -92,9 +92,9 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status":    "updated",
-		"applied":   applied,
-		"revision":  workspace.Revision,
+		"status":      "updated",
+		"applied":     applied,
+		"revision":    workspace.Revision,
 		"preview_url": runtime.LocalPreview.URL,
 	})
 }
@@ -116,6 +116,26 @@ func ReleaseLocalPreviewContent(c *gin.Context) {
 		ErrorInternal(c, "Local preview workspace is unavailable")
 		return
 	}
+	workspace, active := workspaceManager.Active(runtime.ID)
+	if !active {
+		c.JSON(http.StatusOK, gin.H{"status": "released", "released": false})
+		return
+	}
+	if workspace.DraftID != req.DraftID {
+		ErrorConflict(c, services.ErrLocalPreviewSessionConflict.Error())
+		return
+	}
+
+	// Hugo may be watching files inside the shadow directory. Stop it before
+	// removing contentDir so shutdown cannot race filesystem cleanup.
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
+	cancel()
+	if stopErr != nil {
+		ErrorInternal(c, "Failed to stop Local Live Preview process")
+		return
+	}
+
 	released, err := workspaceManager.Release(runtime.ID, req.DraftID)
 	if err != nil {
 		if errors.Is(err, services.ErrLocalPreviewSessionConflict) {
@@ -125,15 +145,5 @@ func ReleaseLocalPreviewContent(c *gin.Context) {
 		ErrorBadRequest(c, err.Error())
 		return
 	}
-	if released {
-		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
-		stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
-		cancel()
-		if stopErr != nil {
-			ErrorInternal(c, "Failed to stop Local Live Preview process")
-			return
-		}
-	}
-
 	c.JSON(http.StatusOK, gin.H{"status": "released", "released": released})
 }

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"hugo-cms/pkg/services"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type localPreviewContentRequest struct {
+	DraftID     string                 `json:"draft_id"`
+	Revision    uint64                 `json:"revision"`
+	Path        string                 `json:"path"`
+	Content     string                 `json:"content,omitempty"`
+	FrontMatter map[string]interface{} `json:"frontmatter,omitempty"`
+	Body        string                 `json:"body,omitempty"`
+	Format      string                 `json:"format,omitempty"`
+}
+
+type localPreviewReleaseRequest struct {
+	DraftID string `json:"draft_id"`
+}
+
+func UpdateLocalPreviewContent(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	if runtime.LocalPreview.Enabled == nil || !*runtime.LocalPreview.Enabled {
+		ErrorConflict(c, "Local Live Preview is disabled for this site")
+		return
+	}
+	generator := strings.TrimSpace(runtime.Generator)
+	if generator != "" && !strings.EqualFold(generator, "hugo") {
+		ErrorConflict(c, "Local Live Preview currently supports Hugo only")
+		return
+	}
+
+	var req localPreviewContentRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ErrorBadRequest(c, "Invalid JSON")
+		return
+	}
+	if strings.TrimSpace(req.Path) == "" || strings.TrimSpace(req.DraftID) == "" || req.Revision == 0 {
+		ErrorBadRequest(c, "path, draft_id, and positive revision are required")
+		return
+	}
+
+	var finalContent []byte
+	if req.FrontMatter != nil {
+		finalContent, err = services.ConstructFileContent(req.FrontMatter, req.Body, req.Format)
+		if err != nil {
+			ErrorBadRequest(c, "Failed to construct preview content: "+err.Error())
+			return
+		}
+	} else {
+		finalContent = []byte(req.Content)
+	}
+
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	workspace, created, applied, err := workspaceManager.Update(runtime, req.DraftID, req.Path, req.Revision, finalContent)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrLocalPreviewSessionConflict), errors.Is(err, services.ErrLocalPreviewSessionMismatch):
+			ErrorConflict(c, err.Error())
+		default:
+			ErrorBadRequest(c, err.Error())
+		}
+		return
+	}
+
+	if created {
+		// A preview process may already be serving the repository content. Stop
+		// it once so the next request starts Hugo with the shadow contentDir.
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+		stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
+		cancel()
+		if stopErr != nil {
+			_, _ = workspaceManager.Release(runtime.ID, req.DraftID)
+			ErrorInternal(c, "Failed to switch Local Live Preview to shadow content")
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":    "updated",
+		"applied":   applied,
+		"revision":  workspace.Revision,
+		"preview_url": runtime.LocalPreview.URL,
+	})
+}
+
+func ReleaseLocalPreviewContent(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	var req localPreviewReleaseRequest
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.DraftID) == "" {
+		ErrorBadRequest(c, "draft_id is required")
+		return
+	}
+
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	released, err := workspaceManager.Release(runtime.ID, req.DraftID)
+	if err != nil {
+		if errors.Is(err, services.ErrLocalPreviewSessionConflict) {
+			ErrorConflict(c, err.Error())
+			return
+		}
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	if released {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+		stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
+		cancel()
+		if stopErr != nil {
+			ErrorInternal(c, "Failed to stop Local Live Preview process")
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "released", "released": released})
+}

--- a/pkg/handlers/media.go
+++ b/pkg/handlers/media.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/services"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -68,6 +69,7 @@ func UploadMedia(c *gin.Context) {
 		ErrorInternal(c, "Failed to save file: "+err.Error())
 		return
 	}
+	syncLocalPreviewContentResource(runtime, info.RepoPath, false)
 	info.URL = addSiteQuery(info.URL, runtime.ID)
 
 	c.JSON(http.StatusOK, info)
@@ -102,7 +104,22 @@ func DeleteMedia(c *gin.Context) {
 		ErrorInternal(c, "Failed to delete: "+err.Error())
 		return
 	}
+	syncLocalPreviewContentResource(runtime, req.RepoPath, true)
 	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+}
+
+func syncLocalPreviewContentResource(runtime config.SiteRuntime, repoPath string, deleted bool) {
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		slog.Warn("Local preview workspace unavailable during media sync", "site", runtime.ID, "error", err)
+		return
+	}
+	if _, err := workspaceManager.SyncContentResource(runtime, repoPath, deleted); err != nil {
+		// The media operation already succeeded in the production workspace. Do
+		// not turn a preview-only synchronization failure into a misleading media
+		// retry; log it and let the next workspace rebuild recover the resource.
+		slog.Warn("Failed to synchronize media into Local Live Preview", "site", runtime.ID, "path", repoPath, "error", err)
+	}
 }
 
 func ServeMediaRaw(c *gin.Context) {

--- a/pkg/services/local_preview_lifecycle.go
+++ b/pkg/services/local_preview_lifecycle.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	LocalPreviewBindAddress       = "127.0.0.1"
-	DefaultLocalPreviewPortMin    = 14100
-	DefaultLocalPreviewPortMax    = 14999
+	LocalPreviewBindAddress    = "127.0.0.1"
+	DefaultLocalPreviewPortMin = 14100
+	DefaultLocalPreviewPortMax = 14999
 )
 
 type LocalPreviewProcessState string
@@ -30,8 +30,8 @@ type LocalPreviewProcessSlot struct {
 }
 
 // LocalPreviewLifecycle reserves internal loopback ports and records process
-// state. It deliberately does not start generator processes; Phase 2 will own
-// command construction, readiness checks, proxying, and retry on bind races.
+// state. LocalPreviewManager owns command construction, readiness checks,
+// proxying, process shutdown and retry on bind races.
 type LocalPreviewLifecycle struct {
 	mu        sync.Mutex
 	portMin   int
@@ -62,9 +62,9 @@ func NewDefaultLocalPreviewLifecycle() *LocalPreviewLifecycle {
 	return lifecycle
 }
 
-// Reserve returns one stable slot per site. portAvailable is a Phase 2 hook for
-// probing loopback availability; a nil callback treats every unreserved port as
-// available. A child-process bind failure must release/re-reserve and retry.
+// Reserve returns one stable slot per site. portAvailable probes loopback
+// availability; a nil callback treats every unreserved port as available. A
+// child-process bind failure must release/re-reserve and retry.
 func (l *LocalPreviewLifecycle) Reserve(siteID string, portAvailable func(int) bool) (LocalPreviewProcessSlot, error) {
 	siteID = strings.TrimSpace(siteID)
 	if siteID == "" {

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -1,0 +1,295 @@
+package services
+
+import (
+	"errors"
+	"fmt"
+	"hugo-cms/pkg/config"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	ErrLocalPreviewSessionConflict = errors.New("another local preview session is already active for this site")
+	ErrLocalPreviewSessionMismatch = errors.New("local preview session article does not match request")
+)
+
+// LocalPreviewWorkspace is the active unsaved-content workspace for one site.
+// Phase 3 intentionally limits each site to one active draft/session so two
+// browser tabs cannot silently mix unsaved content.
+type LocalPreviewWorkspace struct {
+	SiteID      string
+	DraftID     string
+	ArticlePath string
+	ContentDir  string
+	Revision    uint64
+}
+
+// LocalPreviewWorkspaceManager owns ephemeral shadow content directories. The
+// original repository remains the Hugo source root for configuration, theme,
+// layouts, static files and assets; only contentDir is redirected to this
+// workspace.
+type LocalPreviewWorkspaceManager struct {
+	root     string
+	mu       sync.Mutex
+	sessions map[string]LocalPreviewWorkspace
+	closed   bool
+}
+
+func NewLocalPreviewWorkspaceManager(root string) (*LocalPreviewWorkspaceManager, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return nil, fmt.Errorf("local preview workspace root is required")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve local preview workspace root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0700); err != nil {
+		return nil, fmt.Errorf("create local preview workspace root: %w", err)
+	}
+	return &LocalPreviewWorkspaceManager{
+		root:     absRoot,
+		sessions: make(map[string]LocalPreviewWorkspace),
+	}, nil
+}
+
+var (
+	defaultLocalPreviewWorkspaceOnce sync.Once
+	defaultLocalPreviewWorkspace     *LocalPreviewWorkspaceManager
+	defaultLocalPreviewWorkspaceErr  error
+)
+
+func DefaultLocalPreviewWorkspaceManager() (*LocalPreviewWorkspaceManager, error) {
+	defaultLocalPreviewWorkspaceOnce.Do(func() {
+		root, err := os.MkdirTemp("", "hugo-cms-local-preview-*")
+		if err != nil {
+			defaultLocalPreviewWorkspaceErr = fmt.Errorf("create local preview temporary root: %w", err)
+			return
+		}
+		defaultLocalPreviewWorkspace, defaultLocalPreviewWorkspaceErr = NewLocalPreviewWorkspaceManager(root)
+		if defaultLocalPreviewWorkspaceErr != nil {
+			_ = os.RemoveAll(root)
+		}
+	})
+	return defaultLocalPreviewWorkspace, defaultLocalPreviewWorkspaceErr
+}
+
+// Update creates the site's workspace on the first request and applies the
+// newest editor revision. Older in-flight HTTP requests become harmless no-ops
+// instead of overwriting newer editor state.
+func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftID, articlePath string, revision uint64, content []byte) (LocalPreviewWorkspace, bool, bool, error) {
+	if err := validateDraftID(draftID); err != nil {
+		return LocalPreviewWorkspace{}, false, false, err
+	}
+	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
+	if articlePath == "." || filepath.IsAbs(articlePath) {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("invalid local preview article path")
+	}
+	if revision == 0 {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("local preview revision must be greater than zero")
+	}
+	if runtime.ID == "" {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("local preview site ID is required")
+	}
+
+	sourceContentDir := SafeJoin(runtime.RepoPath, "", runtime.ContentDir)
+	if sourceContentDir == "" {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("invalid local preview content directory")
+	}
+	if SafeJoin(sourceContentDir, "", articlePath) == "" {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("invalid local preview article path")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("local preview workspace manager is closed")
+	}
+
+	workspace, exists := m.sessions[runtime.ID]
+	created := false
+	if exists {
+		if workspace.DraftID != draftID {
+			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionConflict
+		}
+		if workspace.ArticlePath != filepath.ToSlash(articlePath) {
+			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionMismatch
+		}
+		if revision <= workspace.Revision {
+			return workspace, false, false, nil
+		}
+	} else {
+		workspaceRoot := filepath.Join(m.root, runtime.ID, draftID)
+		contentDir := filepath.Join(workspaceRoot, "content")
+		if err := os.RemoveAll(workspaceRoot); err != nil {
+			return LocalPreviewWorkspace{}, false, false, fmt.Errorf("reset local preview workspace: %w", err)
+		}
+		if err := copyLocalPreviewContentTree(sourceContentDir, contentDir); err != nil {
+			_ = os.RemoveAll(workspaceRoot)
+			return LocalPreviewWorkspace{}, false, false, err
+		}
+		workspace = LocalPreviewWorkspace{
+			SiteID:      runtime.ID,
+			DraftID:     draftID,
+			ArticlePath: filepath.ToSlash(articlePath),
+			ContentDir:  contentDir,
+		}
+		created = true
+	}
+
+	target := SafeJoin(workspace.ContentDir, "", articlePath)
+	if target == "" {
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("invalid local preview workspace path")
+	}
+	if err := writeLocalPreviewFileAtomic(target, content); err != nil {
+		if created {
+			_ = os.RemoveAll(filepath.Dir(workspace.ContentDir))
+		}
+		return LocalPreviewWorkspace{}, false, false, err
+	}
+	workspace.Revision = revision
+	m.sessions[runtime.ID] = workspace
+	return workspace, created, true, nil
+}
+
+// Release is idempotent for a site without an active workspace. A stale tab is
+// never allowed to release another tab's active session.
+func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, error) {
+	if err := validateDraftID(draftID); err != nil {
+		return false, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	workspace, ok := m.sessions[siteID]
+	if !ok {
+		return false, nil
+	}
+	if workspace.DraftID != draftID {
+		return false, ErrLocalPreviewSessionConflict
+	}
+	delete(m.sessions, siteID)
+	if err := os.RemoveAll(filepath.Dir(workspace.ContentDir)); err != nil {
+		return true, fmt.Errorf("remove local preview workspace: %w", err)
+	}
+	return true, nil
+}
+
+func (m *LocalPreviewWorkspaceManager) Active(siteID string) (LocalPreviewWorkspace, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	workspace, ok := m.sessions[siteID]
+	return workspace, ok
+}
+
+func (m *LocalPreviewWorkspaceManager) Shutdown() error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return nil
+	}
+	m.closed = true
+	m.sessions = make(map[string]LocalPreviewWorkspace)
+	root := m.root
+	m.mu.Unlock()
+	if err := os.RemoveAll(root); err != nil {
+		return fmt.Errorf("remove local preview workspace root: %w", err)
+	}
+	return nil
+}
+
+func copyLocalPreviewContentTree(source, destination string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return fmt.Errorf("stat local preview content directory: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("local preview content directory must be a real directory")
+	}
+
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, rel)
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("local preview content symlink is not supported: %s", rel)
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !entryInfo.Mode().IsRegular() {
+			return fmt.Errorf("unsupported local preview content file type: %s", rel)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		return copyLocalPreviewFile(path, target, entryInfo.Mode().Perm())
+	})
+}
+
+func copyLocalPreviewFile(source, destination string, mode os.FileMode) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	output, err := os.OpenFile(destination, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(output, input); err != nil {
+		_ = output.Close()
+		return err
+	}
+	return output.Close()
+}
+
+func writeLocalPreviewFileAtomic(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("create local preview article directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".local-preview-*")
+	if err != nil {
+		return fmt.Errorf("create local preview temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0644); err != nil {
+		_ = temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write local preview content: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		// Windows cannot atomically replace an existing path. The fully-written
+		// temporary file is used for the fallback replacement.
+		if _, statErr := os.Stat(path); statErr != nil {
+			return fmt.Errorf("replace local preview content: %w", err)
+		}
+		if removeErr := os.Remove(path); removeErr != nil {
+			return fmt.Errorf("remove previous local preview content: %w", removeErr)
+		}
+		if err := os.Rename(temporaryPath, path); err != nil {
+			return fmt.Errorf("replace local preview content: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -156,6 +156,66 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 	return workspace, created, true, nil
 }
 
+// SyncContentResource mirrors a content-directory resource change made through
+// the normal CMS media API into an already-active shadow workspace. Static
+// resources do not need this because Hugo still uses the original source root.
+func (m *LocalPreviewWorkspaceManager) SyncContentResource(runtime config.SiteRuntime, repoPath string, deleted bool) (bool, error) {
+	if runtime.ID == "" {
+		return false, fmt.Errorf("local preview site ID is required")
+	}
+	sourceContentDir := SafeJoin(runtime.RepoPath, "", runtime.ContentDir)
+	if sourceContentDir == "" {
+		return false, fmt.Errorf("invalid local preview content directory")
+	}
+	sourcePath := SafeJoin(runtime.RepoPath, "", filepath.Clean(strings.TrimSpace(repoPath)))
+	if sourcePath == "" {
+		return false, fmt.Errorf("invalid local preview resource path")
+	}
+	relative, err := filepath.Rel(sourceContentDir, sourcePath)
+	if err != nil || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		// The media file is outside contentDir (for example static/). Hugo still
+		// reads it directly from the original repository, so no shadow sync is
+		// required.
+		return false, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return false, fmt.Errorf("local preview workspace manager is closed")
+	}
+	workspace, active := m.sessions[runtime.ID]
+	if !active {
+		return false, nil
+	}
+	target := SafeJoin(workspace.ContentDir, "", relative)
+	if target == "" {
+		return false, fmt.Errorf("invalid local preview resource target")
+	}
+	if deleted {
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			return false, fmt.Errorf("remove local preview content resource: %w", err)
+		}
+		return true, nil
+	}
+
+	info, err := os.Lstat(sourcePath)
+	if err != nil {
+		return false, fmt.Errorf("stat local preview content resource: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return false, fmt.Errorf("local preview content resource must be a regular file")
+	}
+	content, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return false, fmt.Errorf("read local preview content resource: %w", err)
+	}
+	if err := writeLocalPreviewFileAtomic(target, content); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Release is idempotent for a site without an active workspace. A stale tab is
 // never allowed to release another tab's active session.
 func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, error) {
@@ -172,10 +232,11 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 	if workspace.DraftID != draftID {
 		return false, ErrLocalPreviewSessionConflict
 	}
-	delete(m.sessions, siteID)
-	if err := os.RemoveAll(filepath.Dir(workspace.ContentDir)); err != nil {
-		return true, fmt.Errorf("remove local preview workspace: %w", err)
+	workspaceRoot := filepath.Dir(workspace.ContentDir)
+	if err := os.RemoveAll(workspaceRoot); err != nil {
+		return false, fmt.Errorf("remove local preview workspace: %w", err)
 	}
+	delete(m.sessions, siteID)
 	return true, nil
 }
 

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -151,6 +151,69 @@ func TestLocalPreviewWorkspaceReleaseProtectsActiveDraft(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewWorkspaceSyncsContentResource(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourcePath := filepath.Join(repo, "content", "images", "new.png")
+	if err := os.MkdirAll(filepath.Dir(resourcePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(resourcePath, []byte("image-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	synced, err := manager.SyncContentResource(runtime, filepath.ToSlash(filepath.Join("content", "images", "new.png")), false)
+	if err != nil || !synced {
+		t.Fatalf("SyncContentResource() synced=%v err=%v", synced, err)
+	}
+	got, err := os.ReadFile(filepath.Join(workspace.ContentDir, "images", "new.png"))
+	if err != nil || string(got) != "image-bytes" {
+		t.Fatalf("shadow resource = %q err=%v", got, err)
+	}
+
+	if err := os.Remove(resourcePath); err != nil {
+		t.Fatal(err)
+	}
+	synced, err = manager.SyncContentResource(runtime, filepath.ToSlash(filepath.Join("content", "images", "new.png")), true)
+	if err != nil || !synced {
+		t.Fatalf("delete SyncContentResource() synced=%v err=%v", synced, err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace.ContentDir, "images", "new.png")); !os.IsNotExist(err) {
+		t.Fatalf("shadow resource still exists: %v", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceIgnoresStaticResourceSync(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	if err := os.MkdirAll(filepath.Join(repo, "static"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	staticPath := filepath.Join(repo, "static", "logo.png")
+	if err := os.WriteFile(staticPath, []byte("logo"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content", StaticDir: "static"}
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft")); err != nil {
+		t.Fatal(err)
+	}
+	synced, err := manager.SyncContentResource(runtime, "static/logo.png", false)
+	if err != nil || synced {
+		t.Fatalf("static resource synced=%v err=%v, want false/nil", synced, err)
+	}
+}
+
 func TestLocalPreviewWorkspaceRejectsContentSymlink(t *testing.T) {
 	repo := t.TempDir()
 	contentDir := filepath.Join(repo, "content")

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -1,0 +1,187 @@
+package services
+
+import (
+	"errors"
+	"hugo-cms/pkg/config"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalPreviewWorkspaceMirrorsAndUpdatesContent(t *testing.T) {
+	repo := t.TempDir()
+	contentDir := filepath.Join(repo, "content")
+	if err := os.MkdirAll(filepath.Join(contentDir, "posts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(contentDir, "posts", "one.md"), []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(contentDir, "posts", "two.md"), []byte("second"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, created, applied, err := manager.Update(runtime, "draft-1", "posts/one.md", 1, []byte("new"))
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if !created || !applied {
+		t.Fatalf("created=%v applied=%v, want true/true", created, applied)
+	}
+
+	got, err := os.ReadFile(filepath.Join(workspace.ContentDir, "posts", "one.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("updated content = %q", got)
+	}
+	mirrored, err := os.ReadFile(filepath.Join(workspace.ContentDir, "posts", "two.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(mirrored) != "second" {
+		t.Fatalf("mirrored content = %q", mirrored)
+	}
+	original, err := os.ReadFile(filepath.Join(contentDir, "posts", "one.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(original) != "old" {
+		t.Fatalf("production content was modified: %q", original)
+	}
+}
+
+func TestLocalPreviewWorkspaceRejectsStaleRevision(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 2, []byte("newer"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, created, applied, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("older"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created || applied || workspace.Revision != 2 {
+		t.Fatalf("created=%v applied=%v revision=%d", created, applied, workspace.Revision)
+	}
+	got, err := os.ReadFile(filepath.Join(workspace.ContentDir, "one.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "newer" {
+		t.Fatalf("stale revision overwrote content: %q", got)
+	}
+}
+
+func TestLocalPreviewWorkspaceRejectsOtherDraftSameSite(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("one")); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := manager.Update(runtime, "draft-2", "one.md", 1, []byte("two")); !errors.Is(err, ErrLocalPreviewSessionConflict) {
+		t.Fatalf("error = %v, want session conflict", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceSeparatesSites(t *testing.T) {
+	repoA := makeLocalPreviewWorkspaceRepo(t)
+	repoB := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceA, _, _, err := manager.Update(config.SiteRuntime{ID: "tech", RepoPath: repoA, ContentDir: "content"}, "draft-a", "one.md", 1, []byte("tech"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceB, _, _, err := manager.Update(config.SiteRuntime{ID: "daily", RepoPath: repoB, ContentDir: "content"}, "draft-b", "one.md", 1, []byte("daily"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if workspaceA.ContentDir == workspaceB.ContentDir {
+		t.Fatal("different sites share the same workspace")
+	}
+	gotA, _ := os.ReadFile(filepath.Join(workspaceA.ContentDir, "one.md"))
+	gotB, _ := os.ReadFile(filepath.Join(workspaceB.ContentDir, "one.md"))
+	if string(gotA) != "tech" || string(gotB) != "daily" {
+		t.Fatalf("site contents mixed: tech=%q daily=%q", gotA, gotB)
+	}
+}
+
+func TestLocalPreviewWorkspaceReleaseProtectsActiveDraft(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("one"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Release("tech", "draft-2"); !errors.Is(err, ErrLocalPreviewSessionConflict) {
+		t.Fatalf("error = %v, want session conflict", err)
+	}
+	if _, err := os.Stat(workspace.ContentDir); err != nil {
+		t.Fatalf("active workspace was removed: %v", err)
+	}
+	released, err := manager.Release("tech", "draft-1")
+	if err != nil || !released {
+		t.Fatalf("Release() released=%v err=%v", released, err)
+	}
+	if _, err := os.Stat(workspace.ContentDir); !os.IsNotExist(err) {
+		t.Fatalf("workspace still exists after release: %v", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceRejectsContentSymlink(t *testing.T) {
+	repo := t.TempDir()
+	contentDir := filepath.Join(repo, "content")
+	if err := os.MkdirAll(contentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(repo, "outside.md")
+	if err := os.WriteFile(target, []byte("outside"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(contentDir, "one.md")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err = manager.Update(config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}, "draft-1", "one.md", 1, []byte("draft"))
+	if err == nil {
+		t.Fatal("Update() should reject content symlinks")
+	}
+}
+
+func makeLocalPreviewWorkspaceRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "content", "one.md"), []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -67,6 +67,19 @@ async function fetchWithCSRF(url, options) {
     return res;
 }
 
+async function responseError(res, fallback) {
+    let message = fallback;
+    try {
+        const data = await res.json();
+        message = data?.message || data?.error || fallback;
+    } catch (_) {
+        // Keep the stable fallback when the server did not return JSON.
+    }
+    const error = new Error(message);
+    error.status = res.status;
+    return error;
+}
+
 export async function fetchConfig() {
     const res = await fetch(withSite('/admin/api/config'), { headers: siteHeaders() });
     if (!res.ok) throw new Error("Config fetch failed");
@@ -219,6 +232,33 @@ export async function renderMarkdownPreview(payload, signal) {
         signal
     });
     if (!res.ok) throw new Error("Markdown preview failed");
+    return await res.json();
+}
+
+export async function updateLocalPreviewContent(payload, draftID, revision, signal) {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...siteHeaders()
+        },
+        body: JSON.stringify({ ...payload, draft_id: draftID, revision }),
+        signal
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview update failed");
+    return await res.json();
+}
+
+export async function releaseLocalPreviewContent(draftID) {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/release'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...siteHeaders()
+        },
+        body: JSON.stringify({ draft_id: draftID })
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview release failed");
     return await res.json();
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -116,6 +116,9 @@ async function init() {
 
 async function loadSiteData() {
     cmsConfig = await API.fetchConfig();
+    const site = siteRegistry?.sites?.find(s => s.id === API.getCurrentSite());
+    if (!cmsConfig._cms) cmsConfig._cms = {};
+    cmsConfig._cms.local_preview = site?.preview?.local_preview || { enabled: false, url: '' };
     Editor.setConfig(cmsConfig);
     UI.renderConfigWarnings(cmsConfig);
     deploymentEnabled = UI.configureDeploymentPreview(cmsConfig);
@@ -132,6 +135,16 @@ async function switchSite(siteID) {
         await Editor.flushPendingSave();
     } catch (e) {
         UI.showToast("Site switch cancelled: save failed", "error");
+        UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite);
+        return;
+    }
+
+    try {
+        // Release while API.getCurrentSite() still points at the old site so
+        // the old site's shadow workspace cannot leak into a later edit.
+        await Editor.releaseLocalLivePreview();
+    } catch (e) {
+        UI.showToast("Site switch cancelled: Local Live Preview cleanup failed", "error");
         UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite);
         return;
     }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -12,8 +12,15 @@ let deletingPath = "";
 let previewTimer = null;
 let previewController = null;
 let previewRevision = 0;
+let localPreviewTimer = null;
+let localPreviewRevision = 0;
+let localPreviewSessionID = "";
+let localPreviewSessionPath = "";
+let localPreviewConflictNotified = false;
+const localPreviewInflight = new Set();
 
 const PREVIEW_DEBOUNCE_MS = 180;
+const LOCAL_PREVIEW_DEBOUNCE_MS = 250;
 
 export function getCurrentPath() {
     return currentPath;
@@ -21,6 +28,10 @@ export function getCurrentPath() {
 
 function draftStorageKey(siteID, path) {
     return `hugo-cms:draft:${siteID}:${path}`;
+}
+
+function localPreviewStorageKey(siteID, path) {
+    return `hugo-cms:local-preview:${siteID}:${path}`;
 }
 
 export function createDraftUUID(cryptoProvider = window.crypto) {
@@ -51,6 +62,17 @@ export function getOrCreateDraftID(siteID, path, storage = window.sessionStorage
     return draftID;
 }
 
+function getOrCreateLocalPreviewSessionID(siteID, path, storage = window.sessionStorage, createUUID = createDraftUUID) {
+    if (!siteID || !path) return "";
+    const key = localPreviewStorageKey(siteID, path);
+    let sessionID = storage.getItem(key);
+    if (!sessionID) {
+        sessionID = createUUID();
+        storage.setItem(key, sessionID);
+    }
+    return sessionID;
+}
+
 export function getDraftID() {
     return getOrCreateDraftID(API.getCurrentSite(), currentPath);
 }
@@ -63,9 +85,15 @@ export function setConfig(cfg) {
     cmsConfig = cfg;
 }
 
+function localPreviewEnabled() {
+    return cmsConfig?._cms?.local_preview?.enabled === true;
+}
+
 export function clearEditor() {
     clearAutoSaveTimer();
     cancelMarkdownPreview();
+    cancelLocalPreviewTimer();
+    resetLocalPreviewClientState();
     currentPath = "";
     currentData = null;
     lastSavedPayload = "";
@@ -105,6 +133,7 @@ export function initAutoSave() {
 function handleEditorChange() {
     triggerAutoSave();
     scheduleMarkdownPreview();
+    scheduleLocalLivePreview();
     if (window.markDeploymentPreviewStale) window.markDeploymentPreviewStale();
 }
 
@@ -199,6 +228,89 @@ export async function refreshMarkdownPreview() {
     }
 }
 
+function cancelLocalPreviewTimer() {
+    if (localPreviewTimer) {
+        clearTimeout(localPreviewTimer);
+        localPreviewTimer = null;
+    }
+}
+
+function resetLocalPreviewClientState() {
+    localPreviewRevision = 0;
+    localPreviewSessionID = "";
+    localPreviewSessionPath = "";
+    localPreviewConflictNotified = false;
+}
+
+function scheduleLocalLivePreview() {
+    if (!localPreviewEnabled() || !currentPath || currentPath === deletingPath) return;
+    if (localPreviewTimer) clearTimeout(localPreviewTimer);
+    localPreviewTimer = setTimeout(() => {
+        localPreviewTimer = null;
+        refreshLocalLivePreview().catch(() => undefined);
+    }, LOCAL_PREVIEW_DEBOUNCE_MS);
+}
+
+export async function refreshLocalLivePreview() {
+    if (!localPreviewEnabled() || !currentPath || currentPath === deletingPath) return null;
+    cancelLocalPreviewTimer();
+
+    const requestPath = currentPath;
+    const siteID = API.getCurrentSite();
+    const sessionID = localPreviewSessionID || getOrCreateLocalPreviewSessionID(siteID, requestPath);
+    if (!sessionID) return null;
+
+    if (localPreviewSessionPath && localPreviewSessionPath !== requestPath) {
+        throw new Error("Local Live Preview session path changed without release");
+    }
+    localPreviewSessionID = sessionID;
+    localPreviewSessionPath = requestPath;
+    const revision = ++localPreviewRevision;
+    const payload = getPayload();
+
+    const request = API.updateLocalPreviewContent(payload, sessionID, revision);
+    localPreviewInflight.add(request);
+    try {
+        return await request;
+    } catch (e) {
+        if (e?.status === 409) {
+            if (!localPreviewConflictNotified) {
+                localPreviewConflictNotified = true;
+                UI.showToast("Local Live Preview is active in another tab for this site", "warning");
+            }
+        } else {
+            console.error("[LocalPreview] Update failed:", e);
+        }
+        throw e;
+    } finally {
+        localPreviewInflight.delete(request);
+    }
+}
+
+export async function releaseLocalLivePreview() {
+    cancelLocalPreviewTimer();
+    const sessionID = localPreviewSessionID;
+    if (!sessionID) {
+        resetLocalPreviewClientState();
+        return false;
+    }
+
+    // Do not race release against an update that the server may still be
+    // applying even when the UI has moved on to another article/site.
+    await Promise.allSettled(Array.from(localPreviewInflight));
+    try {
+        const result = await API.releaseLocalPreviewContent(sessionID);
+        return result?.released === true;
+    } catch (e) {
+        // A different tab may own the site's active session. Our stale tab must
+        // not release that workspace, but it can safely forget its local state.
+        if (e?.status !== 409) throw e;
+        return false;
+    } finally {
+        resetLocalPreviewClientState();
+    }
+}
+
 export async function execAutoSave() {
     return queueCurrentSave("Auto Saving...");
 }
@@ -260,9 +372,19 @@ export async function flushPendingSave() {
 export async function loadFile(path) {
     clearAutoSaveTimer();
     cancelMarkdownPreview();
+    cancelLocalPreviewTimer();
     await saveQueue.catch(() => {
         // Loading another file remains possible after a failed save.
     });
+
+    if (currentPath && currentPath !== path) {
+        try {
+            await releaseLocalLivePreview();
+        } catch (e) {
+            UI.showToast("Failed to release Local Live Preview: " + e.message, "error");
+            return;
+        }
+    }
 
     currentPath = path;
     const display = document.getElementById('filename-display');
@@ -278,6 +400,7 @@ export async function loadFile(path) {
         lastSavedPayload = JSON.stringify(getPayload());
         lastQueuedPayload = "";
         await refreshMarkdownPreview();
+        refreshLocalLivePreview().catch(() => undefined);
 
     } catch (e) {
         UI.showEditorError(e);
@@ -325,6 +448,7 @@ export async function deleteFile(refreshListCb) {
     const pathToDelete = currentPath;
     let deleted = false;
     clearAutoSaveTimer();
+    cancelLocalPreviewTimer();
     deletingPath = pathToDelete;
 
     try {
@@ -332,6 +456,7 @@ export async function deleteFile(refreshListCb) {
         // queued saves for this path from starting before DELETE.
         await saveQueue;
         await API.deleteArticle(pathToDelete);
+        await releaseLocalLivePreview();
         deleted = true;
         UI.showToast("Article deleted", "success");
 

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -30,10 +30,6 @@ function draftStorageKey(siteID, path) {
     return `hugo-cms:draft:${siteID}:${path}`;
 }
 
-function localPreviewStorageKey(siteID, path) {
-    return `hugo-cms:local-preview:${siteID}:${path}`;
-}
-
 export function createDraftUUID(cryptoProvider = window.crypto) {
     if (typeof cryptoProvider?.randomUUID === 'function') {
         return cryptoProvider.randomUUID();
@@ -62,15 +58,11 @@ export function getOrCreateDraftID(siteID, path, storage = window.sessionStorage
     return draftID;
 }
 
-function getOrCreateLocalPreviewSessionID(siteID, path, storage = window.sessionStorage, createUUID = createDraftUUID) {
-    if (!siteID || !path) return "";
-    const key = localPreviewStorageKey(siteID, path);
-    let sessionID = storage.getItem(key);
-    if (!sessionID) {
-        sessionID = createUUID();
-        storage.setItem(key, sessionID);
-    }
-    return sessionID;
+// Local Preview ownership is scoped to this browser document/tab. Do not use
+// sessionStorage here: duplicated tabs can inherit the same sessionStorage and
+// would then bypass the server's same-site session conflict boundary.
+export function createLocalPreviewSessionID(createUUID = createDraftUUID) {
+    return createUUID();
 }
 
 export function getDraftID() {
@@ -256,8 +248,7 @@ export async function refreshLocalLivePreview() {
     cancelLocalPreviewTimer();
 
     const requestPath = currentPath;
-    const siteID = API.getCurrentSite();
-    const sessionID = localPreviewSessionID || getOrCreateLocalPreviewSessionID(siteID, requestPath);
+    const sessionID = localPreviewSessionID || createLocalPreviewSessionID();
     if (!sessionID) return null;
 
     if (localPreviewSessionPath && localPreviewSessionPath !== requestPath) {
@@ -300,14 +291,17 @@ export async function releaseLocalLivePreview() {
     await Promise.allSettled(Array.from(localPreviewInflight));
     try {
         const result = await API.releaseLocalPreviewContent(sessionID);
+        resetLocalPreviewClientState();
         return result?.released === true;
     } catch (e) {
-        // A different tab may own the site's active session. Our stale tab must
-        // not release that workspace, but it can safely forget its local state.
-        if (e?.status !== 409) throw e;
-        return false;
-    } finally {
-        resetLocalPreviewClientState();
+        // 409 proves this document no longer owns the site's active workspace.
+        // Network/5xx failures are ambiguous, so retain the session ID and
+        // revision to allow a later release/update to continue safely.
+        if (e?.status === 409) {
+            resetLocalPreviewClientState();
+            return false;
+        }
+        throw e;
     }
 }
 
@@ -456,9 +450,24 @@ export async function deleteFile(refreshListCb) {
         // queued saves for this path from starting before DELETE.
         await saveQueue;
         await API.deleteArticle(pathToDelete);
-        await releaseLocalLivePreview();
+        // Production deletion is committed at this point. Preview cleanup is a
+        // separate best-effort operation and must never re-enable autosave for
+        // the deleted article.
         deleted = true;
-        UI.showToast("Article deleted", "success");
+
+        let previewCleanupError = null;
+        try {
+            await releaseLocalLivePreview();
+        } catch (e) {
+            previewCleanupError = e;
+            console.error("[LocalPreview] Cleanup after article deletion failed:", e);
+        }
+
+        if (previewCleanupError) {
+            UI.showToast("Article deleted, but Local Live Preview cleanup failed: " + previewCleanupError.message, "warning");
+        } else {
+            UI.showToast("Article deleted", "success");
+        }
 
         if (currentPath === pathToDelete) {
             cancelMarkdownPreview();
@@ -474,7 +483,11 @@ export async function deleteFile(refreshListCb) {
 
         if (refreshListCb) await refreshListCb();
     } catch (e) {
-        UI.showToast("Delete failed: " + e.message, "error");
+        if (deleted) {
+            UI.showToast("Article deleted, but refreshing the editor failed: " + e.message, "warning");
+        } else {
+            UI.showToast("Delete failed: " + e.message, "error");
+        }
     } finally {
         if (deletingPath === pathToDelete) {
             deletingPath = "";

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -371,7 +371,10 @@ export async function loadFile(path) {
         // Loading another file remains possible after a failed save.
     });
 
-    if (currentPath && currentPath !== path) {
+    // A failed cleanup can leave preview ownership alive even after the
+    // production article was deleted and currentPath was cleared. Base the
+    // retry decision on Local Preview ownership rather than editor selection.
+    if (localPreviewSessionID && localPreviewSessionPath && localPreviewSessionPath !== path) {
         try {
             await releaseLocalLivePreview();
         } catch (e) {

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -98,7 +98,7 @@ describe("draft IDs", () => {
 });
 
 describe("preview API contracts", () => {
-    it("scopes Markdown and deployment operations to the selected site", async () => {
+    it("scopes Markdown, local, and deployment operations to the selected site", async () => {
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {
             calls.push({ url, options });
@@ -111,6 +111,8 @@ describe("preview API contracts", () => {
         API.setCurrentSite("docs site");
         const article = { path: "posts/one.md", body: "# Draft", frontmatter: { title: "Draft" } };
         await API.renderMarkdownPreview(article);
+        await API.updateLocalPreviewContent(article, "local-session", 7);
+        await API.releaseLocalPreviewContent("local-session");
         await API.triggerPreviewDeployment(article.path, "draft/id");
         await API.fetchPreviewDeployment("draft/id");
         await API.retryPreviewDeployment("draft/id");
@@ -119,14 +121,36 @@ describe("preview API contracts", () => {
 
         assert.equal(calls[1].url, "/admin/api/preview/markdown?site=docs+site");
         assert.deepEqual(JSON.parse(calls[1].options.body), article);
-        assert.equal(calls[2].url, "/admin/api/preview/deployments?site=docs+site");
-        assert.deepEqual(JSON.parse(calls[2].options.body), { path: article.path, draft_id: "draft/id" });
-        assert.equal(calls[3].url, "/admin/api/preview/deployments/draft%2Fid?site=docs+site");
-        assert.equal(calls[4].url, "/admin/api/preview/deployments/draft%2Fid/retry?site=docs+site");
-        assert.equal(calls[5].url, "/admin/api/preview/deployments/draft%2Fid/discard?site=docs+site");
-        assert.deepEqual(JSON.parse(calls[6].options.body), { path: article.path, draft_id: "draft/id" });
+        assert.equal(calls[2].url, "/admin/api/preview/local?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[2].options.body), { ...article, draft_id: "local-session", revision: 7 });
+        assert.equal(calls[3].url, "/admin/api/preview/local/release?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[3].options.body), { draft_id: "local-session" });
+        assert.equal(calls[4].url, "/admin/api/preview/deployments?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[4].options.body), { path: article.path, draft_id: "draft/id" });
+        assert.equal(calls[5].url, "/admin/api/preview/deployments/draft%2Fid?site=docs+site");
+        assert.equal(calls[6].url, "/admin/api/preview/deployments/draft%2Fid/retry?site=docs+site");
+        assert.equal(calls[7].url, "/admin/api/preview/deployments/draft%2Fid/discard?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[8].options.body), { path: article.path, draft_id: "draft/id" });
         calls.slice(1).forEach(call => {
             assert.equal(call.options.headers["X-CMS-Site"], "docs site");
         });
+    });
+
+    it("preserves conflict status from local preview API errors", async () => {
+        globalThis.fetch = async (url) => {
+            if (url === "/admin/api/csrf-token") {
+                return { ok: true, status: 200, json: async () => ({ csrf_token: "csrf" }) };
+            }
+            return {
+                ok: false,
+                status: 409,
+                json: async () => ({ message: "another local preview session is already active for this site" }),
+            };
+        };
+
+        await assert.rejects(
+            () => API.updateLocalPreviewContent({ path: "one.md", content: "draft" }, "local-session", 1),
+            error => error.status === 409 && /another local preview session/.test(error.message),
+        );
     });
 });

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -22,7 +22,7 @@ const {
     normalizeDeploymentState,
     safeExternalURL,
 } = await import("./ui.js");
-const { createDraftUUID, getOrCreateDraftID } = await import("./editor.js");
+const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
 const API = await import("./api.js");
 
 describe("safeExternalURL", () => {
@@ -94,6 +94,15 @@ describe("draft IDs", () => {
         assert.equal(getOrCreateDraftID("docs", "posts/one.md", memoryStorage, createUUID), "uuid-1");
         assert.equal(getOrCreateDraftID("docs", "posts/two.md", memoryStorage, createUUID), "uuid-2");
         assert.equal(getOrCreateDraftID("blog", "posts/one.md", memoryStorage, createUUID), "uuid-3");
+    });
+
+    it("creates Local Preview ownership IDs without browser storage persistence", () => {
+        let sequence = 0;
+        const createUUID = () => `local-${++sequence}`;
+
+        assert.equal(createLocalPreviewSessionID(createUUID), "local-1");
+        assert.equal(createLocalPreviewSessionID(createUUID), "local-2");
+        assert.equal(sessionValues.size, 0);
     });
 });
 


### PR DESCRIPTION
## Summary

Implements Phase 3 of #32: editor state -> shadow content workspace -> Hugo watcher/LiveReload.

- create one ephemeral shadow content workspace per active site/session
- mirror the site's content directory on the first Local Live Preview update
- apply editor body/front matter to the shadow article without writing the production working tree
- debounce editor updates at 250ms
- attach monotonically increasing revisions so stale/out-of-order requests cannot overwrite newer editor state
- keep Local Preview session IDs separate from Deployment Preview draft IDs
- scope Local Preview session IDs to the current browser document/tab instead of sessionStorage so duplicated tabs cannot inherit the same ownership ID
- reject another tab/session for the same site with `409 Conflict`
- allow different sites to use independent workspaces
- pass the active shadow content directory to Hugo via `--contentDir` while keeping source/config/theme/layout/static/assets rooted in the original repository
- stop a saved-content Hugo process once when the first shadow workspace is created, then rely on Hugo watcher for subsequent updates
- stop Hugo before releasing/removing its shadow content directory
- release on article/site switch and clean all workspace state after child processes stop during CMS shutdown
- preserve client session ID/revision on ambiguous release failures (network/5xx), resetting only after a successful release or a 409 ownership conflict
- treat production article deletion as committed as soon as the delete API succeeds; later Local Preview cleanup failures cannot re-enable autosave or recreate the deleted article
- synchronize content-directory media upload/delete into an active shadow workspace; static media remains sourced from the original repository
- add service tests for mirroring, production-tree isolation, stale revisions, multi-site isolation, tab conflict, release safety, resource sync, and symlink rejection
- add frontend API contract tests for Local Preview update/release and document-scoped session IDs
- update Local Live Preview architecture/configuration docs and stale lifecycle comments

## API

- `POST /admin/api/preview/local`
- `POST /admin/api/preview/local/release`

Both are protected by the existing admin auth + CSRF boundary.

## Working tree boundary

The existing 3-second autosave remains the CMS save behavior. The new 250ms Local Live Preview path itself never writes the production working tree or Git index/ref; it only mutates the ephemeral shadow content directory.

## Known Phase 3 limits / acceptance checks

- sites using Hugo Module custom `content` mounts need an environment-specific smoke test; the initial implementation uses Hugo's `--contentDir` override
- actual theme/shortcode/assets/LiveReload behavior still needs the real blog repositories + chosen wildcard/Tailscale ingress smoke test tracked in #32
- because Local Preview ownership IDs are document-scoped, closing or reloading a tab without first releasing can leave the server-side one-site preview session stale until explicit recovery/CMS shutdown; Phase 4 should add explicit stop plus stale-session recovery/lease handling

## Scope after this PR

Phase 4 remains responsible for the explicit Local Live Preview open/new-tab/stop UI, starting/ready/failed state presentation, stale-session recovery, plus deployment examples for Tailscale/wildcard DNS/TLS.