### PR TITLE
feat: Local Previewを記事ページ追従・Preview/Split統合

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -217,7 +217,7 @@ release時はHugo process停止後にworkspaceを削除する。active shadow se
 
 - Local Live Previewを開く/新規tab導線（埋め込みを主導線、新規tabをfallback）
 - desktopの編集+埋め込みpreview並列表示と狭い画面での上下配置
-- iframe loading、応答未確認のbest-effort表示、新規tab fallback。preview側が`homecms-local-preview-ready`の`postMessage`を送る場合は明示的なready通知として扱う
+- iframe loading、応答未確認のbest-effort表示、新規tab fallback。preview側がCMS originをtarget originに指定して`homecms-local-preview-ready`の`postMessage`を送る場合は明示的なready通知として扱う
 - 記事選択時のHugo `--navigateToChanged`による実ページ追従と初回ready後の一度だけの再同期
 - Local Preview有効siteの`Edit` / `Preview` / `Split`統合。無効siteではMarkdown Previewを維持
 - starting / ready / failed / conflict / stale状態表示

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -94,8 +94,11 @@ hugo server
   --buildFuture
   --buildExpired
   --watch
+  --navigateToChanged
   --noHTTPCache
 ```
+
+記事選択時の初回起動では、shadow workspaceへ記事を同期してからHugoへ最初のrequestを送り、ready後に同じ記事を一度だけ再同期する。これにより、Hugo processが起動済みでない場合も`--navigateToChanged`が選択記事の実ページへ遷移できる。以降の同一記事の編集はLiveReloadを利用し、CMSはpermalinkやslugを再実装しない。
 
 ## Reverse proxy / LiveReload
 
@@ -215,6 +218,8 @@ release時はHugo process停止後にworkspaceを削除する。active shadow se
 - Local Live Previewを開く/新規tab導線（埋め込みを主導線、新規tabをfallback）
 - desktopの編集+埋め込みpreview並列表示と狭い画面での上下配置
 - iframe loading、応答未確認のbest-effort表示、新規tab fallback。preview側が`homecms-local-preview-ready`の`postMessage`を送る場合は明示的なready通知として扱う
+- 記事選択時のHugo `--navigateToChanged`による実ページ追従と初回ready後の一度だけの再同期
+- Local Preview有効siteの`Edit` / `Preview` / `Split`統合。無効siteではMarkdown Previewを維持
 - starting / ready / failed / conflict / stale状態表示
 - Local Previewの明示停止とstale session recovery/lease方針
 - private network/Tailscale運用例

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではHugoの`--navigateToChanged`で選択記事の実ページへ追従し、Local Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -157,11 +157,20 @@ Local Live Preview panelでは次を利用できます。
 
 - `埋め込み表示`: 記事を選択するとCMS内のsandbox付きiframeを主表示として自動表示
 - `新規タブで開く`: iframeが利用できない場合や補助的な確認に使う
+- `簡易Markdownを表示`: generatorを使わない補助/fallback表示
 - `管理操作` > `停止`: 自分が所有するsession、またはworkspaceを伴わないsaved-content preview processを停止
 - `管理操作` > `期限切れsessionを回収`: stale leaseだけを安全にreclaim
 - stopped / starting / ready / failed / conflict / staleの状態表示
 
-desktopでは編集画面とLive Previewを左右に並べます。iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
+Local Live Previewが有効なsiteではheaderのview切替を次のように扱います。
+
+- `Edit`: Editorのみを全幅表示
+- `Preview`: Local Live Previewを全幅表示
+- `Split`: EditorとLocal Live Previewを左右（狭い画面では上下）に表示
+
+記事選択時はdesktopでは`Split`を初期viewにし、Hugoが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、Hugo serverの`--navigateToChanged`に遷移を任せます。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
+
+iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
 preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<preview origin>')` を送ると、CMSが明示的なready通知として扱います。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -172,7 +172,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
-preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<preview origin>')` を送ると、CMSが明示的なready通知として扱います。
+preview側を管理できる場合は、正常表示後に親ウィンドウへ `window.parent.postMessage({ type: 'homecms-local-preview-ready' }, '<CMS origin>')` を送ると、CMSが明示的なready通知として扱います。第2引数は埋め込み元であるCMSのoriginに固定し、`*`は使用しません。
 
 ### iframe埋め込み
 

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -602,6 +602,7 @@ func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL strin
 		"--buildFuture",
 		"--buildExpired",
 		"--watch",
+		"--navigateToChanged",
 		"--noHTTPCache",
 	}, nil
 }

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -39,6 +39,7 @@ func TestHugoLocalPreviewArgs(t *testing.T) {
 		"--buildFuture",
 		"--buildExpired",
 		"--watch",
+		"--navigateToChanged",
 		"--noHTTPCache",
 	}
 	if !reflect.DeepEqual(got, want) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -179,7 +179,8 @@ details[open] > summary::before { content: '▾ '; }
 
     /* Keep the editor and Local Preview usable together on small screens. */
     #content-area.local-preview-view-mode, #content-area.local-preview-enabled.split-mode { flex-direction: column; overflow-y: auto; }
-    #content-area.local-preview-view-mode #local-preview-view, #content-area.local-preview-enabled.split-mode #local-preview-view { flex: 0 0 45%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
+    #content-area.local-preview-view-mode #local-preview-view { flex: 1 1 100%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
+    #content-area.local-preview-enabled.split-mode #local-preview-view { flex: 0 0 45%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
     #content-area.local-preview-enabled.split-mode #edit-view { flex: 1 1 55%; width: 100%; min-height: 280px; border-right: 0; }
     .local-preview-panel { padding: 8px 10px; }
     .local-preview-caption, .local-preview-note { display: none; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -68,8 +68,9 @@ textarea { width: 100%; height: 100%; background: #1e1e1e; color: #d4d4d4; borde
 
 /* Local Live Preview */
 #local-preview-view { display: none; flex: 1 1 auto; flex-direction: column; width: 0; min-width: 0; min-height: 0; overflow: hidden; background: #20252b; border-left: 1px solid #333; }
-#content-area.local-preview-enabled.local-preview-mode #edit-view { flex: 1 1 50%; width: 50%; border-right: 1px solid #333; }
-#content-area.local-preview-enabled.local-preview-mode #local-preview-view { display: flex; flex: 1 1 50%; width: 50%; }
+#content-area.local-preview-view-mode #edit-view { display: none !important; }
+#content-area.local-preview-view-mode #preview-view { display: none !important; }
+#content-area.local-preview-view-mode #local-preview-view { display: flex !important; flex: 1 1 100%; width: 100%; border-left: 0; }
 .local-preview-panel { display: flex; flex: 1; min-width: 0; min-height: 0; flex-direction: column; padding: 14px; overflow: hidden; }
 .local-preview-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
 .local-preview-caption { color: #8c959f; font-size: 12px; }
@@ -131,6 +132,8 @@ textarea { width: 100%; height: 100%; background: #1e1e1e; color: #d4d4d4; borde
 #content-area.split-mode #edit-view { flex: 1 1 50%; width: 50%; border-right: 1px solid #333; display: flex !important; }
 #content-area.split-mode #local-preview-view { display: none !important; }
 #content-area.split-mode #preview-view { flex: 1 1 50%; width: 50%; display: block !important; }
+#content-area.local-preview-enabled.split-mode #preview-view { display: none !important; }
+#content-area.local-preview-enabled.split-mode #local-preview-view { display: flex !important; flex: 1 1 50%; width: 50%; }
 
 /* Utils */
 .action-btn { background: #0e639c; color: white; border: none; padding: 6px 12px; border-radius: 3px; font-size: 13px; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 5px; }
@@ -175,9 +178,9 @@ details[open] > summary::before { content: '▾ '; }
     .mobile-actions { display: block; }
 
     /* Keep the editor and Local Preview usable together on small screens. */
-    #content-area.local-preview-enabled.local-preview-mode { flex-direction: column; overflow-y: auto; }
-    #content-area.local-preview-enabled.local-preview-mode #edit-view { flex: 1 1 55%; width: 100%; min-height: 280px; border-right: 0; }
-    #content-area.local-preview-enabled.local-preview-mode #local-preview-view { flex: 0 0 45%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
+    #content-area.local-preview-view-mode, #content-area.local-preview-enabled.split-mode { flex-direction: column; overflow-y: auto; }
+    #content-area.local-preview-view-mode #local-preview-view, #content-area.local-preview-enabled.split-mode #local-preview-view { flex: 0 0 45%; width: 100%; min-height: 260px; border-top: 1px solid #333; border-left: 0; }
+    #content-area.local-preview-enabled.split-mode #edit-view { flex: 1 1 55%; width: 100%; min-height: 280px; border-right: 0; }
     .local-preview-panel { padding: 8px 10px; }
     .local-preview-caption, .local-preview-note { display: none; }
     .local-preview-actions .local-preview-advanced { margin-left: 0; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -6,6 +6,7 @@ import {
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
     shouldResyncLocalPreviewAfterInitialLoad,
+    shouldUseLocalPreviewSplitDefault,
 } from './local_preview.js';
 
 // Global State
@@ -26,6 +27,7 @@ let localPreviewController = null;
 let localPreviewOperationInProgress = false;
 let localPreviewFrameController = null;
 let localPreviewNeedsInitialNavigation = false;
+let localPreviewInitialNavigationInFlight = false;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
@@ -212,7 +214,10 @@ async function loadFile(path) {
         localPreviewFrameController?.resetDismissed();
         localPreviewNeedsInitialNavigation = true;
         updateLocalPreviewAvailability();
-        UI.switchView('split');
+        UI.switchView(shouldUseLocalPreviewSplitDefault({
+            enabled: localPreviewEnabled,
+            narrowViewport: isNarrowViewport(),
+        }) ? 'split' : 'edit');
         try {
             await ensureLocalPreviewSession();
             showEmbeddedLocalPreview({ reload: true });
@@ -247,6 +252,13 @@ async function switchView(viewName) {
 
 function localPreviewURL() {
     return UI.safeExternalURL(cmsConfig?._cms?.local_preview?.url || "");
+}
+
+function isNarrowViewport() {
+    if (typeof window.matchMedia === 'function') {
+        return window.matchMedia('(max-width: 768px)').matches;
+    }
+    return Number(window.innerWidth || 0) > 0 && window.innerWidth <= 768;
 }
 
 function configureLocalPreviewPanel() {
@@ -300,10 +312,21 @@ function handleLocalPreviewFrameLoad() {
         hasCurrentPath: Boolean(Editor.getCurrentPath()),
     })) return;
 
-    localPreviewNeedsInitialNavigation = false;
+    if (localPreviewInitialNavigationInFlight) return;
+    localPreviewInitialNavigationInFlight = true;
+    const requestPath = Editor.getCurrentPath();
     Editor.refreshLocalLivePreview()
-        .then(() => refreshLocalPreviewStatus())
-        .catch(() => undefined);
+        .then(() => {
+            if (Editor.getCurrentPath() === requestPath) localPreviewNeedsInitialNavigation = false;
+            return refreshLocalPreviewStatus();
+        })
+        .catch(() => undefined)
+        .finally(() => {
+            // Keep the pending flag until the content update succeeds, while
+            // the in-flight guard prevents repeated iframe load events from
+            // duplicating the request.
+            localPreviewInitialNavigationInFlight = false;
+        });
 }
 
 function updateLocalPreviewAvailability() {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -5,6 +5,7 @@ import {
     createLocalPreviewFrameController,
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
+    shouldResyncLocalPreviewAfterInitialLoad,
 } from './local_preview.js';
 
 // Global State
@@ -24,6 +25,7 @@ let localPreviewHeartbeatTimer = null;
 let localPreviewController = null;
 let localPreviewOperationInProgress = false;
 let localPreviewFrameController = null;
+let localPreviewNeedsInitialNavigation = false;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
@@ -114,6 +116,7 @@ async function init() {
     window.markDeploymentPreviewStale = markDeploymentPreviewStale;
     window.openLocalLivePreview = openLocalLivePreview;
     window.toggleEmbeddedLocalPreview = toggleEmbeddedLocalPreview;
+    window.showMarkdownFallback = () => switchView('markdown');
     window.stopLocalLivePreview = stopLocalLivePreview;
     window.reclaimLocalLivePreview = reclaimLocalLivePreview;
 
@@ -134,6 +137,7 @@ async function loadSiteData() {
 
     localPreviewEnabled = cmsConfig?._cms?.local_preview?.enabled === true && Boolean(localPreviewURL());
     configureLocalPreviewPanel();
+    UI.switchView('edit');
     if (localPreviewEnabled) {
         await refreshLocalPreviewStatus();
         scheduleLocalPreviewMonitoring();
@@ -206,7 +210,9 @@ async function loadFile(path) {
     localPreviewSessionID = "";
     if (localPreviewEnabled) {
         localPreviewFrameController?.resetDismissed();
-        updateLocalPreviewMode();
+        localPreviewNeedsInitialNavigation = true;
+        updateLocalPreviewAvailability();
+        UI.switchView('split');
         try {
             await ensureLocalPreviewSession();
             showEmbeddedLocalPreview({ reload: true });
@@ -229,7 +235,7 @@ async function refreshFileList() {
 }
 
 async function switchView(viewName) {
-    if (viewName === 'preview') {
+    if ((viewName === 'preview' && !localPreviewEnabled) || viewName === 'markdown') {
         try {
             await Editor.refreshMarkdownPreview();
         } catch (_) {
@@ -245,7 +251,7 @@ function localPreviewURL() {
 
 function configureLocalPreviewPanel() {
     const panel = document.getElementById('local-preview-panel');
-    updateLocalPreviewMode();
+    updateLocalPreviewAvailability();
     if (!localPreviewEnabled) {
         closeEmbeddedLocalPreview();
         return;
@@ -267,7 +273,7 @@ function initializeLocalPreviewFrame() {
         error: document.getElementById('local-preview-frame-error'),
         errorMessage: document.getElementById('local-preview-frame-error-message'),
     });
-    frame.addEventListener('load', () => localPreviewFrameController?.handleLoad());
+    frame.addEventListener('load', handleLocalPreviewFrameLoad);
     frame.addEventListener('error', () => localPreviewFrameController?.handleError());
     window.addEventListener('message', handleLocalPreviewReadyMessage);
 }
@@ -286,22 +292,31 @@ function handleLocalPreviewReadyMessage(event) {
     localPreviewFrameController?.handleReady();
 }
 
-function updateLocalPreviewMode() {
+function handleLocalPreviewFrameLoad() {
+    localPreviewFrameController?.handleLoad();
+    if (!shouldResyncLocalPreviewAfterInitialLoad({
+        pending: localPreviewNeedsInitialNavigation,
+        enabled: localPreviewEnabled,
+        hasCurrentPath: Boolean(Editor.getCurrentPath()),
+    })) return;
+
+    localPreviewNeedsInitialNavigation = false;
+    Editor.refreshLocalLivePreview()
+        .then(() => refreshLocalPreviewStatus())
+        .catch(() => undefined);
+}
+
+function updateLocalPreviewAvailability() {
     const contentArea = document.getElementById('content-area');
     if (!contentArea) return;
     const hasCurrentPath = Boolean(Editor.getCurrentPath());
-    const embedded = localPreviewFrameController?.isVisible() === true;
     contentArea.dataset.localPreviewHasArticle = String(hasCurrentPath);
     contentArea.classList.toggle('local-preview-enabled', localPreviewEnabled);
-    contentArea.classList.toggle(
-        'local-preview-mode',
-        localPreviewEnabled && !contentArea.classList.contains('split-mode') && (hasCurrentPath || embedded),
-    );
 }
 
 function showEmbeddedLocalPreview(options = {}) {
     const shown = localPreviewFrameController?.show(options) === true;
-    if (shown) updateLocalPreviewMode();
+    if (shown) updateLocalPreviewAvailability();
     return shown;
 }
 
@@ -310,8 +325,9 @@ function showLocalPreviewFrameError(message) {
 }
 
 function closeEmbeddedLocalPreview(options = {}) {
+    localPreviewNeedsInitialNavigation = false;
     localPreviewFrameController?.close(options);
-    updateLocalPreviewMode();
+    updateLocalPreviewAvailability();
 }
 
 function localPreviewStatusClass(status) {
@@ -484,6 +500,7 @@ async function toggleEmbeddedLocalPreview() {
     if (!url) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
     try {
         localPreviewFrameController?.resetDismissed();
+        localPreviewNeedsInitialNavigation = true;
         if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
         showEmbeddedLocalPreview({ reload: true });
         setTimeout(() => refreshLocalPreviewStatus(), 500);
@@ -518,6 +535,7 @@ async function reclaimLocalLivePreview() {
         localPreviewSessionID = "";
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
+            localPreviewNeedsInitialNavigation = true;
             await ensureLocalPreviewSession();
             showEmbeddedLocalPreview({ reload: true });
         }

--- a/static/js/local_preview.js
+++ b/static/js/local_preview.js
@@ -10,6 +10,10 @@ export function shouldAutoShowEmbeddedLocalPreview({ status, sessionOwned, hasCu
     return hasCurrentPath && sessionOwned === true && !dismissed && (status === 'starting' || status === 'ready');
 }
 
+export function shouldResyncLocalPreviewAfterInitialLoad({ pending, enabled, hasCurrentPath } = {}) {
+    return pending === true && enabled === true && hasCurrentPath === true;
+}
+
 export function createLocalPreviewFrameController({
     getURL,
     wrapper,

--- a/static/js/local_preview.js
+++ b/static/js/local_preview.js
@@ -14,6 +14,10 @@ export function shouldResyncLocalPreviewAfterInitialLoad({ pending, enabled, has
     return pending === true && enabled === true && hasCurrentPath === true;
 }
 
+export function shouldUseLocalPreviewSplitDefault({ enabled, narrowViewport } = {}) {
+    return enabled === true && narrowViewport !== true;
+}
+
 export function createLocalPreviewFrameController({
     getURL,
     wrapper,

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -3,27 +3,38 @@ import * as API from './api.js';
 
 export function switchView(viewName) {
     const contentArea = document.getElementById('content-area');
-    contentArea.classList.remove('split-mode');
-    contentArea.classList.toggle(
-        'local-preview-mode',
-        viewName === 'edit' &&
-        contentArea.classList.contains('local-preview-enabled') &&
-        contentArea.dataset.localPreviewHasArticle === 'true',
-    );
-    document.getElementById('btn-view-split').classList.remove('active');
+    if (viewName === 'split') {
+        applySplitView(contentArea);
+        return;
+    }
 
-    document.getElementById('edit-view').style.display = 'none';
-    document.getElementById('preview-view').style.display = 'none';
+    contentArea.classList.remove('split-mode', 'local-preview-view-mode');
+    const editView = document.getElementById('edit-view');
+    const previewView = document.getElementById('preview-view');
+    const localPreviewView = document.getElementById('local-preview-view');
+    editView.style.display = 'none';
+    previewView.style.display = 'none';
+    localPreviewView.style.display = 'none';
 
     if (viewName === 'edit') {
-        document.getElementById('edit-view').style.display = 'flex';
+        editView.style.display = 'flex';
     } else if (viewName === 'preview') {
-        document.getElementById('preview-view').style.display = 'block';
+        if (contentArea.classList.contains('local-preview-enabled')) {
+            contentArea.classList.add('local-preview-view-mode');
+            localPreviewView.style.display = 'flex';
+        } else {
+            previewView.style.display = 'block';
+        }
+    } else if (viewName === 'markdown') {
+        previewView.style.display = 'block';
     }
+
+    contentArea.dataset.viewMode = viewName === 'markdown' ? 'preview' : viewName;
+    document.getElementById('btn-view-split').classList.remove('active');
 
     const toggles = document.querySelectorAll('.view-toggle');
     toggles.forEach(btn => {
-        if (btn.id === 'btn-view-' + viewName) {
+        if (btn.id === 'btn-view-' + (viewName === 'markdown' ? 'preview' : viewName)) {
             btn.classList.add('active');
         } else {
             btn.classList.remove('active');
@@ -31,21 +42,34 @@ export function switchView(viewName) {
     });
 }
 
+function applySplitView(contentArea) {
+    const localPreviewEnabled = contentArea.classList.contains('local-preview-enabled');
+    const editView = document.getElementById('edit-view');
+    const previewView = document.getElementById('preview-view');
+    const localPreviewView = document.getElementById('local-preview-view');
+
+    contentArea.classList.remove('local-preview-view-mode');
+    contentArea.classList.add('split-mode');
+    editView.style.display = 'flex';
+    previewView.style.display = localPreviewEnabled ? 'none' : 'block';
+    localPreviewView.style.display = localPreviewEnabled ? 'flex' : 'none';
+    contentArea.dataset.viewMode = 'split';
+
+    document.getElementById('btn-view-split').classList.add('active');
+    document.getElementById('btn-view-edit').classList.remove('active');
+    document.getElementById('btn-view-preview').classList.remove('active');
+
+    // Trigger the simple preview build only when it is the active split surface.
+    if (!localPreviewEnabled && window.buildAndPreview) window.buildAndPreview();
+}
+
 export function toggleSplitView() {
     const contentArea = document.getElementById('content-area');
     const isSplit = contentArea.classList.toggle('split-mode');
-    const splitBtn = document.getElementById('btn-view-split');
 
     if (isSplit) {
-        contentArea.classList.remove('local-preview-mode');
-        splitBtn.classList.add('active');
-        document.getElementById('btn-view-edit').classList.remove('active');
-        document.getElementById('btn-view-preview').classList.remove('active');
-
-        // Trigger build since preview is shown
-        if (window.buildAndPreview) window.buildAndPreview();
+        applySplitView(contentArea);
     } else {
-        splitBtn.classList.remove('active');
         switchView('edit');
     }
 }

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -22,11 +22,13 @@ const {
     normalizeDeploymentState,
     normalizeLocalPreviewState,
     safeExternalURL,
+    switchView,
 } = await import("./ui.js");
 const {
     createLocalPreviewFrameController,
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
+    shouldResyncLocalPreviewAfterInitialLoad,
 } = await import("./local_preview.js");
 const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
 const API = await import("./api.js");
@@ -143,6 +145,13 @@ describe("embedded Local Preview state transitions", () => {
         assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "ready", sessionOwned: true, hasCurrentPath: true, dismissed: true }), false);
     });
 
+    it("resyncs the selected article only once after the initial iframe response", () => {
+        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: true, hasCurrentPath: true }), true);
+        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: false, enabled: true, hasCurrentPath: true }), false);
+        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: false, hasCurrentPath: true }), false);
+        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: true, hasCurrentPath: false }), false);
+    });
+
     it("shows the iframe in loading state and clears it after a ready event", () => {
         const harness = createPreviewFrameHarness();
 
@@ -180,6 +189,86 @@ describe("embedded Local Preview state transitions", () => {
         harness.controller.show({ reload: true });
         assert.equal(harness.controller.isDismissed(), false);
         assert.equal(harness.controller.isVisible(), true);
+    });
+});
+
+function createViewHarness({ localPreviewEnabled = false } = {}) {
+    const makeClassList = (...initial) => {
+        const values = new Set(initial);
+        return {
+            add(value) { values.add(value); },
+            remove(...items) { items.forEach(value => values.delete(value)); },
+            contains(value) { return values.has(value); },
+        };
+    };
+    const makeElement = id => ({
+        id,
+        classList: makeClassList(),
+        dataset: {},
+        style: { display: "" },
+    });
+    const contentArea = makeElement("content-area");
+    if (localPreviewEnabled) contentArea.classList.add("local-preview-enabled");
+    const elements = new Map([
+        ["content-area", contentArea],
+        ["edit-view", makeElement("edit-view")],
+        ["preview-view", makeElement("preview-view")],
+        ["local-preview-view", makeElement("local-preview-view")],
+        ["btn-view-edit", makeElement("btn-view-edit")],
+        ["btn-view-preview", makeElement("btn-view-preview")],
+        ["btn-view-split", makeElement("btn-view-split")],
+    ]);
+    const previousDocument = globalThis.document;
+    globalThis.document = {
+        getElementById(id) { return elements.get(id); },
+        querySelectorAll(selector) {
+            return selector === ".view-toggle"
+                ? [elements.get("btn-view-edit"), elements.get("btn-view-preview"), elements.get("btn-view-split")]
+                : [];
+        },
+    };
+    return {
+        contentArea,
+        editView: elements.get("edit-view"),
+        previewView: elements.get("preview-view"),
+        localPreviewView: elements.get("local-preview-view"),
+        restore() { globalThis.document = previousDocument; },
+    };
+}
+
+describe("view surface integration", () => {
+    it("uses Local Live Preview for Preview and Split when enabled", () => {
+        const harness = createViewHarness({ localPreviewEnabled: true });
+        try {
+            switchView("preview");
+            assert.equal(harness.localPreviewView.style.display, "flex");
+            assert.equal(harness.previewView.style.display, "none");
+            assert.equal(harness.editView.style.display, "none");
+
+            switchView("split");
+            assert.equal(harness.contentArea.classList.contains("split-mode"), true);
+            assert.equal(harness.editView.style.display, "flex");
+            assert.equal(harness.localPreviewView.style.display, "flex");
+            assert.equal(harness.previewView.style.display, "none");
+
+            switchView("edit");
+            assert.equal(harness.contentArea.classList.contains("split-mode"), false);
+            assert.equal(harness.editView.style.display, "flex");
+            assert.equal(harness.localPreviewView.style.display, "none");
+        } finally {
+            harness.restore();
+        }
+    });
+
+    it("keeps the Markdown surface as Preview when Local Live Preview is disabled", () => {
+        const harness = createViewHarness();
+        try {
+            switchView("preview");
+            assert.equal(harness.previewView.style.display, "block");
+            assert.equal(harness.localPreviewView.style.display, "none");
+        } finally {
+            harness.restore();
+        }
     });
 });
 

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -29,6 +29,7 @@ const {
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
     shouldResyncLocalPreviewAfterInitialLoad,
+    shouldUseLocalPreviewSplitDefault,
 } = await import("./local_preview.js");
 const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
 const API = await import("./api.js");
@@ -150,6 +151,12 @@ describe("embedded Local Preview state transitions", () => {
         assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: false, enabled: true, hasCurrentPath: true }), false);
         assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: false, hasCurrentPath: true }), false);
         assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: true, hasCurrentPath: false }), false);
+    });
+
+    it("uses Split as the desktop default but keeps Edit on narrow viewports", () => {
+        assert.equal(shouldUseLocalPreviewSplitDefault({ enabled: true, narrowViewport: false }), true);
+        assert.equal(shouldUseLocalPreviewSplitDefault({ enabled: true, narrowViewport: true }), false);
+        assert.equal(shouldUseLocalPreviewSplitDefault({ enabled: false, narrowViewport: false }), false);
     });
 
     it("shows the iframe in loading state and clears it after a ready event", () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
             <div style="display: flex; align-items: center;">
                 <div class="view-toggles">
                     <button class="view-toggle active" id="btn-view-edit" onclick="switchView('edit')">Edit</button>
-                    <button class="view-toggle" id="btn-view-preview" onclick="switchView('preview')">本文プレビュー</button>
+                    <button class="view-toggle" id="btn-view-preview" onclick="switchView('preview')">Preview</button>
                     <button class="view-toggle" id="btn-view-split" onclick="toggleSplitView()">Split</button>
                 </div>
                 
@@ -111,6 +111,7 @@
                     <div class="local-preview-actions">
                         <button id="local-preview-open-btn" class="action-btn secondary" onclick="openLocalLivePreview()">新規タブで開く</button>
                         <button id="local-preview-embed-btn" class="action-btn" onclick="toggleEmbeddedLocalPreview()">埋め込みを表示</button>
+                        <button id="local-preview-markdown-btn" class="action-btn secondary" onclick="showMarkdownFallback()">簡易Markdownを表示</button>
                         <details id="local-preview-advanced" class="local-preview-advanced hidden">
                             <summary>管理操作</summary>
                             <div class="deployment-actions">


### PR DESCRIPTION
## 概要\n\nIssue #40を実装しました。\n\n- Hugo serverへ --navigateToChanged を追加\n- iframe初回応答後に選択記事を一度だけ再同期し、初回起動後もHugoの実ページへ追従\n- Local Preview有効siteの Edit / Preview / Split を統合\n- 簡易Markdown Previewをfallback/補助表示として維持\n- desktop/mobileレイアウトと状態遷移の回帰テストを追加\n- 関連docsを更新\n\n## 検証\n\n- go test ./...\n- go vet ./...\n- go build -buildvcs=false ./...\n- Node.js frontend tests: 19 passed\n\nCloses #40\nRelated: #37, #38, #39