### PR TITLE
feat: improve Local Live Preview UI

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -212,8 +212,10 @@ release時はHugo process停止後にworkspaceを削除する。active shadow se
 
 ## Phase 4への契約
 
-- Local Live Previewを開く/新規tab導線
-- starting / ready / failed状態表示
+- Local Live Previewを開く/新規tab導線（埋め込みを主導線、新規tabをfallback）
+- desktopの編集+埋め込みpreview並列表示と狭い画面での上下配置
+- iframe loading/error表示と新規tab fallback
+- starting / ready / failed / conflict / stale状態表示
 - Local Previewの明示停止とstale session recovery/lease方針
 - private network/Tailscale運用例
 - wildcard DNS / TLS ingress構成例

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -214,7 +214,7 @@ release時はHugo process停止後にworkspaceを削除する。active shadow se
 
 - Local Live Previewを開く/新規tab導線（埋め込みを主導線、新規tabをfallback）
 - desktopの編集+埋め込みpreview並列表示と狭い画面での上下配置
-- iframe loading/error表示と新規tab fallback
+- iframe loading、応答未確認のbest-effort表示、新規tab fallback。preview側が`homecms-local-preview-ready`の`postMessage`を送る場合は明示的なready通知として扱う
 - starting / ready / failed / conflict / stale状態表示
 - Local Previewの明示停止とstale session recovery/lease方針
 - private network/Tailscale運用例

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。明示的なopen/stop UIと状態表示はPhase 4で追加します。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -161,7 +161,9 @@ Local Live Preview panelでは次を利用できます。
 - `管理操作` > `期限切れsessionを回収`: stale leaseだけを安全にreclaim
 - stopped / starting / ready / failed / conflict / staleの状態表示
 
-desktopでは編集画面とLive Previewを左右に並べます。iframeの読み込み中はloading表示を出し、frame policy・外部認証・通信失敗などで一定時間応答がない場合はエラーと「新規タブで開く」fallbackを表示します。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
+desktopでは編集画面とLive Previewを左右に並べます。iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
+
+preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<preview origin>')` を送ると、CMSが明示的なready通知として扱います。
 
 ### iframe埋め込み
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,6 +1,6 @@
 # Local Live Preview設定ガイド
 
-> Issue #32ではPhase 1/2/3がmainへmerge済みです。Phase 4では、session lease/recovery、status/stop API、UIからのopen/stopとoptional iframe埋め込みを追加します。
+> Issue #32ではPhase 1〜4が実装済みです。session lease/recovery、status/stop APIに加え、CMS内の埋め込みpreviewを主導線とするUIを提供します。
 
 ## 基本設定
 
@@ -155,11 +155,13 @@ recovery時もHugo processを先にstopしてからshadow workspaceを削除し�
 
 Local Live Preview panelでは次を利用できます。
 
-- `新規タブで開く`: 常に利用できる主導線
-- `埋め込み表示`: CMS内のsandbox付きiframeへ表示
-- `停止`: 自分が所有するsession、またはworkspaceを伴わないsaved-content preview processを停止
-- `期限切れsessionを回収`: stale leaseだけを安全にreclaim
+- `埋め込み表示`: 記事を選択するとCMS内のsandbox付きiframeを主表示として自動表示
+- `新規タブで開く`: iframeが利用できない場合や補助的な確認に使う
+- `管理操作` > `停止`: 自分が所有するsession、またはworkspaceを伴わないsaved-content preview processを停止
+- `管理操作` > `期限切れsessionを回収`: stale leaseだけを安全にreclaim
 - stopped / starting / ready / failed / conflict / staleの状態表示
+
+desktopでは編集画面とLive Previewを左右に並べます。iframeの読み込み中はloading表示を出し、frame policy・外部認証・通信失敗などで一定時間応答がない場合はエラーと「新規タブで開く」fallbackを表示します。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
 ### iframe埋め込み
 
@@ -173,7 +175,7 @@ X-Frame-Options: SAMEORIGIN
 Content-Security-Policy: frame-ancestors 'none'
 ```
 
-Cloudflare Access等のviewer authenticationのlogin画面がiframeを拒否する構成もあります。そのため**新規タブ表示を主導線として必ず残し、埋め込みはoptional**とします。
+Cloudflare Access等のviewer authenticationのlogin画面がiframeを拒否する構成もあります。そのため**埋め込みを主導線にしつつ、新規タブ表示を必ずfallbackとして残します**。
 
 CMS側iframeにはsandboxを付け、top-level navigation等を許可しません。Hugo/LiveReloadに必要なscriptとsame-origin権限だけを許可します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -163,7 +163,7 @@ Local Live Preview panelでは次を利用できます。
 
 desktopでは編集画面とLive Previewを左右に並べます。iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
-preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<preview origin>')` を送ると、CMSが明示的なready通知として扱います。
+preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<CMS origin>')` を送ると、CMSが明示的なready通知として扱います。第2引数のtarget originはpreview originではなく、親フレームであるCMSのorigin（例: `https://cms.example.com`）を指定してください。
 
 ### iframe埋め込み
 

--- a/main_test.go
+++ b/main_test.go
@@ -99,6 +99,25 @@ func TestMarkdownPreviewDoesNotUseIframe(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewProvidesEmbeddedSurfaceAndFallback(t *testing.T) {
+	content, err := os.ReadFile("templates/index.html")
+	if err != nil {
+		t.Fatalf("read admin template: %v", err)
+	}
+	template := string(content)
+	for _, marker := range []string{
+		`id="local-preview-view"`,
+		`id="local-preview-frame"`,
+		`id="local-preview-frame-loading"`,
+		`id="local-preview-frame-error"`,
+		`onclick="openLocalLivePreview()"`,
+	} {
+		if !strings.Contains(template, marker) {
+			t.Fatalf("Local Preview template is missing %s", marker)
+		}
+	}
+}
+
 func TestHTTPServerDoesNotCapRequestBodyDuration(t *testing.T) {
 	server := newHTTPServer(http.NotFoundHandler())
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -58,13 +58,35 @@ header { height: 50px; background: #252526; display: flex; align-items: center; 
 .view-toggle.active { background: #333; color: white; }
 
 /* Content Area */
-#content-area { flex: 1; position: relative; overflow: hidden; display: flex; }
+#content-area { flex: 1; position: relative; overflow: hidden; display: flex; min-width: 0; min-height: 0; }
 
 /* Editor View */
-#edit-view { display: flex; flex-direction: column; height: 100%; width: 100%; }
+#edit-view { display: flex; flex: 1 1 auto; flex-direction: column; height: 100%; width: 100%; min-width: 0; min-height: 0; }
 #fm-container { background: #252526; padding: 15px; border-bottom: 1px solid #333; max-height: 40%; overflow-y: auto; }
 #editor-wrapper { flex: 1; position: relative; }
 textarea { width: 100%; height: 100%; background: #1e1e1e; color: #d4d4d4; border: none; padding: 20px; font-family: Consolas, "Courier New", monospace; font-size: 15px; box-sizing: border-box; resize: none; outline: none; line-height: 1.5; }
+
+/* Local Live Preview */
+#local-preview-view { display: none; flex: 1 1 auto; flex-direction: column; width: 0; min-width: 0; min-height: 0; overflow: hidden; background: #20252b; border-left: 1px solid #333; }
+#content-area.local-preview-enabled.local-preview-mode #edit-view { flex: 1 1 50%; width: 50%; border-right: 1px solid #333; }
+#content-area.local-preview-enabled.local-preview-mode #local-preview-view { display: flex; flex: 1 1 50%; width: 50%; }
+.local-preview-panel { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; padding: 14px; overflow: hidden; }
+.local-preview-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+.local-preview-caption { color: #8c959f; font-size: 12px; }
+.local-preview-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 9px; }
+.local-preview-actions .local-preview-advanced { margin-left: auto; }
+.local-preview-advanced > summary { padding: 6px 9px; border: 1px solid #4a4a4a; border-radius: 3px; background: #3c3c3c; color: #ccc; font-weight: normal; }
+.local-preview-advanced[open] > summary { border-radius: 3px 3px 0 0; }
+.local-preview-advanced .deployment-actions { margin-top: 0; padding: 8px; border: 1px solid #4a4a4a; border-top: 0; background: #2a2a2a; }
+.local-preview-loading { margin-top: 7px; color: #e2c08d; font-size: 12px; }
+.local-preview-embed { position: relative; display: flex; flex: 1; min-width: 0; min-height: 320px; margin-top: 12px; overflow: hidden; border: 1px solid #454d56; border-radius: 6px; background: #fff; }
+.local-preview-embed iframe { display: block; width: 100%; height: 100%; min-height: 320px; border: 0; background: #fff; }
+.local-preview-frame-overlay, .local-preview-frame-error { position: absolute; inset: 0; z-index: 1; display: flex; align-items: center; justify-content: center; gap: 10px; padding: 24px; box-sizing: border-box; text-align: center; }
+.local-preview-frame-overlay { color: #57606a; background: rgba(255, 255, 255, 0.92); }
+.local-preview-frame-error { z-index: 2; flex-direction: column; color: #24292f; background: rgba(255, 248, 197, 0.97); }
+.local-preview-frame-error strong { color: #9a6700; }
+.local-preview-frame-error span { max-width: 420px; font-size: 12px; line-height: 1.5; }
+.local-preview-note { margin-top: 8px; color: #8c959f; font-size: 11px; line-height: 1.4; }
 
 /* Markdown body preview */
 #preview-view { display: none; height: 100%; width: 100%; overflow-y: auto; background: #fff; color: #24292f; }
@@ -106,8 +128,9 @@ textarea { width: 100%; height: 100%; background: #1e1e1e; color: #d4d4d4; borde
 .deployment-link:hover { text-decoration: underline; }
 
 /* Split Mode */
-#content-area.split-mode #edit-view { width: 50%; border-right: 1px solid #333; display: flex !important; }
-#content-area.split-mode #preview-view { width: 50%; display: block !important; }
+#content-area.split-mode #edit-view { flex: 1 1 50%; width: 50%; border-right: 1px solid #333; display: flex !important; }
+#content-area.split-mode #local-preview-view { display: none !important; }
+#content-area.split-mode #preview-view { flex: 1 1 50%; width: 50%; display: block !important; }
 
 /* Utils */
 .action-btn { background: #0e639c; color: white; border: none; padding: 6px 12px; border-radius: 3px; font-size: 13px; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 5px; }
@@ -151,8 +174,18 @@ details[open] > summary::before { content: '▾ '; }
     .desktop-actions { display: none; }
     .mobile-actions { display: block; }
 
+    /* Keep the editor and Local Preview usable together on small screens. */
+    #content-area.local-preview-enabled.local-preview-mode { flex-direction: column; overflow-y: auto; }
+    #content-area.local-preview-enabled.local-preview-mode #edit-view { flex: 1 1 55%; width: 100%; min-height: 280px; border-right: 0; }
+    #content-area.local-preview-enabled.local-preview-mode #local-preview-view { flex: 0 0 45%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
+    .local-preview-panel { padding: 8px 10px; }
+    .local-preview-caption, .local-preview-note { display: none; }
+    .local-preview-actions .local-preview-advanced { margin-left: 0; }
+    .local-preview-embed, .local-preview-embed iframe { min-height: 200px; }
+
     /* Disable Split on Mobile */
     #content-area.split-mode #edit-view, #content-area.split-mode #preview-view { width: 100%; }
+    #content-area.split-mode #edit-view { flex-basis: 100%; }
     #content-area.split-mode #preview-view { display: none !important; }
     #btn-view-split { display: none; }
     

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,11 @@
 import * as API from './api.js';
 import * as UI from './ui.js';
 import * as Editor from './editor.js';
+import {
+    createLocalPreviewFrameController,
+    shouldAutoShowEmbeddedLocalPreview,
+    shouldCloseEmbeddedLocalPreview,
+} from './local_preview.js';
 
 // Global State
 let cmsConfig = null;
@@ -18,16 +23,15 @@ let localPreviewPollTimer = null;
 let localPreviewHeartbeatTimer = null;
 let localPreviewController = null;
 let localPreviewOperationInProgress = false;
-let localPreviewFrameLoadTimer = null;
-let localPreviewEmbedDismissed = false;
+let localPreviewFrameController = null;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
-const LOCAL_PREVIEW_FRAME_TIMEOUT_MS = 10000;
 
 init();
 
 async function init() {
+    initializeLocalPreviewFrame();
     try {
         siteRegistry = await API.fetchSites();
         API.initializeCurrentSite(siteRegistry);
@@ -39,8 +43,6 @@ async function init() {
     }
 
     Editor.initAutoSave();
-    initializeLocalPreviewFrame();
-
     window.switchView = switchView;
     window.toggleSplitView = UI.toggleSplitView;
     window.toggleSidebar = UI.toggleSidebar;
@@ -203,7 +205,8 @@ async function loadFile(path) {
 
     localPreviewSessionID = "";
     if (localPreviewEnabled) {
-        localPreviewEmbedDismissed = false;
+        localPreviewFrameController?.resetDismissed();
+        updateLocalPreviewMode();
         try {
             await ensureLocalPreviewSession();
             showEmbeddedLocalPreview({ reload: true });
@@ -241,77 +244,74 @@ function localPreviewURL() {
 }
 
 function configureLocalPreviewPanel() {
-    const contentArea = document.getElementById('content-area');
     const panel = document.getElementById('local-preview-panel');
-    if (contentArea) {
-        contentArea.classList.toggle('local-preview-enabled', localPreviewEnabled);
-        contentArea.classList.toggle('local-preview-mode', localPreviewEnabled);
-    }
+    updateLocalPreviewMode();
     if (!localPreviewEnabled) {
         closeEmbeddedLocalPreview();
         return;
     }
     if (!panel) return;
-    localPreviewEmbedDismissed = false;
+    localPreviewFrameController?.resetDismissed();
     renderLocalPreviewState({ enabled: true, status: 'stopped', process_state: 'stopped', session_active: false });
 }
 
 function initializeLocalPreviewFrame() {
     const frame = document.getElementById('local-preview-frame');
-    if (!frame || frame.dataset.listenersAttached === 'true') return;
-    frame.addEventListener('load', handleLocalPreviewFrameLoad);
-    frame.addEventListener('error', () => showLocalPreviewFrameError('preview ingressから応答を受け取れませんでした。'));
-    frame.dataset.listenersAttached = 'true';
+    if (!frame || localPreviewFrameController) return;
+    localPreviewFrameController = createLocalPreviewFrameController({
+        getURL: localPreviewURL,
+        wrapper: document.getElementById('local-preview-embed'),
+        frame,
+        button: document.getElementById('local-preview-embed-btn'),
+        loading: document.getElementById('local-preview-frame-loading'),
+        error: document.getElementById('local-preview-frame-error'),
+        errorMessage: document.getElementById('local-preview-frame-error-message'),
+    });
+    frame.addEventListener('load', () => localPreviewFrameController?.handleLoad());
+    frame.addEventListener('error', () => localPreviewFrameController?.handleError());
+    window.addEventListener('message', handleLocalPreviewReadyMessage);
 }
 
-function clearLocalPreviewFrameLoadTimer() {
-    if (localPreviewFrameLoadTimer) {
-        clearTimeout(localPreviewFrameLoadTimer);
-        localPreviewFrameLoadTimer = null;
+function handleLocalPreviewReadyMessage(event) {
+    const frame = document.getElementById('local-preview-frame');
+    const url = localPreviewURL();
+    if (!frame || !url || event.source !== frame.contentWindow) return;
+    let origin;
+    try {
+        origin = new URL(url).origin;
+    } catch (_) {
+        return;
     }
+    if (event.origin !== origin || event.data?.type !== 'homecms-local-preview-ready') return;
+    localPreviewFrameController?.handleReady();
 }
 
-function handleLocalPreviewFrameLoad() {
-    clearLocalPreviewFrameLoadTimer();
-    const loading = document.getElementById('local-preview-frame-loading');
-    const error = document.getElementById('local-preview-frame-error');
-    if (loading) loading.classList.add('hidden');
-    if (error) error.classList.add('hidden');
+function updateLocalPreviewMode() {
+    const contentArea = document.getElementById('content-area');
+    if (!contentArea) return;
+    const hasCurrentPath = Boolean(Editor.getCurrentPath());
+    const embedded = localPreviewFrameController?.isVisible() === true;
+    contentArea.dataset.localPreviewHasArticle = String(hasCurrentPath);
+    contentArea.classList.toggle('local-preview-enabled', localPreviewEnabled);
+    contentArea.classList.toggle(
+        'local-preview-mode',
+        localPreviewEnabled && !contentArea.classList.contains('split-mode') && (hasCurrentPath || embedded),
+    );
+}
+
+function showEmbeddedLocalPreview(options = {}) {
+    const shown = localPreviewFrameController?.show(options) === true;
+    if (shown) updateLocalPreviewMode();
+    return shown;
 }
 
 function showLocalPreviewFrameError(message) {
-    clearLocalPreviewFrameLoadTimer();
-    const loading = document.getElementById('local-preview-frame-loading');
-    const error = document.getElementById('local-preview-frame-error');
-    const errorMessage = document.getElementById('local-preview-frame-error-message');
-    if (loading) loading.classList.add('hidden');
-    if (errorMessage && message) errorMessage.textContent = message;
-    if (error) error.classList.remove('hidden');
+    localPreviewFrameController?.showError(message);
 }
 
-function showEmbeddedLocalPreview({ reload = false } = {}) {
-    const wrapper = document.getElementById('local-preview-embed');
-    const frame = document.getElementById('local-preview-frame');
-    const btn = document.getElementById('local-preview-embed-btn');
-    const url = localPreviewURL();
-    if (!wrapper || !frame || !url) return false;
-
-    const wasVisible = !wrapper.classList.contains('hidden');
-    const shouldLoad = reload || frame.getAttribute('src') !== url;
-    wrapper.classList.remove('hidden');
-    if (btn) btn.textContent = '埋め込みを閉じる';
-    if (!wasVisible || shouldLoad) {
-        const loading = document.getElementById('local-preview-frame-loading');
-        const error = document.getElementById('local-preview-frame-error');
-        if (loading) loading.classList.remove('hidden');
-        if (error) error.classList.add('hidden');
-        clearLocalPreviewFrameLoadTimer();
-        if (shouldLoad) frame.src = url;
-        localPreviewFrameLoadTimer = setTimeout(() => {
-            showLocalPreviewFrameError('previewの読み込みに時間がかかっています。新規タブで開いてください。');
-        }, LOCAL_PREVIEW_FRAME_TIMEOUT_MS);
-    }
-    return true;
+function closeEmbeddedLocalPreview(options = {}) {
+    localPreviewFrameController?.close(options);
+    updateLocalPreviewMode();
 }
 
 function localPreviewStatusClass(status) {
@@ -370,9 +370,15 @@ function renderLocalPreviewState(state) {
         stopBtn.classList.toggle('hidden', !(state?.session_owned || (!state?.session_active && processRunning)));
     }
 
-    if (!Editor.getCurrentPath() || status === 'conflict' || status === 'stale') {
+    const hasCurrentPath = Boolean(Editor.getCurrentPath());
+    if (shouldCloseEmbeddedLocalPreview({ status, hasCurrentPath })) {
         closeEmbeddedLocalPreview();
-    } else if ((status === 'starting' || status === 'ready') && state?.session_owned === true && Editor.getCurrentPath() && !localPreviewEmbedDismissed) {
+    } else if (shouldAutoShowEmbeddedLocalPreview({
+        status,
+        sessionOwned: state?.session_owned,
+        hasCurrentPath,
+        dismissed: localPreviewFrameController?.isDismissed(),
+    })) {
         showEmbeddedLocalPreview();
     } else if (status === 'failed' && state?.process_error) {
         showLocalPreviewFrameError(state.process_error);
@@ -477,28 +483,13 @@ async function toggleEmbeddedLocalPreview() {
     const url = localPreviewURL();
     if (!url) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
     try {
-        localPreviewEmbedDismissed = false;
+        localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
         showEmbeddedLocalPreview({ reload: true });
         setTimeout(() => refreshLocalPreviewStatus(), 500);
     } catch (e) {
         UI.showToast('埋め込みpreviewを開始できません: ' + e.message, 'error');
     }
-}
-
-function closeEmbeddedLocalPreview({ dismiss = false } = {}) {
-    const wrapper = document.getElementById('local-preview-embed');
-    const frame = document.getElementById('local-preview-frame');
-    const btn = document.getElementById('local-preview-embed-btn');
-    clearLocalPreviewFrameLoadTimer();
-    if (dismiss) localPreviewEmbedDismissed = true;
-    if (wrapper) wrapper.classList.add('hidden');
-    if (frame) frame.src = 'about:blank';
-    if (btn) btn.textContent = '埋め込み表示';
-    const loading = document.getElementById('local-preview-frame-loading');
-    const error = document.getElementById('local-preview-frame-error');
-    if (loading) loading.classList.add('hidden');
-    if (error) error.classList.add('hidden');
 }
 
 async function stopLocalLivePreview() {
@@ -525,7 +516,7 @@ async function reclaimLocalLivePreview() {
     try {
         await API.reclaimStaleLocalPreview();
         localPreviewSessionID = "";
-        localPreviewEmbedDismissed = false;
+        localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
             await ensureLocalPreviewSession();
             showEmbeddedLocalPreview({ reload: true });

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -18,9 +18,12 @@ let localPreviewPollTimer = null;
 let localPreviewHeartbeatTimer = null;
 let localPreviewController = null;
 let localPreviewOperationInProgress = false;
+let localPreviewFrameLoadTimer = null;
+let localPreviewEmbedDismissed = false;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
+const LOCAL_PREVIEW_FRAME_TIMEOUT_MS = 10000;
 
 init();
 
@@ -36,6 +39,7 @@ async function init() {
     }
 
     Editor.initAutoSave();
+    initializeLocalPreviewFrame();
 
     window.switchView = switchView;
     window.toggleSplitView = UI.toggleSplitView;
@@ -199,8 +203,10 @@ async function loadFile(path) {
 
     localPreviewSessionID = "";
     if (localPreviewEnabled) {
+        localPreviewEmbedDismissed = false;
         try {
             await ensureLocalPreviewSession();
+            showEmbeddedLocalPreview({ reload: true });
         } catch (_) {
             // Editor already reports 409 conflicts; status panel provides the
             // persistent recovery action when the old session becomes stale.
@@ -235,14 +241,77 @@ function localPreviewURL() {
 }
 
 function configureLocalPreviewPanel() {
+    const contentArea = document.getElementById('content-area');
     const panel = document.getElementById('local-preview-panel');
-    if (!panel) return;
-    panel.classList.toggle('hidden', !localPreviewEnabled);
+    if (contentArea) {
+        contentArea.classList.toggle('local-preview-enabled', localPreviewEnabled);
+        contentArea.classList.toggle('local-preview-mode', localPreviewEnabled);
+    }
     if (!localPreviewEnabled) {
         closeEmbeddedLocalPreview();
         return;
     }
+    if (!panel) return;
+    localPreviewEmbedDismissed = false;
     renderLocalPreviewState({ enabled: true, status: 'stopped', process_state: 'stopped', session_active: false });
+}
+
+function initializeLocalPreviewFrame() {
+    const frame = document.getElementById('local-preview-frame');
+    if (!frame || frame.dataset.listenersAttached === 'true') return;
+    frame.addEventListener('load', handleLocalPreviewFrameLoad);
+    frame.addEventListener('error', () => showLocalPreviewFrameError('preview ingressから応答を受け取れませんでした。'));
+    frame.dataset.listenersAttached = 'true';
+}
+
+function clearLocalPreviewFrameLoadTimer() {
+    if (localPreviewFrameLoadTimer) {
+        clearTimeout(localPreviewFrameLoadTimer);
+        localPreviewFrameLoadTimer = null;
+    }
+}
+
+function handleLocalPreviewFrameLoad() {
+    clearLocalPreviewFrameLoadTimer();
+    const loading = document.getElementById('local-preview-frame-loading');
+    const error = document.getElementById('local-preview-frame-error');
+    if (loading) loading.classList.add('hidden');
+    if (error) error.classList.add('hidden');
+}
+
+function showLocalPreviewFrameError(message) {
+    clearLocalPreviewFrameLoadTimer();
+    const loading = document.getElementById('local-preview-frame-loading');
+    const error = document.getElementById('local-preview-frame-error');
+    const errorMessage = document.getElementById('local-preview-frame-error-message');
+    if (loading) loading.classList.add('hidden');
+    if (errorMessage && message) errorMessage.textContent = message;
+    if (error) error.classList.remove('hidden');
+}
+
+function showEmbeddedLocalPreview({ reload = false } = {}) {
+    const wrapper = document.getElementById('local-preview-embed');
+    const frame = document.getElementById('local-preview-frame');
+    const btn = document.getElementById('local-preview-embed-btn');
+    const url = localPreviewURL();
+    if (!wrapper || !frame || !url) return false;
+
+    const wasVisible = !wrapper.classList.contains('hidden');
+    const shouldLoad = reload || frame.getAttribute('src') !== url;
+    wrapper.classList.remove('hidden');
+    if (btn) btn.textContent = '埋め込みを閉じる';
+    if (!wasVisible || shouldLoad) {
+        const loading = document.getElementById('local-preview-frame-loading');
+        const error = document.getElementById('local-preview-frame-error');
+        if (loading) loading.classList.remove('hidden');
+        if (error) error.classList.add('hidden');
+        clearLocalPreviewFrameLoadTimer();
+        if (shouldLoad) frame.src = url;
+        localPreviewFrameLoadTimer = setTimeout(() => {
+            showLocalPreviewFrameError('previewの読み込みに時間がかかっています。新規タブで開いてください。');
+        }, LOCAL_PREVIEW_FRAME_TIMEOUT_MS);
+    }
+    return true;
 }
 
 function localPreviewStatusClass(status) {
@@ -270,6 +339,8 @@ function renderLocalPreviewState(state) {
     state = localPreviewState;
     const statusEl = document.getElementById('local-preview-status');
     const messageEl = document.getElementById('local-preview-message');
+    const loadingEl = document.getElementById('local-preview-loading');
+    const advancedEl = document.getElementById('local-preview-advanced');
     const reclaimBtn = document.getElementById('local-preview-reclaim-btn');
     const stopBtn = document.getElementById('local-preview-stop-btn');
     if (!statusEl || !messageEl) return;
@@ -288,10 +359,23 @@ function renderLocalPreviewState(state) {
     else if (state?.session_active) message = 'このsiteには別の編集sessionがあります。';
     messageEl.textContent = message;
 
+    if (loadingEl) loadingEl.classList.toggle('hidden', status !== 'starting');
+
+    const processRunning = state?.process_state && state.process_state !== 'stopped';
+    const canManage = Boolean(state?.session_owned || state?.session_stale || (!state?.session_active && processRunning));
+    if (advancedEl) advancedEl.classList.toggle('hidden', !canManage);
+
     if (reclaimBtn) reclaimBtn.classList.toggle('hidden', !state?.session_stale);
     if (stopBtn) {
-        const processRunning = state?.process_state && state.process_state !== 'stopped';
         stopBtn.classList.toggle('hidden', !(state?.session_owned || (!state?.session_active && processRunning)));
+    }
+
+    if (!Editor.getCurrentPath() || status === 'conflict' || status === 'stale') {
+        closeEmbeddedLocalPreview();
+    } else if ((status === 'starting' || status === 'ready') && state?.session_owned === true && Editor.getCurrentPath() && !localPreviewEmbedDismissed) {
+        showEmbeddedLocalPreview();
+    } else if (status === 'failed' && state?.process_error) {
+        showLocalPreviewFrameError(state.process_error);
     }
 }
 
@@ -356,7 +440,7 @@ async function refreshLocalPreviewStatus() {
     try {
         const state = await API.fetchLocalPreviewStatus(localPreviewSessionID, controller.signal);
         renderLocalPreviewState(state);
-        return state;
+        return localPreviewState;
     } catch (e) {
         if (e?.name !== 'AbortError') console.error('[LocalPreview] status failed', e);
         return null;
@@ -386,30 +470,35 @@ async function toggleEmbeddedLocalPreview() {
     const btn = document.getElementById('local-preview-embed-btn');
     if (!wrapper || !frame || !btn) return;
     if (!wrapper.classList.contains('hidden')) {
-        closeEmbeddedLocalPreview();
+        closeEmbeddedLocalPreview({ dismiss: true });
         return;
     }
 
     const url = localPreviewURL();
     if (!url) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
     try {
+        localPreviewEmbedDismissed = false;
         if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
-        frame.src = url;
-        wrapper.classList.remove('hidden');
-        btn.textContent = '埋め込みを閉じる';
+        showEmbeddedLocalPreview({ reload: true });
         setTimeout(() => refreshLocalPreviewStatus(), 500);
     } catch (e) {
         UI.showToast('埋め込みpreviewを開始できません: ' + e.message, 'error');
     }
 }
 
-function closeEmbeddedLocalPreview() {
+function closeEmbeddedLocalPreview({ dismiss = false } = {}) {
     const wrapper = document.getElementById('local-preview-embed');
     const frame = document.getElementById('local-preview-frame');
     const btn = document.getElementById('local-preview-embed-btn');
+    clearLocalPreviewFrameLoadTimer();
+    if (dismiss) localPreviewEmbedDismissed = true;
     if (wrapper) wrapper.classList.add('hidden');
     if (frame) frame.src = 'about:blank';
     if (btn) btn.textContent = '埋め込み表示';
+    const loading = document.getElementById('local-preview-frame-loading');
+    const error = document.getElementById('local-preview-frame-error');
+    if (loading) loading.classList.add('hidden');
+    if (error) error.classList.add('hidden');
 }
 
 async function stopLocalLivePreview() {
@@ -436,7 +525,11 @@ async function reclaimLocalLivePreview() {
     try {
         await API.reclaimStaleLocalPreview();
         localPreviewSessionID = "";
-        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        localPreviewEmbedDismissed = false;
+        if (Editor.getCurrentPath()) {
+            await ensureLocalPreviewSession();
+            showEmbeddedLocalPreview({ reload: true });
+        }
         UI.showToast('Local Live Preview sessionを回収しました', 'success');
     } catch (e) {
         UI.showToast('Local Live Previewを回収できません: ' + e.message, 'error');

--- a/static/js/local_preview.js
+++ b/static/js/local_preview.js
@@ -1,0 +1,98 @@
+export const LOCAL_PREVIEW_FRAME_TIMEOUT_MS = 10000;
+
+const DEFAULT_TIMEOUT_MESSAGE = 'previewの読み込みを確認できません。新規タブで開いてください。';
+
+export function shouldCloseEmbeddedLocalPreview({ status, hasCurrentPath } = {}) {
+    return !hasCurrentPath || status === 'conflict' || status === 'stale';
+}
+
+export function shouldAutoShowEmbeddedLocalPreview({ status, sessionOwned, hasCurrentPath, dismissed } = {}) {
+    return hasCurrentPath && sessionOwned === true && !dismissed && (status === 'starting' || status === 'ready');
+}
+
+export function createLocalPreviewFrameController({
+    getURL,
+    wrapper,
+    frame,
+    button,
+    loading,
+    error,
+    errorMessage,
+    setTimeoutFn = globalThis.setTimeout,
+    clearTimeoutFn = globalThis.clearTimeout,
+    timeoutMs = LOCAL_PREVIEW_FRAME_TIMEOUT_MS,
+    timeoutMessage = DEFAULT_TIMEOUT_MESSAGE,
+} = {}) {
+    let loadTimer = null;
+    let dismissed = false;
+
+    function clearLoadTimer() {
+        if (loadTimer !== null) {
+            clearTimeoutFn(loadTimer);
+            loadTimer = null;
+        }
+    }
+
+    function isVisible() {
+        return Boolean(wrapper && !wrapper.classList.contains('hidden'));
+    }
+
+    function showError(message) {
+        clearLoadTimer();
+        if (loading) loading.classList.add('hidden');
+        if (errorMessage && message) errorMessage.textContent = message;
+        if (error) error.classList.remove('hidden');
+    }
+
+    function markReady() {
+        clearLoadTimer();
+        if (loading) loading.classList.add('hidden');
+        if (error) error.classList.add('hidden');
+    }
+
+    function show({ reload = false } = {}) {
+        const url = typeof getURL === 'function' ? getURL() : '';
+        if (!wrapper || !frame || !url) return false;
+
+        const wasVisible = isVisible();
+        const currentSrc = typeof frame.getAttribute === 'function'
+            ? frame.getAttribute('src')
+            : frame.src;
+        const shouldLoad = reload || currentSrc !== url;
+
+        wrapper.classList.remove('hidden');
+        if (button) button.textContent = '埋め込みを閉じる';
+
+        if (!wasVisible || shouldLoad) {
+            if (loading) loading.classList.remove('hidden');
+            if (error) error.classList.add('hidden');
+            clearLoadTimer();
+            if (shouldLoad) frame.src = url;
+            loadTimer = setTimeoutFn(() => showError(timeoutMessage), timeoutMs);
+        }
+        return true;
+    }
+
+    function close({ dismiss = false } = {}) {
+        clearLoadTimer();
+        if (dismiss) dismissed = true;
+        if (wrapper) wrapper.classList.add('hidden');
+        if (frame) frame.src = 'about:blank';
+        if (button) button.textContent = '埋め込み表示';
+        if (loading) loading.classList.add('hidden');
+        if (error) error.classList.add('hidden');
+    }
+
+    return {
+        clearLoadTimer,
+        close,
+        handleError: (message) => showError(message || 'preview ingressから応答を確認できませんでした。'),
+        handleLoad: markReady,
+        handleReady: markReady,
+        isDismissed: () => dismissed,
+        isVisible,
+        resetDismissed: () => { dismissed = false; },
+        show,
+        showError,
+    };
+}

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -4,7 +4,12 @@ import * as API from './api.js';
 export function switchView(viewName) {
     const contentArea = document.getElementById('content-area');
     contentArea.classList.remove('split-mode');
-    contentArea.classList.toggle('local-preview-mode', viewName === 'edit');
+    contentArea.classList.toggle(
+        'local-preview-mode',
+        viewName === 'edit' &&
+        contentArea.classList.contains('local-preview-enabled') &&
+        contentArea.dataset.localPreviewHasArticle === 'true',
+    );
     document.getElementById('btn-view-split').classList.remove('active');
 
     document.getElementById('edit-view').style.display = 'none';

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -4,6 +4,7 @@ import * as API from './api.js';
 export function switchView(viewName) {
     const contentArea = document.getElementById('content-area');
     contentArea.classList.remove('split-mode');
+    contentArea.classList.toggle('local-preview-mode', viewName === 'edit');
     document.getElementById('btn-view-split').classList.remove('active');
 
     document.getElementById('edit-view').style.display = 'none';
@@ -31,6 +32,7 @@ export function toggleSplitView() {
     const splitBtn = document.getElementById('btn-view-split');
 
     if (isSplit) {
+        contentArea.classList.remove('local-preview-mode');
         splitBtn.classList.add('active');
         document.getElementById('btn-view-edit').classList.remove('active');
         document.getElementById('btn-view-preview').classList.remove('active');

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -23,6 +23,11 @@ const {
     normalizeLocalPreviewState,
     safeExternalURL,
 } = await import("./ui.js");
+const {
+    createLocalPreviewFrameController,
+    shouldAutoShowEmbeddedLocalPreview,
+    shouldCloseEmbeddedLocalPreview,
+} = await import("./local_preview.js");
 const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
 const API = await import("./api.js");
 
@@ -82,6 +87,99 @@ describe("normalizeLocalPreviewState", () => {
         });
 
         assert.equal(state.status, "stale");
+    });
+});
+
+function createPreviewFrameHarness() {
+    const makeClassList = (...initial) => {
+        const values = new Set(initial);
+        return {
+            add(value) { values.add(value); },
+            remove(value) { values.delete(value); },
+            contains(value) { return values.has(value); },
+        };
+    };
+    const wrapper = { classList: makeClassList("hidden") };
+    const frame = {
+        src: "about:blank",
+        getAttribute(name) { return name === "src" ? this.src : null; },
+    };
+    const button = { textContent: "埋め込み表示" };
+    const loading = { classList: makeClassList("hidden") };
+    const error = { classList: makeClassList("hidden") };
+    const errorMessage = { textContent: "" };
+    let timerCallback = null;
+    const controller = createLocalPreviewFrameController({
+        getURL: () => "https://preview.example.test/",
+        wrapper,
+        frame,
+        button,
+        loading,
+        error,
+        errorMessage,
+        setTimeoutFn(callback) {
+            timerCallback = callback;
+            return "preview-timer";
+        },
+        clearTimeoutFn() {
+            timerCallback = null;
+        },
+    });
+    return { controller, wrapper, frame, button, loading, error, errorMessage, triggerTimeout: () => timerCallback?.() };
+}
+
+describe("embedded Local Preview state transitions", () => {
+    it("closes the embed for conflict, stale, or missing article state", () => {
+        assert.equal(shouldCloseEmbeddedLocalPreview({ status: "conflict", hasCurrentPath: true }), true);
+        assert.equal(shouldCloseEmbeddedLocalPreview({ status: "stale", hasCurrentPath: true }), true);
+        assert.equal(shouldCloseEmbeddedLocalPreview({ status: "ready", hasCurrentPath: false }), true);
+        assert.equal(shouldCloseEmbeddedLocalPreview({ status: "ready", hasCurrentPath: true }), false);
+    });
+
+    it("only auto-shows an owned preview for an active article", () => {
+        assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "starting", sessionOwned: true, hasCurrentPath: true, dismissed: false }), true);
+        assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "conflict", sessionOwned: true, hasCurrentPath: true, dismissed: false }), false);
+        assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "ready", sessionOwned: false, hasCurrentPath: true, dismissed: false }), false);
+        assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "ready", sessionOwned: true, hasCurrentPath: true, dismissed: true }), false);
+    });
+
+    it("shows the iframe in loading state and clears it after a ready event", () => {
+        const harness = createPreviewFrameHarness();
+
+        assert.equal(harness.controller.show(), true);
+        assert.equal(harness.controller.isVisible(), true);
+        assert.equal(harness.frame.src, "https://preview.example.test/");
+        assert.equal(harness.loading.classList.contains("hidden"), false);
+        assert.equal(harness.button.textContent, "埋め込みを閉じる");
+
+        harness.controller.handleReady();
+        assert.equal(harness.loading.classList.contains("hidden"), true);
+        assert.equal(harness.error.classList.contains("hidden"), true);
+    });
+
+    it("shows a best-effort fallback state when the iframe does not respond", () => {
+        const harness = createPreviewFrameHarness();
+
+        harness.controller.show();
+        harness.triggerTimeout();
+
+        assert.equal(harness.error.classList.contains("hidden"), false);
+        assert.match(harness.errorMessage.textContent, /確認できません/);
+    });
+
+    it("keeps dismissal separate from manual reopening", () => {
+        const harness = createPreviewFrameHarness();
+
+        harness.controller.show();
+        harness.controller.close({ dismiss: true });
+        assert.equal(harness.controller.isDismissed(), true);
+        assert.equal(harness.controller.isVisible(), false);
+        assert.equal(harness.frame.src, "about:blank");
+
+        harness.controller.resetDismissed();
+        harness.controller.show({ reload: true });
+        assert.equal(harness.controller.isDismissed(), false);
+        assert.equal(harness.controller.isVisible(), true);
     });
 });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,35 +64,6 @@
             </div>
         </header>
 
-        <section id="local-preview-panel" class="deployment-panel hidden" aria-label="Local Live Preview">
-            <div class="deployment-heading">
-                <strong>Local Live Preview</strong>
-                <span id="local-preview-status" class="deployment-status idle">停止</span>
-            </div>
-            <div id="local-preview-message" class="deployment-message" aria-live="polite">
-                Hugoのtheme/layout/shortcode/CSS/JSを含むpreviewです。
-            </div>
-            <div class="deployment-actions">
-                <button id="local-preview-open-btn" class="action-btn" onclick="openLocalLivePreview()">新規タブで開く</button>
-                <button id="local-preview-embed-btn" class="action-btn secondary" onclick="toggleEmbeddedLocalPreview()">埋め込み表示</button>
-                <button id="local-preview-stop-btn" class="action-btn danger hidden" onclick="stopLocalLivePreview()">停止</button>
-                <button id="local-preview-reclaim-btn" class="action-btn secondary hidden" onclick="reclaimLocalLivePreview()">期限切れsessionを回収</button>
-            </div>
-            <div class="deployment-message" role="note">
-                埋め込みはpreview ingressのframe policyや外部認証によって利用できない場合があります。その場合も新規タブ表示は利用できます。
-            </div>
-            <div id="local-preview-embed" class="hidden" style="margin-top: 10px; height: min(58vh, 720px); min-height: 360px; border: 1px solid #444c56; border-radius: 6px; overflow: hidden; background: #fff;">
-                <iframe
-                    id="local-preview-frame"
-                    title="Local Live Preview"
-                    src="about:blank"
-                    sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
-                    referrerpolicy="no-referrer"
-                    style="display: block; width: 100%; height: 100%; border: 0; background: #fff;"
-                ></iframe>
-            </div>
-        </section>
-
         <section id="deployment-panel" class="deployment-panel hidden" aria-label="デプロイプレビュー">
             <div class="deployment-heading">
                 <strong>デプロイプレビュー</strong>
@@ -121,6 +92,55 @@
                     <textarea id="editor" spellcheck="false" placeholder="Select a file to edit..."></textarea>
                 </div>
             </div>
+
+            <section id="local-preview-view" aria-label="Local Live Preview">
+                <div id="local-preview-panel" class="local-preview-panel">
+                    <div class="local-preview-toolbar">
+                        <div class="deployment-heading">
+                            <strong>Live Preview</strong>
+                            <span id="local-preview-status" class="deployment-status idle">停止</span>
+                        </div>
+                        <span class="local-preview-caption">編集中のサイト表示</span>
+                    </div>
+                    <div id="local-preview-message" class="deployment-message" aria-live="polite">
+                        記事を選択すると未保存内容をpreviewへ反映します。
+                    </div>
+                    <div id="local-preview-loading" class="local-preview-loading hidden" role="status" aria-live="polite">
+                        Hugo previewを起動しています…
+                    </div>
+                    <div class="local-preview-actions">
+                        <button id="local-preview-open-btn" class="action-btn secondary" onclick="openLocalLivePreview()">新規タブで開く</button>
+                        <button id="local-preview-embed-btn" class="action-btn" onclick="toggleEmbeddedLocalPreview()">埋め込みを表示</button>
+                        <details id="local-preview-advanced" class="local-preview-advanced hidden">
+                            <summary>管理操作</summary>
+                            <div class="deployment-actions">
+                                <button id="local-preview-stop-btn" class="action-btn danger hidden" onclick="stopLocalLivePreview()">停止</button>
+                                <button id="local-preview-reclaim-btn" class="action-btn secondary hidden" onclick="reclaimLocalLivePreview()">期限切れsessionを回収</button>
+                            </div>
+                        </details>
+                    </div>
+                    <div id="local-preview-embed" class="local-preview-embed hidden">
+                        <div id="local-preview-frame-loading" class="local-preview-frame-overlay" role="status" aria-live="polite">
+                            Previewを読み込み中…
+                        </div>
+                        <iframe
+                            id="local-preview-frame"
+                            title="Local Live Preview"
+                            src="about:blank"
+                            sandbox="allow-scripts allow-same-origin allow-forms allow-modals allow-popups"
+                            referrerpolicy="no-referrer"
+                        ></iframe>
+                        <div id="local-preview-frame-error" class="local-preview-frame-error hidden" role="alert">
+                            <strong>埋め込みpreviewを表示できませんでした</strong>
+                            <span id="local-preview-frame-error-message">preview ingressのframe policyまたは外部認証で拒否された可能性があります。</span>
+                            <button class="action-btn" onclick="openLocalLivePreview()">新規タブで開く</button>
+                        </div>
+                    </div>
+                    <div class="local-preview-note" role="note">
+                        埋め込みが利用できない環境では「新規タブで開く」を使用してください。
+                    </div>
+                </div>
+            </section>
 
             <div id="preview-view">
                 <div class="markdown-preview-notice" role="note">

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,8 +131,8 @@
                             referrerpolicy="no-referrer"
                         ></iframe>
                         <div id="local-preview-frame-error" class="local-preview-frame-error hidden" role="alert">
-                            <strong>埋め込みpreviewを表示できませんでした</strong>
-                            <span id="local-preview-frame-error-message">preview ingressのframe policyまたは外部認証で拒否された可能性があります。</span>
+                            <strong>埋め込みpreviewの応答を確認できません</strong>
+                            <span id="local-preview-frame-error-message">preview側の応答を確認できませんでした。frame policyまたは外部認証などの可能性があります。</span>
                             <button class="action-btn" onclick="openLocalLivePreview()">新規タブで開く</button>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary\n\n- embed Local Live Preview as the primary editing surface\n- show editor and live preview side by side on desktop\n- add responsive layout, loading/error states, and new-tab fallback\n- move stop/reclaim into secondary management actions\n- update documentation and template regression coverage\n\nCloses #38\nRelated: #32, #37