### PR TITLE
feat: add Phase 4 Local Live Preview lifecycle and UI

### DIFF
--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,6 +1,6 @@
 # Local Live Preview設定ガイド
 
-> Issue #32ではPhase 1/2がmainへmerge済みです。Phase 3 (#35)では、editorの未保存内容をproduction working treeとは別のshadow content workspaceへdebounce反映し、Hugo watcher/LiveReloadへつなぎます。
+> Issue #32ではPhase 1/2/3がmainへmerge済みです。Phase 4では、session lease/recovery、status/stop API、UIからのopen/stopとoptional iframe埋め込みを追加します。
 
 ## 基本設定
 
@@ -104,7 +104,7 @@ https://tech.preview.example.com/css/main.css
 
 内部upstreamを指すabsolute `Location`だけを外部preview originへ補正し、HTTP Upgradeを透過してLiveReload WebSocketを通します。
 
-## Phase 3: 未保存editor内容
+## 未保存editor内容
 
 Local Live Previewが有効なsiteでは、editor変更を約250ms debounceして次へ送ります。
 
@@ -136,11 +136,48 @@ workspace作成時点のcontent resourceは初回mirrorに含まれます。そ�
 
 static配下は元repositoryをHugoが直接参照するためshadow同期しません。media本体の保存成功後にpreview同期だけ失敗した場合は、media操作を失敗扱いにせずserver logへ記録します。
 
-### tab / draft競合
+## session lease / recovery
 
-初期実装では同一siteにつきactive Local Live Preview sessionは1つです。別tab/sessionから同siteを更新すると`409 Conflict`となり、既存workspaceを上書きしません。別siteは独立して利用できます。
+Local Preview ownership IDはbrowser document/tabのmemory上だけに保持します。複製tabが同じIDを引き継がないため、同一siteの別tab/sessionは`409 Conflict`になります。
 
-### article/site切替とcleanup
+一方、tab reload、browser crash、network断ではrelease requestを確実に送れません。そのためactive workspaceにはlast-seen leaseを持たせます。
+
+- lease TTL: 2分
+- CMS editorは30秒ごとにheartbeat
+- editor update自体もleaseを更新
+- lease切れworkspaceは`stale`としてstatus APIへ表示
+- stale workspaceは明示的なreclaim APIでCMS再起動なしに回収可能
+- liveなsessionはreclaimできない
+
+recovery時もHugo processを先にstopしてからshadow workspaceを削除します。
+
+## UI
+
+Local Live Preview panelでは次を利用できます。
+
+- `新規タブで開く`: 常に利用できる主導線
+- `埋め込み表示`: CMS内のsandbox付きiframeへ表示
+- `停止`: 自分が所有するsession、またはworkspaceを伴わないsaved-content preview processを停止
+- `期限切れsessionを回収`: stale leaseだけを安全にreclaim
+- stopped / starting / ready / failed / conflict / staleの状態表示
+
+### iframe埋め込み
+
+preview hostnameはCMSとは別originなので、iframe埋め込み自体は可能です。CMSはpreview subdomainへsession cookieを共有しません。
+
+ただし、外部preview ingressが次のheaderでframeを禁止している場合は埋め込めません。
+
+```text
+X-Frame-Options: DENY
+X-Frame-Options: SAMEORIGIN
+Content-Security-Policy: frame-ancestors 'none'
+```
+
+Cloudflare Access等のviewer authenticationのlogin画面がiframeを拒否する構成もあります。そのため**新規タブ表示を主導線として必ず残し、埋め込みはoptional**とします。
+
+CMS側iframeにはsandboxを付け、top-level navigation等を許可しません。Hugo/LiveReloadに必要なscriptとsame-origin権限だけを許可します。
+
+## article/site切替とcleanup
 
 article/site切替時はin-flight update完了を待ってsessionをreleaseします。
 
@@ -151,9 +188,7 @@ Hugo process stop
 
 CMS shutdownでもHugo child停止後にtemporary workspaceを削除します。workspaceは`PREVIEW_STATE_DIR`へ永続化しません。
 
-ブラウザtabを切替操作なしで閉じた場合の確実なreleaseはPhase 4の明示停止/lease recoveryで扱います。
-
-### Hugo Modules
+## Hugo Modules
 
 Hugo Modulesで`content`をcustom mountしているsiteは実blog repositoryでsmoke testしてください。必要ならmount-awareなpreview方式を追加します。
 
@@ -171,7 +206,16 @@ release:
 POST /admin/api/preview/local/release
 ```
 
-両方とも既存admin auth + CSRF境界の内側です。
+lifecycle:
+
+```text
+GET  /admin/api/preview/local/status
+POST /admin/api/preview/local/heartbeat
+POST /admin/api/preview/local/stop
+POST /admin/api/preview/local/reclaim
+```
+
+すべて既存admin auth + CSRF境界の内側です。status APIは別tabのowner session IDを返しません。
 
 ## 旧preview方式との違い
 

--- a/main.go
+++ b/main.go
@@ -51,10 +51,8 @@ func SetupRouter() (*gin.Engine, error) {
 	// than by sharing the CMS admin cookie with repository-generated JavaScript.
 	r.Use(handlers.LocalPreviewIngress(services.DefaultLocalPreviewManager()))
 
-	// Determine if we are running on HTTPS
 	isSecure := strings.HasPrefix(appURL, "https://")
 
-	// Session Setup
 	secret := os.Getenv("SESSION_SECRET")
 	if secret == "" {
 		if gin.Mode() == gin.ReleaseMode {
@@ -75,7 +73,7 @@ func SetupRouter() (*gin.Engine, error) {
 	encryptionKey := sha256.Sum256([]byte("hugo-cms/session-encryption/" + secret))
 	store := cookie.NewStore(authKey[:], encryptionKey[:])
 	store.Options(sessions.Options{
-		Path:     "/", // Cookie valid for whole domain
+		Path:     "/",
 		MaxAge:   86400 * 7,
 		HttpOnly: true,
 		Secure:   isSecure,
@@ -83,14 +81,11 @@ func SetupRouter() (*gin.Engine, error) {
 	})
 	r.Use(sessions.Sessions("mysession", store))
 
-	// Static Files & Templates
 	r.LoadHTMLGlob("templates/*")
 
-	// --- Health Check Endpoints (Public) ---
 	r.GET("/health", handlers.HealthCheck)
 	r.GET("/ready", handlers.ReadinessCheck)
 
-	// --- Admin Routes ---
 	admin := r.Group("/admin")
 	admin.Use(func(c *gin.Context) {
 		c.Header("X-Content-Type-Options", "nosniff")
@@ -99,29 +94,30 @@ func SetupRouter() (*gin.Engine, error) {
 		c.Next()
 	})
 	{
-		// Public Auth
 		admin.GET("/login", handlers.LoginPage)
 		admin.GET("/login/github", handlers.GithubLogin)
 		admin.GET("/auth/callback", handlers.AuthCallback)
 		admin.GET("/logout", handlers.Logout)
 
-		// Protected Admin
 		authorized := admin.Group("/")
 		authorized.Use(handlers.AuthRequired)
-		authorized.Use(handlers.TokenValidation) // Periodically validate GitHub token
+		authorized.Use(handlers.TokenValidation)
 		{
-			// CMS Static Assets (Protected)
 			authorized.Static("/static", "./static")
 
 			authorized.GET("/", func(c *gin.Context) { c.HTML(http.StatusOK, "index.html", nil) })
 			api := authorized.Group("/api")
 			api.Use(handlers.RequestBodyLimit(config.MaxUploadSize + (1 << 20)))
-			api.Use(handlers.CSRFProtection) // Apply CSRF protection to all API routes
+			api.Use(handlers.CSRFProtection)
 			{
-				api.GET("/csrf-token", handlers.GetCSRFToken) // Endpoint to get CSRF token
+				api.GET("/csrf-token", handlers.GetCSRFToken)
 				api.POST("/preview/markdown", handlers.RenderMarkdownPreview)
 				api.POST("/preview/local", handlers.UpdateLocalPreviewContent)
 				api.POST("/preview/local/release", handlers.ReleaseLocalPreviewContent)
+				api.GET("/preview/local/status", handlers.GetLocalPreviewStatus)
+				api.POST("/preview/local/heartbeat", handlers.HeartbeatLocalPreviewContent)
+				api.POST("/preview/local/stop", handlers.StopLocalPreview)
+				api.POST("/preview/local/reclaim", handlers.ReclaimStaleLocalPreview)
 				api.POST("/preview/deployments", handlers.UpdateDeploymentPreview)
 				api.GET("/preview/deployments/:draft_id", handlers.GetDeploymentPreview)
 				api.POST("/preview/deployments/:draft_id/retry", handlers.RetryDeploymentPreview)
@@ -153,16 +149,12 @@ func newHTTPServer(handler http.Handler) *http.Server {
 		Addr:              ":" + config.ServerPort,
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
-		// Request bodies are size-limited by middleware. Global read and
-		// write deadlines would make valid large uploads depend on connection
-		// speed and can prevent the final response from being written.
-		IdleTimeout:    2 * time.Minute,
-		MaxHeaderBytes: 1 << 20,
+		IdleTimeout:       2 * time.Minute,
+		MaxHeaderBytes:    1 << 20,
 	}
 }
 
 func main() {
-	// Initialize config
 	if err := config.Init(); err != nil {
 		slog.Error("Invalid configuration", "error", err)
 		os.Exit(1)
@@ -201,16 +193,12 @@ func main() {
 		}
 	}()
 
-	// Wait for interrupt signal to gracefully shutdown the server
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	slog.Info("Shutting down server...")
 
 	previewManager := services.DefaultLocalPreviewManager()
-	// Reject any new lazy preview starts immediately. Existing preview requests
-	// may finish while the HTTP server drains, then all child processes are
-	// stopped after no new HTTP requests can be accepted.
 	previewManager.BeginShutdown()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -225,7 +213,6 @@ func main() {
 	}
 	cancelPreview()
 
-	// Child Hugo processes are stopped before removing their contentDir.
 	if err := workspaceManager.Shutdown(); err != nil {
 		slog.Error("Failed to remove local preview shadow workspace", "error", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -85,7 +85,16 @@ func TestMarkdownPreviewDoesNotUseIframe(t *testing.T) {
 	if !strings.Contains(template, `id="markdown-preview"`) {
 		t.Fatal("template is missing the Markdown preview container")
 	}
-	if strings.Contains(template, "<iframe") {
+	previewStart := strings.Index(template, `<div id="preview-view">`)
+	if previewStart < 0 {
+		t.Fatal("template is missing the Markdown preview view")
+	}
+	previewEnd := strings.Index(template[previewStart:], `<div id="modal-overlay">`)
+	if previewEnd < 0 {
+		t.Fatal("template is missing the Markdown preview view")
+	}
+	markdownPreview := template[previewStart : previewStart+previewEnd]
+	if strings.Contains(markdownPreview, "<iframe") {
 		t.Fatal("Markdown preview must not use an iframe")
 	}
 }

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -70,7 +70,10 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 	workspace, created, applied, err := workspaceManager.Update(runtime, req.DraftID, req.Path, req.Revision, finalContent)
 	if err != nil {
 		switch {
-		case errors.Is(err, services.ErrLocalPreviewSessionConflict), errors.Is(err, services.ErrLocalPreviewSessionMismatch):
+		case errors.Is(err, services.ErrLocalPreviewSessionConflict),
+			errors.Is(err, services.ErrLocalPreviewSessionMismatch),
+			errors.Is(err, services.ErrLocalPreviewSessionExpired),
+			errors.Is(err, services.ErrLocalPreviewSessionReclaiming):
 			ErrorConflict(c, err.Error())
 		default:
 			ErrorBadRequest(c, err.Error())
@@ -137,7 +140,7 @@ func ReleaseLocalPreviewContent(c *gin.Context) {
 
 	released, err := workspaceManager.Release(runtime.ID, req.DraftID)
 	if err != nil {
-		if errors.Is(err, services.ErrLocalPreviewSessionConflict) {
+		if errors.Is(err, services.ErrLocalPreviewSessionConflict) || errors.Is(err, services.ErrLocalPreviewSessionReclaiming) {
 			ErrorConflict(c, err.Error())
 			return
 		}

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -79,8 +79,6 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 	}
 
 	if created {
-		// A preview process may already be serving the repository content. Stop
-		// it once so the next request starts Hugo with the shadow contentDir.
 		ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
 		stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
 		cancel()
@@ -91,11 +89,14 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 		}
 	}
 
+	// session_id is returned only to the authenticated document that supplied
+	// it. Status/recovery endpoints never disclose another tab's owner ID.
 	c.JSON(http.StatusOK, gin.H{
 		"status":      "updated",
 		"applied":     applied,
 		"revision":    workspace.Revision,
 		"preview_url": runtime.LocalPreview.URL,
+		"session_id":  req.DraftID,
 	})
 }
 
@@ -126,8 +127,6 @@ func ReleaseLocalPreviewContent(c *gin.Context) {
 		return
 	}
 
-	// Hugo may be watching files inside the shadow directory. Stop it before
-	// removing contentDir so shutdown cannot race filesystem cleanup.
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
 	stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
 	cancel()

--- a/pkg/handlers/local_preview_control.go
+++ b/pkg/handlers/local_preview_control.go
@@ -1,0 +1,193 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"hugo-cms/pkg/services"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type localPreviewControlRequest struct {
+	DraftID string `json:"draft_id"`
+}
+
+func GetLocalPreviewStatus(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	enabled := runtime.LocalPreview.Enabled != nil && *runtime.LocalPreview.Enabled
+	if !enabled {
+		c.JSON(http.StatusOK, gin.H{
+			"enabled": false,
+			"status":  "disabled",
+		})
+		return
+	}
+
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	workspace, active, stale := workspaceManager.Status(runtime.ID)
+	draftID := strings.TrimSpace(c.Query("draft_id"))
+	owned := active && draftID != "" && workspace.DraftID == draftID
+
+	processState := services.LocalPreviewStopped
+	processError := ""
+	if slot, ok := services.DefaultLocalPreviewManager().Status(runtime.ID); ok {
+		processState = slot.State
+		processError = slot.Error
+	}
+
+	status := string(processState)
+	if stale {
+		status = "stale"
+	} else if active && draftID != "" && !owned {
+		status = "conflict"
+	}
+
+	response := gin.H{
+		"enabled":          true,
+		"status":           status,
+		"process_state":    processState,
+		"process_error":    processError,
+		"preview_url":      runtime.LocalPreview.URL,
+		"session_active":   active,
+		"session_owned":    owned,
+		"session_stale":    stale,
+		"lease_seconds":    int(workspaceManager.LeaseTTL().Seconds()),
+		"has_current_owner": active && !stale,
+	}
+	if active && !workspace.LastSeenAt.IsZero() {
+		age := time.Since(workspace.LastSeenAt)
+		if age < 0 {
+			age = 0
+		}
+		response["last_seen_age_seconds"] = int(age.Seconds())
+	}
+	c.JSON(http.StatusOK, response)
+}
+
+func HeartbeatLocalPreviewContent(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	var req localPreviewControlRequest
+	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.DraftID) == "" {
+		ErrorBadRequest(c, "draft_id is required")
+		return
+	}
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	workspace, err := workspaceManager.Heartbeat(runtime.ID, req.DraftID)
+	if err != nil {
+		switch {
+		case errors.Is(err, services.ErrLocalPreviewSessionConflict), errors.Is(err, services.ErrLocalPreviewSessionNotFound):
+			ErrorConflict(c, err.Error())
+		default:
+			ErrorBadRequest(c, err.Error())
+		}
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":   "active",
+		"revision": workspace.Revision,
+	})
+}
+
+func StopLocalPreview(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	var req localPreviewControlRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ErrorBadRequest(c, "Invalid JSON")
+		return
+	}
+
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	workspace, active := workspaceManager.Active(runtime.ID)
+	if active {
+		if strings.TrimSpace(req.DraftID) == "" || workspace.DraftID != req.DraftID {
+			ErrorConflict(c, services.ErrLocalPreviewSessionConflict.Error())
+			return
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
+	cancel()
+	if stopErr != nil {
+		ErrorInternal(c, "Failed to stop Local Live Preview process")
+		return
+	}
+	if active {
+		if _, err := workspaceManager.Release(runtime.ID, req.DraftID); err != nil {
+			if errors.Is(err, services.ErrLocalPreviewSessionConflict) {
+				ErrorConflict(c, err.Error())
+				return
+			}
+			ErrorBadRequest(c, err.Error())
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "stopped"})
+}
+
+func ReclaimStaleLocalPreview(c *gin.Context) {
+	runtime, err := requestedRuntime(c)
+	if err != nil {
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	workspaceManager, err := services.DefaultLocalPreviewWorkspaceManager()
+	if err != nil {
+		ErrorInternal(c, "Local preview workspace is unavailable")
+		return
+	}
+	_, active, stale := workspaceManager.Status(runtime.ID)
+	if !active {
+		c.JSON(http.StatusOK, gin.H{"status": "stopped", "reclaimed": false})
+		return
+	}
+	if !stale {
+		ErrorConflict(c, services.ErrLocalPreviewSessionNotStale.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
+	cancel()
+	if stopErr != nil {
+		ErrorInternal(c, "Failed to stop stale Local Live Preview process")
+		return
+	}
+	reclaimed, err := workspaceManager.ReleaseStale(runtime.ID)
+	if err != nil {
+		if errors.Is(err, services.ErrLocalPreviewSessionNotStale) {
+			ErrorConflict(c, err.Error())
+			return
+		}
+		ErrorBadRequest(c, err.Error())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "stopped", "reclaimed": reclaimed})
+}

--- a/pkg/handlers/local_preview_control.go
+++ b/pkg/handlers/local_preview_control.go
@@ -54,15 +54,15 @@ func GetLocalPreviewStatus(c *gin.Context) {
 	}
 
 	response := gin.H{
-		"enabled":          true,
-		"status":           status,
-		"process_state":    processState,
-		"process_error":    processError,
-		"preview_url":      runtime.LocalPreview.URL,
-		"session_active":   active,
-		"session_owned":    owned,
-		"session_stale":    stale,
-		"lease_seconds":    int(workspaceManager.LeaseTTL().Seconds()),
+		"enabled":           true,
+		"status":            status,
+		"process_state":     processState,
+		"process_error":     processError,
+		"preview_url":       runtime.LocalPreview.URL,
+		"session_active":    active,
+		"session_owned":     owned,
+		"session_stale":     stale,
+		"lease_seconds":     int(workspaceManager.LeaseTTL().Seconds()),
 		"has_current_owner": active && !stale,
 	}
 	if active && !workspace.LastSeenAt.IsZero() {
@@ -94,7 +94,10 @@ func HeartbeatLocalPreviewContent(c *gin.Context) {
 	workspace, err := workspaceManager.Heartbeat(runtime.ID, req.DraftID)
 	if err != nil {
 		switch {
-		case errors.Is(err, services.ErrLocalPreviewSessionConflict), errors.Is(err, services.ErrLocalPreviewSessionNotFound):
+		case errors.Is(err, services.ErrLocalPreviewSessionConflict),
+			errors.Is(err, services.ErrLocalPreviewSessionNotFound),
+			errors.Is(err, services.ErrLocalPreviewSessionExpired),
+			errors.Is(err, services.ErrLocalPreviewSessionReclaiming):
 			ErrorConflict(c, err.Error())
 		default:
 			ErrorBadRequest(c, err.Error())
@@ -141,7 +144,7 @@ func StopLocalPreview(c *gin.Context) {
 	}
 	if active {
 		if _, err := workspaceManager.Release(runtime.ID, req.DraftID); err != nil {
-			if errors.Is(err, services.ErrLocalPreviewSessionConflict) {
+			if errors.Is(err, services.ErrLocalPreviewSessionConflict) || errors.Is(err, services.ErrLocalPreviewSessionReclaiming) {
 				ErrorConflict(c, err.Error())
 				return
 			}
@@ -163,13 +166,18 @@ func ReclaimStaleLocalPreview(c *gin.Context) {
 		ErrorInternal(c, "Local preview workspace is unavailable")
 		return
 	}
-	_, active, stale := workspaceManager.Status(runtime.ID)
-	if !active {
-		c.JSON(http.StatusOK, gin.H{"status": "stopped", "reclaimed": false})
+
+	claim, claimed, err := workspaceManager.ClaimStale(runtime.ID)
+	if err != nil {
+		if errors.Is(err, services.ErrLocalPreviewSessionNotStale) || errors.Is(err, services.ErrLocalPreviewSessionReclaiming) {
+			ErrorConflict(c, err.Error())
+			return
+		}
+		ErrorBadRequest(c, err.Error())
 		return
 	}
-	if !stale {
-		ErrorConflict(c, services.ErrLocalPreviewSessionNotStale.Error())
+	if !claimed {
+		c.JSON(http.StatusOK, gin.H{"status": "stopped", "reclaimed": false})
 		return
 	}
 
@@ -177,12 +185,14 @@ func ReclaimStaleLocalPreview(c *gin.Context) {
 	stopErr := services.DefaultLocalPreviewManager().Stop(ctx, runtime.ID)
 	cancel()
 	if stopErr != nil {
+		workspaceManager.CancelReclaim(claim)
 		ErrorInternal(c, "Failed to stop stale Local Live Preview process")
 		return
 	}
-	reclaimed, err := workspaceManager.ReleaseStale(runtime.ID)
+	reclaimed, err := workspaceManager.FinishReclaim(claim)
 	if err != nil {
-		if errors.Is(err, services.ErrLocalPreviewSessionNotStale) {
+		workspaceManager.CancelReclaim(claim)
+		if errors.Is(err, services.ErrLocalPreviewSessionConflict) || errors.Is(err, services.ErrLocalPreviewSessionReclaiming) {
 			ErrorConflict(c, err.Error())
 			return
 		}

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -16,10 +16,12 @@ import (
 const DefaultLocalPreviewLeaseTTL = 2 * time.Minute
 
 var (
-	ErrLocalPreviewSessionConflict = errors.New("another local preview session is already active for this site")
-	ErrLocalPreviewSessionMismatch = errors.New("local preview session article does not match request")
-	ErrLocalPreviewSessionNotFound = errors.New("local preview session is not active")
-	ErrLocalPreviewSessionNotStale = errors.New("local preview session is still active")
+	ErrLocalPreviewSessionConflict   = errors.New("another local preview session is already active for this site")
+	ErrLocalPreviewSessionMismatch   = errors.New("local preview session article does not match request")
+	ErrLocalPreviewSessionNotFound   = errors.New("local preview session is not active")
+	ErrLocalPreviewSessionNotStale   = errors.New("local preview session is still active")
+	ErrLocalPreviewSessionExpired    = errors.New("local preview session lease has expired")
+	ErrLocalPreviewSessionReclaiming = errors.New("local preview session is being reclaimed")
 )
 
 // LocalPreviewWorkspace is the active unsaved-content workspace for one site.
@@ -34,17 +36,33 @@ type LocalPreviewWorkspace struct {
 	LastSeenAt  time.Time
 }
 
+// LocalPreviewReclaim is an opaque ownership token for reclaiming one stale
+// workspace. Callers must either finish or cancel the claim before another
+// session for the same site can be created.
+type LocalPreviewReclaim struct {
+	siteID  string
+	draftID string
+	token   uint64
+}
+
+type localPreviewReclaimState struct {
+	draftID string
+	token   uint64
+}
+
 // LocalPreviewWorkspaceManager owns ephemeral shadow content directories. The
 // original repository remains the Hugo source root for configuration, theme,
 // layouts, static files and assets; only contentDir is redirected to this
 // workspace.
 type LocalPreviewWorkspaceManager struct {
-	root     string
-	mu       sync.Mutex
-	sessions map[string]LocalPreviewWorkspace
-	closed   bool
-	leaseTTL time.Duration
-	now      func() time.Time
+	root             string
+	mu               sync.Mutex
+	sessions         map[string]LocalPreviewWorkspace
+	reclaiming       map[string]localPreviewReclaimState
+	nextReclaimToken uint64
+	closed           bool
+	leaseTTL         time.Duration
+	now              func() time.Time
 }
 
 func NewLocalPreviewWorkspaceManager(root string) (*LocalPreviewWorkspaceManager, error) {
@@ -60,10 +78,11 @@ func NewLocalPreviewWorkspaceManager(root string) (*LocalPreviewWorkspaceManager
 		return nil, fmt.Errorf("create local preview workspace root: %w", err)
 	}
 	return &LocalPreviewWorkspaceManager{
-		root:     absRoot,
-		sessions: make(map[string]LocalPreviewWorkspace),
-		leaseTTL: DefaultLocalPreviewLeaseTTL,
-		now:      time.Now,
+		root:       absRoot,
+		sessions:   make(map[string]LocalPreviewWorkspace),
+		reclaiming: make(map[string]localPreviewReclaimState),
+		leaseTTL:   DefaultLocalPreviewLeaseTTL,
+		now:        time.Now,
 	}, nil
 }
 
@@ -108,10 +127,15 @@ func (m *LocalPreviewWorkspaceManager) staleLocked(workspace LocalPreviewWorkspa
 	return now.Sub(workspace.LastSeenAt) > m.leaseTTL
 }
 
+func (m *LocalPreviewWorkspaceManager) reclaimingLocked(siteID string) bool {
+	_, ok := m.reclaiming[siteID]
+	return ok
+}
+
 // Update creates the site's workspace on the first request and applies the
 // newest editor revision. Older in-flight HTTP requests become harmless no-ops
-// instead of overwriting newer editor state. Every request from the owner also
-// renews its lease, including a stale revision that arrives out of order.
+// instead of overwriting newer editor state. Requests renew a lease only while
+// it is still valid; an expired session must be reclaimed before it can restart.
 func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftID, articlePath string, revision uint64, content []byte) (LocalPreviewWorkspace, bool, bool, error) {
 	if err := validateDraftID(draftID); err != nil {
 		return LocalPreviewWorkspace{}, false, false, err
@@ -140,11 +164,17 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 	if m.closed {
 		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("local preview workspace manager is closed")
 	}
+	if m.reclaimingLocked(runtime.ID) {
+		return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionReclaiming
+	}
 	now := m.currentTimeLocked()
 
 	workspace, exists := m.sessions[runtime.ID]
 	created := false
 	if exists {
+		if m.staleLocked(workspace, now) {
+			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionExpired
+		}
 		if workspace.DraftID != draftID {
 			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionConflict
 		}
@@ -192,9 +222,9 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 	return workspace, created, true, nil
 }
 
-// Heartbeat renews the lease without changing content. A browser tab that was
-// temporarily throttled can renew its own expired lease as long as nobody has
-// reclaimed the workspace yet.
+// Heartbeat renews a live lease without changing content. Once the lease has
+// expired, the browser must reclaim/restart instead of reviving a session whose
+// Hugo process may already be stopping.
 func (m *LocalPreviewWorkspaceManager) Heartbeat(siteID, draftID string) (LocalPreviewWorkspace, error) {
 	if err := validateDraftID(draftID); err != nil {
 		return LocalPreviewWorkspace{}, err
@@ -204,6 +234,9 @@ func (m *LocalPreviewWorkspaceManager) Heartbeat(siteID, draftID string) (LocalP
 	if m.closed {
 		return LocalPreviewWorkspace{}, fmt.Errorf("local preview workspace manager is closed")
 	}
+	if m.reclaimingLocked(siteID) {
+		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionReclaiming
+	}
 	workspace, ok := m.sessions[siteID]
 	if !ok {
 		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionNotFound
@@ -211,7 +244,11 @@ func (m *LocalPreviewWorkspaceManager) Heartbeat(siteID, draftID string) (LocalP
 	if workspace.DraftID != draftID {
 		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionConflict
 	}
-	workspace.LastSeenAt = m.currentTimeLocked()
+	now := m.currentTimeLocked()
+	if m.staleLocked(workspace, now) {
+		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionExpired
+	}
+	workspace.LastSeenAt = now
 	m.sessions[siteID] = workspace
 	return workspace, nil
 }
@@ -252,8 +289,11 @@ func (m *LocalPreviewWorkspaceManager) SyncContentResource(runtime config.SiteRu
 	if m.closed {
 		return false, fmt.Errorf("local preview workspace manager is closed")
 	}
+	if m.reclaimingLocked(runtime.ID) {
+		return false, nil
+	}
 	workspace, active := m.sessions[runtime.ID]
-	if !active {
+	if !active || m.staleLocked(workspace, m.currentTimeLocked()) {
 		return false, nil
 	}
 	target := SafeJoin(workspace.ContentDir, "", relative)
@@ -292,6 +332,9 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.reclaimingLocked(siteID) {
+		return false, ErrLocalPreviewSessionReclaiming
+	}
 
 	workspace, ok := m.sessions[siteID]
 	if !ok {
@@ -303,20 +346,75 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 	return m.removeWorkspaceLocked(siteID, workspace)
 }
 
-// ReleaseStale removes an expired workspace without requiring its previous
-// document-scoped owner ID. The stale check is repeated under the manager lock
-// so a heartbeat racing with recovery prevents accidental reclamation.
-func (m *LocalPreviewWorkspaceManager) ReleaseStale(siteID string) (bool, error) {
+// ClaimStale atomically marks an expired workspace as reclaiming. While the
+// claim is held, heartbeat/update/release/resource-sync operations for the same
+// site cannot mutate or revive the session. This claim must be acquired before
+// stopping Hugo so a racing heartbeat cannot leave a fresh session with a
+// stopped process.
+func (m *LocalPreviewWorkspaceManager) ClaimStale(siteID string) (LocalPreviewReclaim, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.closed {
+		return LocalPreviewReclaim{}, false, fmt.Errorf("local preview workspace manager is closed")
+	}
+	if m.reclaimingLocked(siteID) {
+		return LocalPreviewReclaim{}, false, ErrLocalPreviewSessionReclaiming
+	}
 	workspace, ok := m.sessions[siteID]
+	if !ok {
+		return LocalPreviewReclaim{}, false, nil
+	}
+	if !m.staleLocked(workspace, m.currentTimeLocked()) {
+		return LocalPreviewReclaim{}, false, ErrLocalPreviewSessionNotStale
+	}
+	m.nextReclaimToken++
+	state := localPreviewReclaimState{draftID: workspace.DraftID, token: m.nextReclaimToken}
+	m.reclaiming[siteID] = state
+	return LocalPreviewReclaim{siteID: siteID, draftID: workspace.DraftID, token: state.token}, true, nil
+}
+
+// FinishReclaim removes the workspace owned by a previously acquired stale
+// claim. The token and draft ID prevent an old cleanup attempt from deleting a
+// different session if the lifecycle changes in the future.
+func (m *LocalPreviewWorkspaceManager) FinishReclaim(claim LocalPreviewReclaim) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state, ok := m.reclaiming[claim.siteID]
+	if !ok || state.token != claim.token || state.draftID != claim.draftID {
+		return false, ErrLocalPreviewSessionReclaiming
+	}
+	defer delete(m.reclaiming, claim.siteID)
+	workspace, ok := m.sessions[claim.siteID]
 	if !ok {
 		return false, nil
 	}
-	if !m.staleLocked(workspace, m.currentTimeLocked()) {
-		return false, ErrLocalPreviewSessionNotStale
+	if workspace.DraftID != claim.draftID {
+		return false, ErrLocalPreviewSessionConflict
 	}
-	return m.removeWorkspaceLocked(siteID, workspace)
+	return m.removeWorkspaceLocked(claim.siteID, workspace)
+}
+
+// CancelReclaim releases a stale claim without removing the workspace. It is
+// used when Hugo cannot be stopped; the expired session remains stale and can
+// be reclaimed again, but it still cannot be revived by heartbeat/update.
+func (m *LocalPreviewWorkspaceManager) CancelReclaim(claim LocalPreviewReclaim) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	state, ok := m.reclaiming[claim.siteID]
+	if ok && state.token == claim.token && state.draftID == claim.draftID {
+		delete(m.reclaiming, claim.siteID)
+	}
+}
+
+// ReleaseStale atomically claims and removes an expired workspace. Callers that
+// must stop the Hugo process before deleting the workspace should use
+// ClaimStale followed by FinishReclaim instead.
+func (m *LocalPreviewWorkspaceManager) ReleaseStale(siteID string) (bool, error) {
+	claim, claimed, err := m.ClaimStale(siteID)
+	if err != nil || !claimed {
+		return false, err
+	}
+	return m.FinishReclaim(claim)
 }
 
 func (m *LocalPreviewWorkspaceManager) removeWorkspaceLocked(siteID string, workspace LocalPreviewWorkspace) (bool, error) {
@@ -341,6 +439,7 @@ func (m *LocalPreviewWorkspaceManager) Shutdown() error {
 	}
 	m.closed = true
 	m.sessions = make(map[string]LocalPreviewWorkspace)
+	m.reclaiming = make(map[string]localPreviewReclaimState)
 	root := m.root
 	m.mu.Unlock()
 	if err := os.RemoveAll(root); err != nil {

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -10,22 +10,28 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
+
+const DefaultLocalPreviewLeaseTTL = 2 * time.Minute
 
 var (
 	ErrLocalPreviewSessionConflict = errors.New("another local preview session is already active for this site")
 	ErrLocalPreviewSessionMismatch = errors.New("local preview session article does not match request")
+	ErrLocalPreviewSessionNotFound = errors.New("local preview session is not active")
+	ErrLocalPreviewSessionNotStale = errors.New("local preview session is still active")
 )
 
 // LocalPreviewWorkspace is the active unsaved-content workspace for one site.
-// Phase 3 intentionally limits each site to one active draft/session so two
-// browser tabs cannot silently mix unsaved content.
+// Each site is intentionally limited to one active browser-document session so
+// separate tabs cannot silently mix unsaved content.
 type LocalPreviewWorkspace struct {
 	SiteID      string
 	DraftID     string
 	ArticlePath string
 	ContentDir  string
 	Revision    uint64
+	LastSeenAt  time.Time
 }
 
 // LocalPreviewWorkspaceManager owns ephemeral shadow content directories. The
@@ -37,6 +43,8 @@ type LocalPreviewWorkspaceManager struct {
 	mu       sync.Mutex
 	sessions map[string]LocalPreviewWorkspace
 	closed   bool
+	leaseTTL time.Duration
+	now      func() time.Time
 }
 
 func NewLocalPreviewWorkspaceManager(root string) (*LocalPreviewWorkspaceManager, error) {
@@ -54,6 +62,8 @@ func NewLocalPreviewWorkspaceManager(root string) (*LocalPreviewWorkspaceManager
 	return &LocalPreviewWorkspaceManager{
 		root:     absRoot,
 		sessions: make(map[string]LocalPreviewWorkspace),
+		leaseTTL: DefaultLocalPreviewLeaseTTL,
+		now:      time.Now,
 	}, nil
 }
 
@@ -78,9 +88,30 @@ func DefaultLocalPreviewWorkspaceManager() (*LocalPreviewWorkspaceManager, error
 	return defaultLocalPreviewWorkspace, defaultLocalPreviewWorkspaceErr
 }
 
+func (m *LocalPreviewWorkspaceManager) LeaseTTL() time.Duration {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.leaseTTL
+}
+
+func (m *LocalPreviewWorkspaceManager) currentTimeLocked() time.Time {
+	if m.now == nil {
+		return time.Now().UTC()
+	}
+	return m.now().UTC()
+}
+
+func (m *LocalPreviewWorkspaceManager) staleLocked(workspace LocalPreviewWorkspace, now time.Time) bool {
+	if workspace.LastSeenAt.IsZero() {
+		return true
+	}
+	return now.Sub(workspace.LastSeenAt) > m.leaseTTL
+}
+
 // Update creates the site's workspace on the first request and applies the
 // newest editor revision. Older in-flight HTTP requests become harmless no-ops
-// instead of overwriting newer editor state.
+// instead of overwriting newer editor state. Every request from the owner also
+// renews its lease, including a stale revision that arrives out of order.
 func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftID, articlePath string, revision uint64, content []byte) (LocalPreviewWorkspace, bool, bool, error) {
 	if err := validateDraftID(draftID); err != nil {
 		return LocalPreviewWorkspace{}, false, false, err
@@ -109,6 +140,7 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 	if m.closed {
 		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("local preview workspace manager is closed")
 	}
+	now := m.currentTimeLocked()
 
 	workspace, exists := m.sessions[runtime.ID]
 	created := false
@@ -119,7 +151,9 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 		if workspace.ArticlePath != filepath.ToSlash(articlePath) {
 			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionMismatch
 		}
+		workspace.LastSeenAt = now
 		if revision <= workspace.Revision {
+			m.sessions[runtime.ID] = workspace
 			return workspace, false, false, nil
 		}
 	} else {
@@ -137,6 +171,7 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 			DraftID:     draftID,
 			ArticlePath: filepath.ToSlash(articlePath),
 			ContentDir:  contentDir,
+			LastSeenAt:  now,
 		}
 		created = true
 	}
@@ -152,8 +187,44 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 		return LocalPreviewWorkspace{}, false, false, err
 	}
 	workspace.Revision = revision
+	workspace.LastSeenAt = now
 	m.sessions[runtime.ID] = workspace
 	return workspace, created, true, nil
+}
+
+// Heartbeat renews the lease without changing content. A browser tab that was
+// temporarily throttled can renew its own expired lease as long as nobody has
+// reclaimed the workspace yet.
+func (m *LocalPreviewWorkspaceManager) Heartbeat(siteID, draftID string) (LocalPreviewWorkspace, error) {
+	if err := validateDraftID(draftID); err != nil {
+		return LocalPreviewWorkspace{}, err
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return LocalPreviewWorkspace{}, fmt.Errorf("local preview workspace manager is closed")
+	}
+	workspace, ok := m.sessions[siteID]
+	if !ok {
+		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionNotFound
+	}
+	if workspace.DraftID != draftID {
+		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionConflict
+	}
+	workspace.LastSeenAt = m.currentTimeLocked()
+	m.sessions[siteID] = workspace
+	return workspace, nil
+}
+
+// Status reports the active workspace and whether its lease has expired.
+func (m *LocalPreviewWorkspaceManager) Status(siteID string) (LocalPreviewWorkspace, bool, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	workspace, ok := m.sessions[siteID]
+	if !ok {
+		return LocalPreviewWorkspace{}, false, false
+	}
+	return workspace, true, m.staleLocked(workspace, m.currentTimeLocked())
 }
 
 // SyncContentResource mirrors a content-directory resource change made through
@@ -173,9 +244,6 @@ func (m *LocalPreviewWorkspaceManager) SyncContentResource(runtime config.SiteRu
 	}
 	relative, err := filepath.Rel(sourceContentDir, sourcePath)
 	if err != nil || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
-		// The media file is outside contentDir (for example static/). Hugo still
-		// reads it directly from the original repository, so no shadow sync is
-		// required.
 		return false, nil
 	}
 
@@ -232,6 +300,26 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 	if workspace.DraftID != draftID {
 		return false, ErrLocalPreviewSessionConflict
 	}
+	return m.removeWorkspaceLocked(siteID, workspace)
+}
+
+// ReleaseStale removes an expired workspace without requiring its previous
+// document-scoped owner ID. The stale check is repeated under the manager lock
+// so a heartbeat racing with recovery prevents accidental reclamation.
+func (m *LocalPreviewWorkspaceManager) ReleaseStale(siteID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	workspace, ok := m.sessions[siteID]
+	if !ok {
+		return false, nil
+	}
+	if !m.staleLocked(workspace, m.currentTimeLocked()) {
+		return false, ErrLocalPreviewSessionNotStale
+	}
+	return m.removeWorkspaceLocked(siteID, workspace)
+}
+
+func (m *LocalPreviewWorkspaceManager) removeWorkspaceLocked(siteID string, workspace LocalPreviewWorkspace) (bool, error) {
 	workspaceRoot := filepath.Dir(workspace.ContentDir)
 	if err := os.RemoveAll(workspaceRoot); err != nil {
 		return false, fmt.Errorf("remove local preview workspace: %w", err)
@@ -241,10 +329,8 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 }
 
 func (m *LocalPreviewWorkspaceManager) Active(siteID string) (LocalPreviewWorkspace, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	workspace, ok := m.sessions[siteID]
-	return workspace, ok
+	workspace, active, _ := m.Status(siteID)
+	return workspace, active
 }
 
 func (m *LocalPreviewWorkspaceManager) Shutdown() error {
@@ -340,8 +426,6 @@ func writeLocalPreviewFileAtomic(path string, content []byte) error {
 		return err
 	}
 	if err := os.Rename(temporaryPath, path); err != nil {
-		// Windows cannot atomically replace an existing path. The fully-written
-		// temporary file is used for the fallback replacement.
 		if _, statErr := os.Stat(path); statErr != nil {
 			return fmt.Errorf("replace local preview content: %w", err)
 		}

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLocalPreviewWorkspaceMirrorsAndUpdatesContent(t *testing.T) {
@@ -148,6 +149,72 @@ func TestLocalPreviewWorkspaceReleaseProtectsActiveDraft(t *testing.T) {
 	}
 	if _, err := os.Stat(workspace.ContentDir); !os.IsNotExist(err) {
 		t.Fatalf("workspace still exists after release: %v", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceLeaseAndHeartbeat(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.leaseTTL = 2 * time.Minute
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !workspace.LastSeenAt.Equal(now) {
+		t.Fatalf("last seen = %s, want %s", workspace.LastSeenAt, now)
+	}
+
+	now = now.Add(3 * time.Minute)
+	_, active, stale := manager.Status("tech")
+	if !active || !stale {
+		t.Fatalf("active=%v stale=%v, want true/true", active, stale)
+	}
+	workspace, err = manager.Heartbeat("tech", "draft-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !workspace.LastSeenAt.Equal(now) {
+		t.Fatalf("heartbeat last seen = %s, want %s", workspace.LastSeenAt, now)
+	}
+	_, _, stale = manager.Status("tech")
+	if stale {
+		t.Fatal("heartbeat did not renew lease")
+	}
+	if _, err := manager.Heartbeat("tech", "draft-2"); !errors.Is(err, ErrLocalPreviewSessionConflict) {
+		t.Fatalf("heartbeat error = %v, want conflict", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceReleaseStaleRequiresExpiredLease(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.leaseTTL = time.Minute
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.ReleaseStale("tech"); !errors.Is(err, ErrLocalPreviewSessionNotStale) {
+		t.Fatalf("ReleaseStale error = %v, want not stale", err)
+	}
+	now = now.Add(2 * time.Minute)
+	released, err := manager.ReleaseStale("tech")
+	if err != nil || !released {
+		t.Fatalf("ReleaseStale released=%v err=%v", released, err)
+	}
+	if _, err := os.Stat(workspace.ContentDir); !os.IsNotExist(err) {
+		t.Fatalf("stale workspace still exists: %v", err)
 	}
 }
 

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -170,11 +170,7 @@ func TestLocalPreviewWorkspaceLeaseAndHeartbeat(t *testing.T) {
 		t.Fatalf("last seen = %s, want %s", workspace.LastSeenAt, now)
 	}
 
-	now = now.Add(3 * time.Minute)
-	_, active, stale := manager.Status("tech")
-	if !active || !stale {
-		t.Fatalf("active=%v stale=%v, want true/true", active, stale)
-	}
+	now = now.Add(time.Minute)
 	workspace, err = manager.Heartbeat("tech", "draft-1")
 	if err != nil {
 		t.Fatal(err)
@@ -182,12 +178,150 @@ func TestLocalPreviewWorkspaceLeaseAndHeartbeat(t *testing.T) {
 	if !workspace.LastSeenAt.Equal(now) {
 		t.Fatalf("heartbeat last seen = %s, want %s", workspace.LastSeenAt, now)
 	}
-	_, _, stale = manager.Status("tech")
-	if stale {
-		t.Fatal("heartbeat did not renew lease")
+
+	expiredLastSeen := workspace.LastSeenAt
+	now = now.Add(3 * time.Minute)
+	_, active, stale := manager.Status("tech")
+	if !active || !stale {
+		t.Fatalf("active=%v stale=%v, want true/true", active, stale)
+	}
+	if _, err := manager.Heartbeat("tech", "draft-1"); !errors.Is(err, ErrLocalPreviewSessionExpired) {
+		t.Fatalf("heartbeat error = %v, want expired", err)
+	}
+	workspace, _, stale = manager.Status("tech")
+	if !stale || !workspace.LastSeenAt.Equal(expiredLastSeen) {
+		t.Fatalf("expired heartbeat mutated lease: stale=%v last_seen=%s want=%s", stale, workspace.LastSeenAt, expiredLastSeen)
 	}
 	if _, err := manager.Heartbeat("tech", "draft-2"); !errors.Is(err, ErrLocalPreviewSessionConflict) {
 		t.Fatalf("heartbeat error = %v, want conflict", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceExpiredUpdateCannotRevive(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.leaseTTL = time.Minute
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("first"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(2 * time.Minute)
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 2, []byte("revived")); !errors.Is(err, ErrLocalPreviewSessionExpired) {
+		t.Fatalf("Update() error = %v, want expired", err)
+	}
+	current, active, stale := manager.Status("tech")
+	if !active || !stale || current.Revision != 1 {
+		t.Fatalf("active=%v stale=%v revision=%d, want true/true/1", active, stale, current.Revision)
+	}
+	got, err := os.ReadFile(filepath.Join(workspace.ContentDir, "one.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("expired update changed content: %q", got)
+	}
+}
+
+func TestLocalPreviewWorkspaceClaimStaleBlocksSameSiteMutations(t *testing.T) {
+	repoTech := makeLocalPreviewWorkspaceRepo(t)
+	repoDaily := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.leaseTTL = time.Minute
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	tech := config.SiteRuntime{ID: "tech", RepoPath: repoTech, ContentDir: "content"}
+	daily := config.SiteRuntime{ID: "daily", RepoPath: repoDaily, ContentDir: "content"}
+	workspace, _, _, err := manager.Update(tech, "draft-tech", "one.md", 1, []byte("tech"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := manager.Update(daily, "draft-daily", "one.md", 1, []byte("daily")); err != nil {
+		t.Fatal(err)
+	}
+
+	now = now.Add(2 * time.Minute)
+	claim, claimed, err := manager.ClaimStale("tech")
+	if err != nil || !claimed {
+		t.Fatalf("ClaimStale() claimed=%v err=%v", claimed, err)
+	}
+	if _, err := manager.Heartbeat("tech", "draft-tech"); !errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+		t.Fatalf("Heartbeat() error = %v, want reclaiming", err)
+	}
+	if _, _, _, err := manager.Update(tech, "draft-tech", "one.md", 2, []byte("race")); !errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+		t.Fatalf("Update() error = %v, want reclaiming", err)
+	}
+	if _, err := manager.Release("tech", "draft-tech"); !errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+		t.Fatalf("Release() error = %v, want reclaiming", err)
+	}
+	if _, _, err := manager.ClaimStale("tech"); !errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+		t.Fatalf("second ClaimStale() error = %v, want reclaiming", err)
+	}
+	if _, err := manager.Heartbeat("daily", "draft-daily"); !errors.Is(err, ErrLocalPreviewSessionExpired) {
+		t.Fatalf("daily heartbeat error = %v, want independently expired", err)
+	}
+
+	resourcePath := filepath.Join(repoTech, "content", "image.png")
+	if err := os.WriteFile(resourcePath, []byte("image"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	synced, err := manager.SyncContentResource(tech, "content/image.png", false)
+	if err != nil || synced {
+		t.Fatalf("SyncContentResource() synced=%v err=%v, want false/nil while reclaiming", synced, err)
+	}
+
+	reclaimed, err := manager.FinishReclaim(claim)
+	if err != nil || !reclaimed {
+		t.Fatalf("FinishReclaim() reclaimed=%v err=%v", reclaimed, err)
+	}
+	if _, err := os.Stat(workspace.ContentDir); !os.IsNotExist(err) {
+		t.Fatalf("reclaimed workspace still exists: %v", err)
+	}
+	if _, active, _ := manager.Status("tech"); active {
+		t.Fatal("reclaimed session is still active")
+	}
+	if _, _, _, err := manager.Update(tech, "draft-new", "one.md", 1, []byte("new")); err != nil {
+		t.Fatalf("new session after reclaim failed: %v", err)
+	}
+}
+
+func TestLocalPreviewWorkspaceCancelReclaimDoesNotReviveExpiredSession(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	manager.leaseTTL = time.Minute
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return now }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft")); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(2 * time.Minute)
+	claim, claimed, err := manager.ClaimStale("tech")
+	if err != nil || !claimed {
+		t.Fatalf("ClaimStale() claimed=%v err=%v", claimed, err)
+	}
+	manager.CancelReclaim(claim)
+	if _, err := manager.Heartbeat("tech", "draft-1"); !errors.Is(err, ErrLocalPreviewSessionExpired) {
+		t.Fatalf("Heartbeat() error = %v, want expired after cancel", err)
+	}
+	claim, claimed, err = manager.ClaimStale("tech")
+	if err != nil || !claimed {
+		t.Fatalf("second ClaimStale() claimed=%v err=%v", claimed, err)
+	}
+	if reclaimed, err := manager.FinishReclaim(claim); err != nil || !reclaimed {
+		t.Fatalf("FinishReclaim() reclaimed=%v err=%v", reclaimed, err)
 	}
 }
 

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -47,7 +47,6 @@ function getCSRFHeaders() {
     return csrfToken ? { 'X-CSRF-Token': csrfToken } : {};
 }
 
-// Reset CSRF token on 403 errors (token expired/invalid)
 function resetCSRFToken() {
     csrfToken = null;
 }
@@ -119,7 +118,6 @@ export async function saveArticle(payload) {
         },
         body: JSON.stringify(payload)
     });
-    // Handle CSRF token expiration - retry once with fresh token
     if (res.status === 403) {
         resetCSRFToken();
         await ensureCSRFToken(true);
@@ -259,6 +257,56 @@ export async function releaseLocalPreviewContent(draftID) {
         body: JSON.stringify({ draft_id: draftID })
     });
     if (!res.ok) throw await responseError(res, "Local Live Preview release failed");
+    return await res.json();
+}
+
+export async function fetchLocalPreviewStatus(draftID = "", signal) {
+    let url = '/admin/api/preview/local/status';
+    if (draftID) url += `?draft_id=${encodeURIComponent(draftID)}`;
+    const res = await fetch(withSite(url), {
+        headers: siteHeaders(),
+        signal
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview status failed");
+    return await res.json();
+}
+
+export async function heartbeatLocalPreviewContent(draftID) {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/heartbeat'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...siteHeaders()
+        },
+        body: JSON.stringify({ draft_id: draftID })
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview heartbeat failed");
+    return await res.json();
+}
+
+export async function stopLocalPreviewContent(draftID = "") {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/stop'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...siteHeaders()
+        },
+        body: JSON.stringify({ draft_id: draftID })
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview stop failed");
+    return await res.json();
+}
+
+export async function reclaimStaleLocalPreview() {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/reclaim'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            ...siteHeaders()
+        },
+        body: JSON.stringify({})
+    });
+    if (!res.ok) throw await responseError(res, "Local Live Preview recovery failed");
     return await res.json();
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -11,8 +11,17 @@ let deploymentState = null;
 let deploymentPollTimer = null;
 let deploymentController = null;
 let deploymentOperationInProgress = false;
+let localPreviewEnabled = false;
+let localPreviewState = null;
+let localPreviewSessionID = "";
+let localPreviewPollTimer = null;
+let localPreviewHeartbeatTimer = null;
+let localPreviewController = null;
+let localPreviewOperationInProgress = false;
 
-// Initialization
+const LOCAL_PREVIEW_POLL_MS = 3000;
+const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
+
 init();
 
 async function init() {
@@ -28,16 +37,12 @@ async function init() {
 
     Editor.initAutoSave();
 
-    // --- Expose functions to Global Scope for HTML onclick handlers ---
-
-    // UI
     window.switchView = switchView;
     window.toggleSplitView = UI.toggleSplitView;
     window.toggleSidebar = UI.toggleSidebar;
     window.toggleHeaderMenu = UI.toggleHeaderMenu;
     window.closeModal = UI.closeModal;
 
-    // Editor
     window.loadFile = loadFile;
     window.buildAndPreview = () => Editor.refreshMarkdownPreview();
     window.saveFile = async () => {
@@ -45,14 +50,16 @@ async function init() {
         await refreshFileList();
     };
     window.createNewFile = () => Editor.createNewFile(refreshFileList);
-    window.deleteFile = () => Editor.deleteFile(refreshFileList);
+    window.deleteFile = async () => {
+        await Editor.deleteFile(refreshFileList);
+        await refreshLocalPreviewStatus();
+        if (!localPreviewState?.session_active) localPreviewSessionID = "";
+    };
     window.insertImage = () => {
         const currentPath = Editor.getCurrentPath();
         let collectionName = null;
         const collection = UI.getCollectionForPath(currentPath, cmsConfig);
-        if (collection) {
-            collectionName = collection.name;
-        }
+        if (collection) collectionName = collection.name;
 
         UI.showMediaLibrary((file) => {
             const markdown = `![${file.name}](${file.path})`;
@@ -62,40 +69,30 @@ async function init() {
     window.insertSnippet = async () => {
         try {
             const snippets = await API.fetchSnippets();
-            
             const showList = () => {
                 UI.showSnippetsModal(snippets, (snippet) => {
                     let body = Array.isArray(snippet.body) ? snippet.body.join('\n') : snippet.body;
-    
                     const vars = new Map();
-                    // Regex for ${1:default} or ${1}
                     const regex = /\$\{(\d+)(?::([^}]*))?\}/g;
                     let match;
                     while ((match = regex.exec(body)) !== null) {
                         const id = match[1];
                         const def = match[2] || "";
-                        if (!vars.has(id)) {
-                            vars.set(id, { id, label: def || `Param ${id}`, default: def });
-                        }
+                        if (!vars.has(id)) vars.set(id, { id, label: def || `Param ${id}`, default: def });
                     }
-    
                     if (vars.size > 0) {
                         const varList = Array.from(vars.values()).sort((a, b) => a.id - b.id);
                         UI.showSnippetInputModal(varList, (values) => {
-                            let finalBody = body.replace(regex, (m, id, def) => {
-                                return values[id] !== undefined ? values[id] : (def || "");
-                            });
+                            const finalBody = body.replace(regex, (m, id, def) => values[id] !== undefined ? values[id] : (def || ""));
                             Editor.insertText(finalBody);
-                        }, showList); // Pass showList as onBack
+                        }, showList);
                     } else {
                         Editor.insertText(body);
                         UI.closeModal();
                     }
                 });
             };
-            
             showList();
-
         } catch (e) {
             UI.showToast("Failed to load snippets: " + e.message, "error");
         }
@@ -103,24 +100,39 @@ async function init() {
     window.resetChanges = Editor.resetChanges;
     window.showDiff = Editor.showDiff;
 
-    // Actions
     window.runSync = runSync;
     window.publishFile = publishFile;
     window.updateDeploymentPreview = updateDeploymentPreview;
     window.retryDeploymentPreview = retryDeploymentPreview;
     window.discardDeploymentPreview = discardDeploymentPreview;
     window.markDeploymentPreviewStale = markDeploymentPreviewStale;
+    window.openLocalLivePreview = openLocalLivePreview;
+    window.toggleEmbeddedLocalPreview = toggleEmbeddedLocalPreview;
+    window.stopLocalLivePreview = stopLocalLivePreview;
+    window.reclaimLocalLivePreview = reclaimLocalLivePreview;
 
     console.log("Hugo CMS Initialized");
 }
 
 async function loadSiteData() {
+    stopLocalPreviewMonitoring();
+    localPreviewSessionID = "";
+    localPreviewState = null;
+
     cmsConfig = await API.fetchConfig();
     const site = siteRegistry?.sites?.find(s => s.id === API.getCurrentSite());
     if (!cmsConfig._cms) cmsConfig._cms = {};
     cmsConfig._cms.local_preview = site?.preview?.local_preview || { enabled: false, url: '' };
     Editor.setConfig(cmsConfig);
     UI.renderConfigWarnings(cmsConfig);
+
+    localPreviewEnabled = cmsConfig?._cms?.local_preview?.enabled === true && Boolean(localPreviewURL());
+    configureLocalPreviewPanel();
+    if (localPreviewEnabled) {
+        await refreshLocalPreviewStatus();
+        scheduleLocalPreviewMonitoring();
+    }
+
     deploymentEnabled = UI.configureDeploymentPreview(cmsConfig);
     deploymentState = null;
     UI.renderDeploymentState(null);
@@ -140,16 +152,17 @@ async function switchSite(siteID) {
     }
 
     try {
-        // Release while API.getCurrentSite() still points at the old site so
-        // the old site's shadow workspace cannot leak into a later edit.
         await Editor.releaseLocalLivePreview();
+        localPreviewSessionID = "";
     } catch (e) {
         UI.showToast("Site switch cancelled: Local Live Preview cleanup failed", "error");
         UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite);
         return;
     }
 
+    stopLocalPreviewMonitoring();
     stopDeploymentPolling();
+    closeEmbeddedLocalPreview();
     API.setCurrentSite(siteID);
     Editor.clearEditor();
     try {
@@ -173,7 +186,17 @@ async function loadFile(path) {
     stopDeploymentPolling();
     deploymentState = null;
     UI.renderDeploymentState(null);
+    localPreviewSessionID = "";
     await Editor.loadFile(path);
+    if (localPreviewEnabled && Editor.getCurrentPath() === path) {
+        try {
+            await ensureLocalPreviewSession();
+        } catch (_) {
+            // Editor already reports 409 conflicts; status panel provides the
+            // persistent recovery action when the old session becomes stale.
+        }
+        await refreshLocalPreviewStatus();
+    }
     if (deploymentEnabled && Editor.getCurrentPath() === path) {
         await refreshDeploymentState();
     }
@@ -182,9 +205,7 @@ async function loadFile(path) {
 async function refreshFileList() {
     try {
         const files = await API.fetchArticles();
-        if (files) {
-            UI.renderFileList(files, cmsConfig);
-        }
+        if (files) UI.renderFileList(files, cmsConfig);
     } catch (e) {
         UI.showToast("Failed to fetch file list", "error");
     }
@@ -194,12 +215,229 @@ async function switchView(viewName) {
     if (viewName === 'preview') {
         try {
             await Editor.refreshMarkdownPreview();
-        } catch (e) {
-            // The preview surface already shows the request error. Editing and
-            // saving remain available even when rendering is temporarily down.
+        } catch (_) {
+            // The preview surface already shows the request error.
         }
     }
     UI.switchView(viewName);
+}
+
+function localPreviewURL() {
+    return UI.safeExternalURL(cmsConfig?._cms?.local_preview?.url || "");
+}
+
+function configureLocalPreviewPanel() {
+    const panel = document.getElementById('local-preview-panel');
+    if (!panel) return;
+    panel.classList.toggle('hidden', !localPreviewEnabled);
+    if (!localPreviewEnabled) {
+        closeEmbeddedLocalPreview();
+        return;
+    }
+    renderLocalPreviewState({ enabled: true, status: 'stopped', process_state: 'stopped', session_active: false });
+}
+
+function localPreviewStatusClass(status) {
+    if (status === 'ready') return 'ready';
+    if (status === 'starting') return 'queued';
+    if (status === 'failed' || status === 'stale' || status === 'conflict') return 'failed';
+    return 'idle';
+}
+
+function localPreviewStatusLabel(status) {
+    return ({
+        stopped: '停止',
+        starting: '起動中',
+        ready: 'Ready',
+        failed: '失敗',
+        stopping: '停止中',
+        stale: '期限切れ',
+        conflict: '別タブ使用中',
+        disabled: '無効',
+    })[status] || status || '停止';
+}
+
+function renderLocalPreviewState(state) {
+    localPreviewState = state || null;
+    const statusEl = document.getElementById('local-preview-status');
+    const messageEl = document.getElementById('local-preview-message');
+    const reclaimBtn = document.getElementById('local-preview-reclaim-btn');
+    const stopBtn = document.getElementById('local-preview-stop-btn');
+    if (!statusEl || !messageEl) return;
+
+    const status = state?.status || 'stopped';
+    statusEl.textContent = localPreviewStatusLabel(status);
+    statusEl.className = `deployment-status ${localPreviewStatusClass(status)}`;
+
+    let message = '記事を選択すると未保存内容をshadow workspaceへ同期します。';
+    if (status === 'ready') message = 'Hugo Live Preview is ready. 編集内容はLiveReloadで反映されます。';
+    else if (status === 'starting') message = 'Hugoを起動しています…';
+    else if (status === 'failed') message = state?.process_error || 'Hugo Live Previewの起動に失敗しました。';
+    else if (status === 'stale') message = '以前のタブのpreview sessionが期限切れです。安全に回収して再開できます。';
+    else if (status === 'conflict') message = 'このsiteのLocal Live Previewは別のタブで使用中です。';
+    else if (state?.session_active && state?.session_owned) message = '未保存内容は同期済みです。Previewを開くとHugoを起動します。';
+    else if (state?.session_active) message = 'このsiteには別の編集sessionがあります。';
+    messageEl.textContent = message;
+
+    if (reclaimBtn) reclaimBtn.classList.toggle('hidden', !state?.session_stale);
+    if (stopBtn) {
+        const processRunning = state?.process_state && state.process_state !== 'stopped';
+        stopBtn.classList.toggle('hidden', !(state?.session_owned || (!state?.session_active && processRunning)));
+    }
+}
+
+async function ensureLocalPreviewSession() {
+    if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
+    try {
+        const result = await Editor.refreshLocalLivePreview();
+        if (result?.session_id) localPreviewSessionID = result.session_id;
+        return result;
+    } catch (e) {
+        if (e?.status === 409) {
+            renderLocalPreviewState({
+                ...(localPreviewState || {}),
+                enabled: true,
+                status: 'conflict',
+                session_active: true,
+                session_owned: false,
+            });
+        }
+        throw e;
+    }
+}
+
+function stopLocalPreviewMonitoring() {
+    if (localPreviewPollTimer) clearTimeout(localPreviewPollTimer);
+    if (localPreviewHeartbeatTimer) clearTimeout(localPreviewHeartbeatTimer);
+    localPreviewPollTimer = null;
+    localPreviewHeartbeatTimer = null;
+    if (localPreviewController) localPreviewController.abort();
+    localPreviewController = null;
+}
+
+function scheduleLocalPreviewMonitoring() {
+    if (!localPreviewEnabled) return;
+    if (!localPreviewPollTimer) {
+        localPreviewPollTimer = setTimeout(async () => {
+            localPreviewPollTimer = null;
+            await refreshLocalPreviewStatus();
+            scheduleLocalPreviewMonitoring();
+        }, LOCAL_PREVIEW_POLL_MS);
+    }
+    if (!localPreviewHeartbeatTimer) {
+        localPreviewHeartbeatTimer = setTimeout(async () => {
+            localPreviewHeartbeatTimer = null;
+            if (localPreviewSessionID) {
+                try {
+                    await API.heartbeatLocalPreviewContent(localPreviewSessionID);
+                } catch (e) {
+                    if (e?.status !== 409) console.error('[LocalPreview] heartbeat failed', e);
+                }
+            }
+            scheduleLocalPreviewMonitoring();
+        }, LOCAL_PREVIEW_HEARTBEAT_MS);
+    }
+}
+
+async function refreshLocalPreviewStatus() {
+    if (!localPreviewEnabled) return null;
+    if (localPreviewController) localPreviewController.abort();
+    const controller = new AbortController();
+    localPreviewController = controller;
+    try {
+        const state = await API.fetchLocalPreviewStatus(localPreviewSessionID, controller.signal);
+        renderLocalPreviewState(state);
+        return state;
+    } catch (e) {
+        if (e?.name !== 'AbortError') console.error('[LocalPreview] status failed', e);
+        return null;
+    } finally {
+        if (localPreviewController === controller) localPreviewController = null;
+    }
+}
+
+async function openLocalLivePreview() {
+    const url = localPreviewURL();
+    if (!localPreviewEnabled || !url) {
+        UI.showToast('Local Live Preview is not configured', 'warning');
+        return;
+    }
+    try {
+        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        window.open(url, '_blank', 'noopener');
+        setTimeout(() => refreshLocalPreviewStatus(), 500);
+    } catch (e) {
+        UI.showToast('Local Live Previewを開けません: ' + e.message, 'error');
+    }
+}
+
+async function toggleEmbeddedLocalPreview() {
+    const wrapper = document.getElementById('local-preview-embed');
+    const frame = document.getElementById('local-preview-frame');
+    const btn = document.getElementById('local-preview-embed-btn');
+    if (!wrapper || !frame || !btn) return;
+    if (!wrapper.classList.contains('hidden')) {
+        closeEmbeddedLocalPreview();
+        return;
+    }
+
+    const url = localPreviewURL();
+    if (!url) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
+    try {
+        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        frame.src = url;
+        wrapper.classList.remove('hidden');
+        btn.textContent = '埋め込みを閉じる';
+        setTimeout(() => refreshLocalPreviewStatus(), 500);
+    } catch (e) {
+        UI.showToast('埋め込みpreviewを開始できません: ' + e.message, 'error');
+    }
+}
+
+function closeEmbeddedLocalPreview() {
+    const wrapper = document.getElementById('local-preview-embed');
+    const frame = document.getElementById('local-preview-frame');
+    const btn = document.getElementById('local-preview-embed-btn');
+    if (wrapper) wrapper.classList.add('hidden');
+    if (frame) frame.src = 'about:blank';
+    if (btn) btn.textContent = '埋め込み表示';
+}
+
+async function stopLocalLivePreview() {
+    if (!localPreviewEnabled || localPreviewOperationInProgress) return;
+    localPreviewOperationInProgress = true;
+    try {
+        // Editor owns the authoritative document-scoped ID. Releasing it first
+        // safely stops/removes an owned shadow workspace. The explicit stop API
+        // then handles the saved-content-only process case idempotently.
+        await Editor.releaseLocalLivePreview();
+        localPreviewSessionID = "";
+        await API.stopLocalPreviewContent("");
+        closeEmbeddedLocalPreview();
+        UI.showToast('Local Live Previewを停止しました', 'success');
+    } catch (e) {
+        UI.showToast('Local Live Previewを停止できません: ' + e.message, 'error');
+    } finally {
+        localPreviewOperationInProgress = false;
+        await refreshLocalPreviewStatus();
+    }
+}
+
+async function reclaimLocalLivePreview() {
+    if (!localPreviewEnabled || localPreviewOperationInProgress) return;
+    if (!confirm('期限切れのLocal Live Preview sessionを回収して再開しますか？')) return;
+    localPreviewOperationInProgress = true;
+    try {
+        await API.reclaimStaleLocalPreview();
+        localPreviewSessionID = "";
+        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        UI.showToast('Local Live Preview sessionを回収しました', 'success');
+    } catch (e) {
+        UI.showToast('Local Live Previewを回収できません: ' + e.message, 'error');
+    } finally {
+        localPreviewOperationInProgress = false;
+        await refreshLocalPreviewStatus();
+    }
 }
 
 async function runSync() {
@@ -367,7 +605,7 @@ async function retryDeploymentPreview() {
         applyDeploymentState(state);
     } catch (e) {
         applyDeploymentState({ ...deploymentState, status: 'failed', message: e.message });
-        UI.showToast(e.message, 'error');
+        UI.showToast(e.message, "error");
     } finally {
         deploymentOperationInProgress = false;
     }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -266,7 +266,8 @@ function localPreviewStatusLabel(status) {
 }
 
 function renderLocalPreviewState(state) {
-    localPreviewState = state || null;
+    localPreviewState = UI.normalizeLocalPreviewState(state);
+    state = localPreviewState;
     const statusEl = document.getElementById('local-preview-status');
     const messageEl = document.getElementById('local-preview-message');
     const reclaimBtn = document.getElementById('local-preview-reclaim-btn');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -186,9 +186,19 @@ async function loadFile(path) {
     stopDeploymentPolling();
     deploymentState = null;
     UI.renderDeploymentState(null);
-    localPreviewSessionID = "";
+    const previousLocalPreviewSessionID = localPreviewSessionID;
     await Editor.loadFile(path);
-    if (localPreviewEnabled && Editor.getCurrentPath() === path) {
+    if (Editor.getCurrentPath() !== path) {
+        // Editor keeps its owner ID when release failed; keep the matching
+        // heartbeat handle so the live session does not expire while the user
+        // retries the switch.
+        localPreviewSessionID = previousLocalPreviewSessionID;
+        await refreshLocalPreviewStatus();
+        return;
+    }
+
+    localPreviewSessionID = "";
+    if (localPreviewEnabled) {
         try {
             await ensureLocalPreviewSession();
         } catch (_) {
@@ -197,9 +207,7 @@ async function loadFile(path) {
         }
         await refreshLocalPreviewStatus();
     }
-    if (deploymentEnabled && Editor.getCurrentPath() === path) {
-        await refreshDeploymentState();
-    }
+    if (deploymentEnabled) await refreshDeploymentState();
 }
 
 async function refreshFileList() {
@@ -407,12 +415,9 @@ async function stopLocalLivePreview() {
     if (!localPreviewEnabled || localPreviewOperationInProgress) return;
     localPreviewOperationInProgress = true;
     try {
-        // Editor owns the authoritative document-scoped ID. Releasing it first
-        // safely stops/removes an owned shadow workspace. The explicit stop API
-        // then handles the saved-content-only process case idempotently.
-        await Editor.releaseLocalLivePreview();
+        const released = await Editor.releaseLocalLivePreview();
         localPreviewSessionID = "";
-        await API.stopLocalPreviewContent("");
+        if (!released) await API.stopLocalPreviewContent("");
         closeEmbeddedLocalPreview();
         UI.showToast('Local Live Previewを停止しました', 'success');
     } catch (e) {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -560,6 +560,15 @@ export function normalizeDeploymentState(value) {
     };
 }
 
+export function normalizeLocalPreviewState(value) {
+    if (!value || typeof value !== 'object') return null;
+    const state = { ...value };
+    if (state.session_active === true && state.session_owned === false && state.session_stale !== true) {
+        state.status = 'conflict';
+    }
+    return state;
+}
+
 export function configureDeploymentPreview(config) {
     const panel = document.getElementById('deployment-panel');
     if (!panel) return false;

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -20,6 +20,7 @@ globalThis.window = {
 
 const {
     normalizeDeploymentState,
+    normalizeLocalPreviewState,
     safeExternalURL,
 } = await import("./ui.js");
 const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
@@ -56,6 +57,31 @@ describe("normalizeDeploymentState", () => {
         assert.equal(normalizeDeploymentState({ status: "unexpected" }).status, "queued");
         assert.equal(normalizeDeploymentState({ status: "stale", url: "https://old.example.test" }).status, "stale");
         assert.equal(normalizeDeploymentState(null), null);
+    });
+});
+
+describe("normalizeLocalPreviewState", () => {
+    it("keeps an active session owned by another tab in conflict", () => {
+        const state = normalizeLocalPreviewState({
+            status: "ready",
+            process_state: "ready",
+            session_active: true,
+            session_owned: false,
+            session_stale: false,
+        });
+
+        assert.equal(state.status, "conflict");
+    });
+
+    it("does not replace the stale recovery state", () => {
+        const state = normalizeLocalPreviewState({
+            status: "stale",
+            session_active: true,
+            session_owned: false,
+            session_stale: true,
+        });
+
+        assert.equal(state.status, "stale");
     });
 });
 

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -107,7 +107,7 @@ describe("draft IDs", () => {
 });
 
 describe("preview API contracts", () => {
-    it("scopes Markdown, local, and deployment operations to the selected site", async () => {
+    it("scopes Markdown, local lifecycle, and deployment operations to the selected site", async () => {
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {
             calls.push({ url, options });
@@ -122,6 +122,10 @@ describe("preview API contracts", () => {
         await API.renderMarkdownPreview(article);
         await API.updateLocalPreviewContent(article, "local-session", 7);
         await API.releaseLocalPreviewContent("local-session");
+        await API.fetchLocalPreviewStatus("local-session");
+        await API.heartbeatLocalPreviewContent("local-session");
+        await API.stopLocalPreviewContent("local-session");
+        await API.reclaimStaleLocalPreview();
         await API.triggerPreviewDeployment(article.path, "draft/id");
         await API.fetchPreviewDeployment("draft/id");
         await API.retryPreviewDeployment("draft/id");
@@ -134,12 +138,18 @@ describe("preview API contracts", () => {
         assert.deepEqual(JSON.parse(calls[2].options.body), { ...article, draft_id: "local-session", revision: 7 });
         assert.equal(calls[3].url, "/admin/api/preview/local/release?site=docs+site");
         assert.deepEqual(JSON.parse(calls[3].options.body), { draft_id: "local-session" });
-        assert.equal(calls[4].url, "/admin/api/preview/deployments?site=docs+site");
-        assert.deepEqual(JSON.parse(calls[4].options.body), { path: article.path, draft_id: "draft/id" });
-        assert.equal(calls[5].url, "/admin/api/preview/deployments/draft%2Fid?site=docs+site");
-        assert.equal(calls[6].url, "/admin/api/preview/deployments/draft%2Fid/retry?site=docs+site");
-        assert.equal(calls[7].url, "/admin/api/preview/deployments/draft%2Fid/discard?site=docs+site");
+        assert.equal(calls[4].url, "/admin/api/preview/local/status?draft_id=local-session&site=docs+site");
+        assert.equal(calls[5].url, "/admin/api/preview/local/heartbeat?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[5].options.body), { draft_id: "local-session" });
+        assert.equal(calls[6].url, "/admin/api/preview/local/stop?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[6].options.body), { draft_id: "local-session" });
+        assert.equal(calls[7].url, "/admin/api/preview/local/reclaim?site=docs+site");
+        assert.equal(calls[8].url, "/admin/api/preview/deployments?site=docs+site");
         assert.deepEqual(JSON.parse(calls[8].options.body), { path: article.path, draft_id: "draft/id" });
+        assert.equal(calls[9].url, "/admin/api/preview/deployments/draft%2Fid?site=docs+site");
+        assert.equal(calls[10].url, "/admin/api/preview/deployments/draft%2Fid/retry?site=docs+site");
+        assert.equal(calls[11].url, "/admin/api/preview/deployments/draft%2Fid/discard?site=docs+site");
+        assert.deepEqual(JSON.parse(calls[12].options.body), { path: article.path, draft_id: "draft/id" });
         calls.slice(1).forEach(call => {
             assert.equal(call.options.headers["X-CMS-Site"], "docs site");
         });

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,6 +64,35 @@
             </div>
         </header>
 
+        <section id="local-preview-panel" class="deployment-panel hidden" aria-label="Local Live Preview">
+            <div class="deployment-heading">
+                <strong>Local Live Preview</strong>
+                <span id="local-preview-status" class="deployment-status idle">停止</span>
+            </div>
+            <div id="local-preview-message" class="deployment-message" aria-live="polite">
+                Hugoのtheme/layout/shortcode/CSS/JSを含むpreviewです。
+            </div>
+            <div class="deployment-actions">
+                <button id="local-preview-open-btn" class="action-btn" onclick="openLocalLivePreview()">新規タブで開く</button>
+                <button id="local-preview-embed-btn" class="action-btn secondary" onclick="toggleEmbeddedLocalPreview()">埋め込み表示</button>
+                <button id="local-preview-stop-btn" class="action-btn danger hidden" onclick="stopLocalLivePreview()">停止</button>
+                <button id="local-preview-reclaim-btn" class="action-btn secondary hidden" onclick="reclaimLocalLivePreview()">期限切れsessionを回収</button>
+            </div>
+            <div class="deployment-message" role="note">
+                埋め込みはpreview ingressのframe policyや外部認証によって利用できない場合があります。その場合も新規タブ表示は利用できます。
+            </div>
+            <div id="local-preview-embed" class="hidden" style="margin-top: 10px; height: min(58vh, 720px); min-height: 360px; border: 1px solid #444c56; border-radius: 6px; overflow: hidden; background: #fff;">
+                <iframe
+                    id="local-preview-frame"
+                    title="Local Live Preview"
+                    src="about:blank"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+                    referrerpolicy="no-referrer"
+                    style="display: block; width: 100%; height: 100%; border: 0; background: #fff;"
+                ></iframe>
+            </div>
+        </section>
+
         <section id="deployment-panel" class="deployment-panel hidden" aria-label="デプロイプレビュー">
             <div class="deployment-heading">
                 <strong>デプロイプレビュー</strong>
@@ -105,7 +134,6 @@
         </div>
     </main>
 
-    <!-- Modal -->
     <div id="modal-overlay">
         <div id="modal-box">
             <div id="modal-header">


### PR DESCRIPTION
## Summary

Implements the main Phase 4 lifecycle/recovery/UI work for #32.

- add a 2-minute Local Preview session lease and renew it on editor updates
- add a 30-second browser heartbeat for the owning document/tab
- report Local Preview lifecycle/status without exposing another tab's owner ID
- allow explicit stop of an owned preview session/process
- allow reclaim only after a session lease becomes stale
- keep same-site live-session conflict isolation (`409 Conflict`)
- add a Local Live Preview panel with stopped / starting / ready / failed / conflict / stale states
- add a primary `新規タブで開く` action
- add an optional sandboxed iframe embed for environments whose preview ingress permits framing
- keep the iframe optional because `frame-ancestors`, `X-Frame-Options`, or external viewer-auth/login pages may forbid embedding
- retain new-tab preview as the reliable fallback
- document lease/recovery and iframe/ingress constraints

## Lifecycle APIs

- `GET /admin/api/preview/local/status`
- `POST /admin/api/preview/local/heartbeat`
- `POST /admin/api/preview/local/stop`
- `POST /admin/api/preview/local/reclaim`

All remain inside the existing admin auth/CSRF boundary. The status endpoint never discloses another tab's document-scoped session ID.

## Lease / recovery

Local Preview ownership remains document/tab scoped and is not persisted to sessionStorage.

- lease TTL: 2 minutes
- heartbeat: every 30 seconds while the current document owns a workspace
- editor updates also renew the lease
- stale sessions can be reclaimed without restarting the CMS
- live sessions cannot be reclaimed
- recovery stops Hugo before deleting the shadow content workspace

This addresses the Phase 3 limitation where browser reload/crash could leave a one-site session allocated until CMS shutdown.

## Embedded preview

The CMS can embed the site preview as a separate-origin iframe. The iframe is sandboxed and does not receive the CMS admin session cookie.

Embedding is intentionally optional. It may be blocked by external preview ingress/auth policy such as:

- `Content-Security-Policy: frame-ancestors ...`
- `X-Frame-Options`
- authentication/login pages that refuse framing

Therefore `新規タブで開く` remains the primary/fallback path.

## Still pending / environment-specific

- actual `tech-blog` / `daily-blog` smoke test
- root-relative CSS/JS/images under the real ingress
- theme/layout/shortcode rendering on the actual repositories
- LiveReload/WebSocket through the chosen wildcard/Tailscale ingress
- concrete Tailscale/wildcard DNS/TLS deployment examples once the deployment topology is selected

Closes no issue yet; #32 should remain open until the real-environment acceptance checks are complete.