### PR TITLE
Issue #44: generatorからLocal Preview URLを解決

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -83,6 +83,7 @@ Hugoは概ね次相当で起動する。
 ```text
 hugo server
   --source .
+  --environment development
   --contentDir <content-dir>
   --bind 127.0.0.1
   --port <internal-port>
@@ -97,7 +98,7 @@ hugo server
   --noHTTPCache
 ```
 
-記事選択時の初回起動では、shadow workspaceをHugoの`--contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装では`--baseURL`にLocal Preview URL、`--noBuildLock`、shadow `--contentDir`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
+記事選択時の初回起動では、shadow workspaceをHugoの`--contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装ではserverと同じ`--environment development`、`--baseURL`にLocal Preview URL、`--noBuildLock`、shadow `--contentDir`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
 
 ## Reverse proxy / LiveReload
 

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -94,11 +94,10 @@ hugo server
   --buildFuture
   --buildExpired
   --watch
-  --navigateToChanged
   --noHTTPCache
 ```
 
-記事選択時の初回起動では、shadow workspaceへ記事を同期してからHugoへ最初のrequestを送り、iframeの初回load後に専用navigation APIを実行する。serverはHugoのready後に同じshadow記事をrevisionを増やさずatomic replaceし、filesystem eventを発生させる。これにより、記事を編集しなくても`--navigateToChanged`が選択記事の実ページへ遷移できる。以降の同一記事の編集はLiveReloadを利用し、CMSはpermalinkやslugを再実装しない。
+記事選択時の初回起動では、shadow workspaceをHugoの`--contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装では`--baseURL`にLocal Preview URL、`--noBuildLock`、shadow `--contentDir`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
 
 ## Reverse proxy / LiveReload
 
@@ -205,13 +204,13 @@ POST /admin/api/preview/local
 
 初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存Hugo processを一度停止する。次のpreview hostname requestでshadow `contentDir`を使ってlazy startし、その後はHugo watcherが変更を拾う。
 
-### 初回記事navigation
+### 初回記事URL解決
 
 ```text
 POST /admin/api/preview/local/navigate
 ```
 
-iframeの初回load後にCMSが`draft_id`と記事pathを送る。serverはactive sessionの所有者・記事pathを検証し、Hugo processのreadyを待ってからshadow記事を同じ内容でatomic replaceする。`--navigateToChanged`のURL解決はHugoに委譲するため、CMS側のslug/url/permalink/page bundle mappingは持たない。この処理はproduction contentを変更せず、editor revisionも増やさない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、409やその他の4xxは再試行しない。通常の編集更新では実行しない。
+記事選択時にCMSが`draft_id`と記事pathを`/admin/api/preview/local/navigate`へ送り、serverはactive sessionの所有者・記事pathを検証する。検証後、`PreviewURLResolver`がshadow workspaceを使ってgeneratorへURL解決を依頼し、`article_url`を返す。Hugo実装は`hugo list all`の`path`と`permalink`を対応づけ、production originではなくLocal Preview originを返す。この処理はproduction content、Git、editor revisionを変更しない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、409やその他の4xxは再試行しない。通常の本文編集はLiveReloadを利用し、URL関連front matter変更時は再解決する。解決失敗時はpreview rootへ黙ってフォールバックしない。
 
 ### release
 
@@ -226,7 +225,7 @@ release時はHugo process停止後にworkspaceを削除する。active shadow se
 - Local Live Previewを開く/新規tab導線（埋め込みを主導線、新規tabをfallback）
 - desktopの編集+埋め込みpreview並列表示と狭い画面での上下配置
 - iframe loading、応答未確認のbest-effort表示、新規tab fallback。preview側がCMS originをtarget originに指定して`homecms-local-preview-ready`の`postMessage`を送る場合は明示的なready通知として扱う
-- 記事選択時のHugo `--navigateToChanged`による実ページ追従と、初回iframe load後のready確認・一度だけの再通知
+- 記事選択時の`PreviewURLResolver`によるgenerator準拠の実ページURL解決と、解決済みURLのiframe/新規タブ表示
 - Local Preview有効siteの`Edit` / `Preview` / `Split`統合。無効siteではMarkdown Previewを維持
 - starting / ready / failed / conflict / stale状態表示
 - Local Previewの明示停止とstale session recovery/lease方針

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -98,7 +98,7 @@ hugo server
   --noHTTPCache
 ```
 
-記事選択時の初回起動では、shadow workspaceをHugoの`--contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装ではserverと同じ`--environment development`、`--baseURL`にLocal Preview URL、`--noBuildLock`、shadow `--contentDir`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
+記事選択時の初回起動では、shadow workspaceをHugoの`contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装ではserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
 
 ## Reverse proxy / LiveReload
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -158,6 +158,16 @@ type GeneratorAdapter interface {
 
 アダプターはコマンドの定義だけを返し、プロセスを直接管理しない。起動、停止、タイムアウト、ログ収集は共通の`ProcessSupervisor`が担当する。
 
+初回のLocal Live Preview URL解決は、未保存内容を含むactive shadow workspaceを受け取る専用契約へ分離する。
+
+```go
+type PreviewURLResolver interface {
+	ResolveArticleURL(ctx context.Context, runtime SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (string, error)
+}
+```
+
+CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal Preview originへ変換する。Hugoでは`hugo list all`を使い、Eleventyなど他generatorのresolverは個別Issueで追加する。
+
 ### Runtime Runner
 
 コマンドを対象サイトのランタイムで実行する。

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではHugoの`--navigateToChanged`で選択記事の実ページへ追従し、Local Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後にもHugoの実ページへ同期する専用navigation APIを追加し、CMS側でURL規則を推測せず初回表示を完了できるようにしています。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -168,11 +168,11 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 - `Preview`: Local Live Previewを全幅表示
 - `Split`: EditorとLocal Live Previewを左右（狭い画面では上下）に表示
 
-記事選択時はdesktopでは`Split`を初期viewにし、Hugoが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、Hugo serverの`--navigateToChanged`に遷移を任せます。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
+記事選択時はdesktopでは`Split`を初期viewにし、generatorが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、generatorのURL resolverへ解決を委譲します。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
 
-記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、iframeの最初の読み込み完了を契機に専用のnavigation APIを呼び出します。serverはHugoがreadyになったことを確認してから同じshadow記事をrevisionを増やさずatomic replaceし、`--navigateToChanged`へfilesystem changeを通知します。これにより、記事を編集しなくてもHugo自身がslug、`url`、permalink、page bundleの実ページURLを解決します。通常の編集更新ではこのnavigation APIを呼び出さず、従来どおりLiveReloadを利用します。
+記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、serverが同じworkspaceを使ってHugo `list all`を実行し、選択記事の`permalink`を取得します。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。これにより、記事を編集しなくてもHugo自身がslug、`url`、permalink、page bundle、languageの実ページURLを解決します。通常の本文編集ではiframeの現在URLを維持してLiveReloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
-初回navigationのnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。
+初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
 
 iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
@@ -217,7 +217,7 @@ editor update:
 POST /admin/api/preview/local
 ```
 
-記事選択後の初回navigation:
+記事選択後の初回URL解決:
 
 ```text
 POST /admin/api/preview/local/navigate
@@ -230,7 +230,7 @@ POST /admin/api/preview/local/navigate
 }
 ```
 
-このAPIはactive sessionの所有者と記事pathを検証し、Hugoのready後にshadow上の同じ記事を再通知します。production content、Git working tree、editorのrevisionは変更しません。
+このAPIはactive sessionの所有者と記事pathを検証し、shadow workspaceを使ってgeneratorの実ページURLを解決します。成功時は`article_url`、`revision`、`session_id`を返し、production content、Git working tree、editorのrevisionは変更しません。解決に失敗した場合はエラーを返し、preview rootへフォールバックしません。
 
 release:
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -170,7 +170,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 記事選択時はdesktopでは`Split`を初期viewにし、generatorが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、generatorのURL resolverへ解決を委譲します。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
 
-記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、serverが同じworkspaceを使ってHugo `list all`を実行し、選択記事の`permalink`を取得します。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。これにより、記事を編集しなくてもHugo自身がslug、`url`、permalink、page bundle、languageの実ページURLを解決します。通常の本文編集ではiframeの現在URLを維持してLiveReloadを利用し、URLに影響するfront matter変更時だけ再解決します。
+記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、serverと同じ`development` environmentでHugo `list all`を実行し、選択記事の`permalink`を取得します。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。これにより、記事を編集しなくてもHugo自身がslug、`url`、permalink、page bundle、languageの実ページURLを解決します。通常の本文編集ではiframeの現在URLを維持してLiveReloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
 初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
 

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -1,7 +1,7 @@
 package handlers
 
 import (
-	"errors"
+	"context"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/services"
 	"net/http"
@@ -18,23 +18,18 @@ type localPreviewNavigateRequest struct {
 
 type localPreviewNavigationWorkspaceManager interface {
 	Status(siteID string) (services.LocalPreviewWorkspace, bool, bool)
-	TouchArticle(runtime config.SiteRuntime, draftID, articlePath string) (services.LocalPreviewWorkspace, error)
 }
 
 type localPreviewNavigationDependencies struct {
-	workspaceManager localPreviewNavigationWorkspaceManager
-	ensureReady      func(config.SiteConfig) error
+	workspaceManager  localPreviewNavigationWorkspaceManager
+	resolveArticleURL func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error)
 }
 
-// NavigateLocalPreview starts Hugo when necessary and touches the selected
-// shadow article after the process is ready. Hugo's --navigateToChanged then
-// resolves the actual page URL, including slugs, permalinks and bundles.
+// NavigateLocalPreview resolves the selected shadow article through the
+// configured generator and returns the URL to open in the local preview.
 func NavigateLocalPreview(c *gin.Context) {
 	navigateLocalPreview(c, localPreviewNavigationDependencies{
-		ensureReady: func(site config.SiteConfig) error {
-			_, err := services.DefaultLocalPreviewManager().EnsureReady(site)
-			return err
-		},
+		resolveArticleURL: services.ResolvePreviewArticleURL,
 	})
 }
 
@@ -91,33 +86,21 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 		return
 	}
 
-	site := runtime.SiteConfig()
-	site.ContentDir = workspace.ContentDir
-	if dependencies.ensureReady == nil {
-		ErrorInternal(c, "Local preview manager is unavailable")
+	if dependencies.resolveArticleURL == nil {
+		ErrorInternal(c, "Local preview URL resolver is unavailable")
 		return
 	}
-	if err := dependencies.ensureReady(site); err != nil {
-		ErrorInternal(c, "Failed to start Local Live Preview")
-		return
-	}
-	workspace, err = workspaceManager.TouchArticle(runtime, req.DraftID, req.Path)
+	resolverRuntime := runtime
+	resolverRuntime.ContentDir = workspace.ContentDir
+	articleURL, err := dependencies.resolveArticleURL(c.Request.Context(), resolverRuntime, workspace, req.Path)
 	if err != nil {
-		switch {
-		case errors.Is(err, services.ErrLocalPreviewSessionConflict),
-			errors.Is(err, services.ErrLocalPreviewSessionMismatch),
-			errors.Is(err, services.ErrLocalPreviewSessionNotFound),
-			errors.Is(err, services.ErrLocalPreviewSessionExpired),
-			errors.Is(err, services.ErrLocalPreviewSessionReclaiming):
-			ErrorConflict(c, err.Error())
-		default:
-			ErrorBadRequest(c, err.Error())
-		}
+		ErrorInternal(c, "Failed to resolve Local Live Preview article URL")
 		return
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status":       "navigated",
+		"status":       "resolved",
+		"article_url":  articleURL,
 		"revision":     workspace.Revision,
 		"preview_url":  runtime.LocalPreview.URL,
 		"session_id":   req.DraftID,

--- a/pkg/handlers/local_preview_navigation_test.go
+++ b/pkg/handlers/local_preview_navigation_test.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/services"
 	"net/http"
@@ -18,16 +20,10 @@ type fakeLocalPreviewNavigationWorkspaceManager struct {
 	workspace services.LocalPreviewWorkspace
 	active    bool
 	stale     bool
-	touched   bool
 }
 
 func (m *fakeLocalPreviewNavigationWorkspaceManager) Status(string) (services.LocalPreviewWorkspace, bool, bool) {
 	return m.workspace, m.active, m.stale
-}
-
-func (m *fakeLocalPreviewNavigationWorkspaceManager) TouchArticle(config.SiteRuntime, string, string) (services.LocalPreviewWorkspace, error) {
-	m.touched = true
-	return m.workspace, nil
 }
 
 func TestNavigateLocalPreviewUsesShadowContentAndPreservesProductionContent(t *testing.T) {
@@ -48,12 +44,15 @@ func TestNavigateLocalPreviewUsesShadowContentAndPreservesProductionContent(t *t
 		t.Fatal(err)
 	}
 
-	var ensuredSite config.SiteConfig
+	var resolvedRuntime config.SiteRuntime
 	response := executeLocalPreviewNavigationRequest(t, site.ID, localPreviewNavigationDependencies{
 		workspaceManager: workspaceManager,
-		ensureReady: func(site config.SiteConfig) error {
-			ensuredSite = site
-			return nil
+		resolveArticleURL: func(_ context.Context, runtime config.SiteRuntime, gotWorkspace services.LocalPreviewWorkspace, path string) (string, error) {
+			resolvedRuntime = runtime
+			if gotWorkspace.ContentDir != workspace.ContentDir || path != "one.md" {
+				t.Fatalf("resolver arguments = runtime=%#v workspace=%#v path=%q", runtime, gotWorkspace, path)
+			}
+			return "https://tech.preview.example.com/posts/one/", nil
 		},
 	}, "draft-1", "one.md")
 	if response.Code != http.StatusOK {
@@ -63,11 +62,11 @@ func TestNavigateLocalPreviewUsesShadowContentAndPreservesProductionContent(t *t
 	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
 		t.Fatal(err)
 	}
-	if payload["status"] != "navigated" || int(payload["revision"].(float64)) != 7 {
+	if payload["status"] != "resolved" || payload["article_url"] != "https://tech.preview.example.com/posts/one/" || int(payload["revision"].(float64)) != 7 {
 		t.Fatalf("response = %#v", payload)
 	}
-	if ensuredSite.ContentDir != workspace.ContentDir {
-		t.Fatalf("Hugo content directory = %q, want shadow directory %q", ensuredSite.ContentDir, workspace.ContentDir)
+	if resolvedRuntime.ContentDir != workspace.ContentDir {
+		t.Fatalf("resolver content directory = %q, want shadow directory %q", resolvedRuntime.ContentDir, workspace.ContentDir)
 	}
 	production, err := os.ReadFile(productionArticle)
 	if err != nil {
@@ -96,12 +95,12 @@ func TestNavigateLocalPreviewRejectsWrongOwnerAndPath(t *testing.T) {
 	if _, _, _, err := workspaceManager.Update(runtime, "draft-1", "one.md", 1, []byte("draft")); err != nil {
 		t.Fatal(err)
 	}
-	ensureCalls := 0
+	resolveCalls := 0
 	dependencies := localPreviewNavigationDependencies{
 		workspaceManager: workspaceManager,
-		ensureReady: func(config.SiteConfig) error {
-			ensureCalls++
-			return nil
+		resolveArticleURL: func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error) {
+			resolveCalls++
+			return "", nil
 		},
 	}
 
@@ -113,8 +112,8 @@ func TestNavigateLocalPreviewRejectsWrongOwnerAndPath(t *testing.T) {
 	if pathResponse.Code != http.StatusConflict {
 		t.Fatalf("wrong path status = %d, want 409", pathResponse.Code)
 	}
-	if ensureCalls != 0 {
-		t.Fatalf("EnsureReady calls = %d, want 0 for rejected requests", ensureCalls)
+	if resolveCalls != 0 {
+		t.Fatalf("resolver calls = %d, want 0 for rejected requests", resolveCalls)
 	}
 }
 
@@ -131,19 +130,42 @@ func TestNavigateLocalPreviewRejectsStaleSession(t *testing.T) {
 		active: true,
 		stale:  true,
 	}
-	ensureCalls := 0
+	resolveCalls := 0
 	response := executeLocalPreviewNavigationRequest(t, site.ID, localPreviewNavigationDependencies{
 		workspaceManager: workspaceManager,
-		ensureReady: func(config.SiteConfig) error {
-			ensureCalls++
-			return nil
+		resolveArticleURL: func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error) {
+			resolveCalls++
+			return "", nil
 		},
 	}, "draft-1", "one.md")
 	if response.Code != http.StatusConflict {
 		t.Fatalf("status = %d, want 409", response.Code)
 	}
-	if ensureCalls != 0 || workspaceManager.touched {
-		t.Fatalf("stale session was processed: ensureCalls=%d touched=%v", ensureCalls, workspaceManager.touched)
+	if resolveCalls != 0 {
+		t.Fatalf("stale session was processed: resolver calls=%d", resolveCalls)
+	}
+}
+
+func TestNavigateLocalPreviewReturnsErrorWhenResolverFails(t *testing.T) {
+	site, _ := localPreviewNavigationTestSite(t)
+	configureLocalPreviewNavigationTestSite(t, site)
+	workspaceManager := &fakeLocalPreviewNavigationWorkspaceManager{
+		workspace: services.LocalPreviewWorkspace{
+			SiteID:      site.ID,
+			DraftID:     "draft-1",
+			ArticlePath: "one.md",
+			ContentDir:  filepath.Join(site.RepoPath, "shadow", "content"),
+		},
+		active: true,
+	}
+	response := executeLocalPreviewNavigationRequest(t, site.ID, localPreviewNavigationDependencies{
+		workspaceManager: workspaceManager,
+		resolveArticleURL: func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error) {
+			return "", errors.New("generator failed")
+		},
+	}, "draft-1", "one.md")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", response.Code)
 	}
 }
 

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -22,6 +22,7 @@ const (
 	defaultLocalPreviewProbeInterval  = 50 * time.Millisecond
 	defaultLocalPreviewStartAttempts  = 3
 	localPreviewStderrLimit           = 64 << 10
+	localPreviewHugoEnvironment       = "development"
 )
 
 var errLocalPreviewShuttingDown = errors.New("local preview manager is shutting down")
@@ -591,6 +592,7 @@ func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL strin
 	return []string{
 		"server",
 		"--source", ".",
+		"--environment", localPreviewHugoEnvironment,
 		"--contentDir", runtime.ContentDir,
 		"--bind", LocalPreviewBindAddress,
 		"--port", strconv.Itoa(port),

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -602,7 +602,6 @@ func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL strin
 		"--buildFuture",
 		"--buildExpired",
 		"--watch",
-		"--navigateToChanged",
 		"--noHTTPCache",
 	}, nil
 }

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -39,7 +39,6 @@ func TestHugoLocalPreviewArgs(t *testing.T) {
 		"--buildFuture",
 		"--buildExpired",
 		"--watch",
-		"--navigateToChanged",
 		"--noHTTPCache",
 	}
 	if !reflect.DeepEqual(got, want) {

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -28,6 +28,7 @@ func TestHugoLocalPreviewArgs(t *testing.T) {
 	want := []string{
 		"server",
 		"--source", ".",
+		"--environment", localPreviewHugoEnvironment,
 		"--contentDir", "content",
 		"--bind", "127.0.0.1",
 		"--port", "14123",

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -222,60 +222,6 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 	return workspace, created, true, nil
 }
 
-// TouchArticle rewrites the selected shadow article without changing its
-// editor revision. It is used after Hugo is ready so --navigateToChanged gets
-// a filesystem event even when the selected article content has not changed.
-func (m *LocalPreviewWorkspaceManager) TouchArticle(runtime config.SiteRuntime, draftID, articlePath string) (LocalPreviewWorkspace, error) {
-	if err := validateDraftID(draftID); err != nil {
-		return LocalPreviewWorkspace{}, err
-	}
-	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
-	if articlePath == "." || filepath.IsAbs(articlePath) {
-		return LocalPreviewWorkspace{}, fmt.Errorf("invalid local preview article path")
-	}
-	if runtime.ID == "" {
-		return LocalPreviewWorkspace{}, fmt.Errorf("local preview site ID is required")
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
-		return LocalPreviewWorkspace{}, fmt.Errorf("local preview workspace manager is closed")
-	}
-	if m.reclaimingLocked(runtime.ID) {
-		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionReclaiming
-	}
-	workspace, ok := m.sessions[runtime.ID]
-	if !ok {
-		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionNotFound
-	}
-	now := m.currentTimeLocked()
-	if m.staleLocked(workspace, now) {
-		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionExpired
-	}
-	if workspace.DraftID != draftID {
-		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionConflict
-	}
-	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
-		return LocalPreviewWorkspace{}, ErrLocalPreviewSessionMismatch
-	}
-
-	target := SafeJoin(workspace.ContentDir, "", articlePath)
-	if target == "" {
-		return LocalPreviewWorkspace{}, fmt.Errorf("invalid local preview article path")
-	}
-	content, err := os.ReadFile(target)
-	if err != nil {
-		return LocalPreviewWorkspace{}, fmt.Errorf("read local preview article: %w", err)
-	}
-	if err := writeLocalPreviewFileAtomic(target, content); err != nil {
-		return LocalPreviewWorkspace{}, err
-	}
-	workspace.LastSeenAt = now
-	m.sessions[runtime.ID] = workspace
-	return workspace, nil
-}
-
 // Heartbeat renews a live lease without changing content. Once the lease has
 // expired, the browser must reclaim/restart instead of reviving a session whose
 // Hugo process may already be stopping.

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -58,41 +58,6 @@ func TestLocalPreviewWorkspaceMirrorsAndUpdatesContent(t *testing.T) {
 	}
 }
 
-func TestLocalPreviewWorkspaceTouchArticleRewritesSameContentWithoutRevisionChange(t *testing.T) {
-	repo := makeLocalPreviewWorkspaceRepo(t)
-	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
-	workspace, _, _, err := manager.Update(runtime, "draft-1", "one.md", 7, []byte("draft"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	touched, err := manager.TouchArticle(runtime, "draft-1", "one.md")
-	if err != nil {
-		t.Fatalf("TouchArticle() error = %v", err)
-	}
-	if touched.Revision != 7 {
-		t.Fatalf("revision = %d, want 7", touched.Revision)
-	}
-	content, err := os.ReadFile(filepath.Join(workspace.ContentDir, "one.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != "draft" {
-		t.Fatalf("touched content = %q, want draft", content)
-	}
-	production, err := os.ReadFile(filepath.Join(repo, "content", "one.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(production) != "original" {
-		t.Fatalf("production content was modified: %q", production)
-	}
-}
-
 func TestLocalPreviewWorkspaceRejectsStaleRevision(t *testing.T) {
 	repo := makeLocalPreviewWorkspaceRepo(t)
 	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -1,0 +1,226 @@
+package services
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"hugo-cms/pkg/config"
+	"io"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const previewURLResolveTimeout = 15 * time.Second
+
+// PreviewURLResolver asks the configured generator to resolve a content path
+// to the URL that should be opened in the local preview origin. The resolver
+// receives the active shadow workspace so unsaved front matter participates in
+// the same URL calculation as the preview server.
+type PreviewURLResolver interface {
+	ResolveArticleURL(context.Context, config.SiteRuntime, LocalPreviewWorkspace, string) (string, error)
+}
+
+func NewPreviewURLResolver(generator string) (PreviewURLResolver, error) {
+	switch strings.ToLower(strings.TrimSpace(generator)) {
+	case "", "hugo":
+		return &hugoPreviewURLResolver{}, nil
+	default:
+		return nil, fmt.Errorf("preview URL resolution is not supported for generator %q", generator)
+	}
+}
+
+func ResolvePreviewArticleURL(ctx context.Context, runtime config.SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (string, error) {
+	resolver, err := NewPreviewURLResolver(runtime.Generator)
+	if err != nil {
+		return "", err
+	}
+	return resolver.ResolveArticleURL(ctx, runtime, workspace, articlePath)
+}
+
+type hugoPreviewURLResolver struct {
+	run func(context.Context, config.SiteRuntime, string) ([]byte, error)
+}
+
+func (resolver *hugoPreviewURLResolver) ResolveArticleURL(ctx context.Context, runtime config.SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (string, error) {
+	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
+	if articlePath == "." || filepath.IsAbs(articlePath) {
+		return "", fmt.Errorf("invalid preview article path")
+	}
+	if workspace.ContentDir == "" {
+		return "", fmt.Errorf("preview workspace content directory is required")
+	}
+	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
+		return "", fmt.Errorf("preview workspace article does not match request")
+	}
+	previewURL, err := localPreviewResolverURL(runtime)
+	if err != nil {
+		return "", err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, previewURLResolveTimeout)
+	defer cancel()
+
+	run := resolver.run
+	if run == nil {
+		run = runHugoListAll
+	}
+	output, err := run(ctx, runtime, previewURL)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("hugo list all timed out after %s", previewURLResolveTimeout)
+		}
+		return "", fmt.Errorf("hugo list all failed: %w", err)
+	}
+	permalink, err := parseHugoListAll(output, runtime, articlePath)
+	if err != nil {
+		return "", err
+	}
+	return localPreviewArticleURL(previewURL, permalink)
+}
+
+func runHugoListAll(ctx context.Context, runtime config.SiteRuntime, previewURL string) ([]byte, error) {
+	cmd := generatorCommandContext(ctx, runtime, "hugo", hugoListAllArgs(runtime, previewURL)...)
+	return cmd.CombinedOutput()
+}
+
+func hugoListAllArgs(runtime config.SiteRuntime, previewURL string) []string {
+	return []string{
+		"list",
+		"all",
+		"--source", ".",
+		"--contentDir", runtime.ContentDir,
+		"--baseURL", previewURL,
+		"--noBuildLock",
+	}
+}
+
+func localPreviewResolverURL(runtime config.SiteRuntime) (string, error) {
+	previewURL := strings.TrimSpace(runtime.LocalPreview.URL)
+	if previewURL == "" {
+		var err error
+		previewURL, err = config.LocalPreviewURL(runtime.ID)
+		if err != nil {
+			return "", err
+		}
+	}
+	parsed, err := url.Parse(previewURL)
+	if err != nil || parsed.Host == "" || parsed.User != nil {
+		return "", fmt.Errorf("invalid local preview URL %q", previewURL)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("unsupported local preview scheme %q", parsed.Scheme)
+	}
+	return parsed.String(), nil
+}
+
+func parseHugoListAll(output []byte, runtime config.SiteRuntime, articlePath string) (string, error) {
+	reader := csv.NewReader(bytes.NewReader(output))
+	reader.FieldsPerRecord = -1
+	reader.LazyQuotes = true
+
+	pathColumn := -1
+	permalinkColumn := -1
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("parse hugo list all output: %w", err)
+		}
+		if pathColumn < 0 {
+			pathColumn = findHugoListColumn(record, "path")
+			permalinkColumn = findHugoListColumn(record, "permalink")
+			if permalinkColumn < 0 {
+				permalinkColumn = findHugoListColumn(record, "url")
+			}
+			if pathColumn < 0 || permalinkColumn < 0 {
+				continue
+			}
+			continue
+		}
+		if pathColumn >= len(record) || permalinkColumn >= len(record) {
+			continue
+		}
+		if !hugoContentPathMatches(runtime, articlePath, record[pathColumn]) {
+			continue
+		}
+		permalink := strings.TrimSpace(record[permalinkColumn])
+		if permalink == "" {
+			return "", fmt.Errorf("hugo did not provide a URL for article %q", articlePath)
+		}
+		return permalink, nil
+	}
+	return "", fmt.Errorf("hugo did not resolve article %q", articlePath)
+}
+
+func findHugoListColumn(record []string, name string) int {
+	for index, value := range record {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "\ufeff"))
+		if strings.EqualFold(value, name) {
+			return index
+		}
+	}
+	return -1
+}
+
+func hugoContentPathMatches(runtime config.SiteRuntime, articlePath, listedPath string) bool {
+	target := normalizeHugoContentPath(articlePath)
+	candidate := normalizeHugoContentPath(listedPath)
+	if target == "" || candidate == "" {
+		return false
+	}
+	if candidate == target {
+		return true
+	}
+	contentDir := normalizeHugoContentPath(runtime.ContentDir)
+	if contentDir != "" && candidate == contentDir+"/"+target {
+		return true
+	}
+	contentBase := path.Base(strings.TrimSuffix(strings.ReplaceAll(runtime.ContentDir, "\\", "/"), "/"))
+	contentBase = normalizeHugoContentPath(contentBase)
+	return contentBase != "" && (candidate == contentBase+"/"+target || strings.HasSuffix(candidate, "/"+contentBase+"/"+target))
+}
+
+func normalizeHugoContentPath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if value == "" {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "./")
+	value = strings.TrimPrefix(value, "/")
+	value = strings.TrimSuffix(filepath.ToSlash(filepath.Clean(value)), "/")
+	if value == "." {
+		return ""
+	}
+	return value
+}
+
+func localPreviewArticleURL(previewURL, resolvedURL string) (string, error) {
+	base, err := url.Parse(previewURL)
+	if err != nil || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
+		return "", fmt.Errorf("invalid local preview URL %q", previewURL)
+	}
+	resolved, err := url.Parse(strings.TrimSpace(resolvedURL))
+	if err != nil || strings.TrimSpace(resolvedURL) == "" {
+		return "", fmt.Errorf("invalid resolved preview URL %q", resolvedURL)
+	}
+	if resolved.Scheme != "" && resolved.Scheme != "http" && resolved.Scheme != "https" {
+		return "", fmt.Errorf("unsupported resolved preview URL scheme %q", resolved.Scheme)
+	}
+	if !resolved.IsAbs() {
+		resolved = base.ResolveReference(resolved)
+	}
+	resolved.Scheme = base.Scheme
+	resolved.Host = base.Host
+	resolved.User = nil
+	return resolved.String(), nil
+}
+
+var _ PreviewURLResolver = (*hugoPreviewURLResolver)(nil)

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -85,19 +85,30 @@ func (resolver *hugoPreviewURLResolver) ResolveArticleURL(ctx context.Context, r
 }
 
 func runHugoListAll(ctx context.Context, runtime config.SiteRuntime, previewURL string) ([]byte, error) {
-	cmd := generatorCommandContext(ctx, runtime, "hugo", hugoListAllArgs(runtime, previewURL)...)
+	cmd := generatorCommandContextWithEnv(
+		ctx,
+		runtime,
+		hugoListAllEnvironment(runtime, previewURL),
+		"hugo",
+		hugoListAllArgs()...,
+	)
 	return cmd.CombinedOutput()
 }
 
-func hugoListAllArgs(runtime config.SiteRuntime, previewURL string) []string {
+func hugoListAllArgs() []string {
 	return []string{
 		"list",
 		"all",
 		"--source", ".",
 		"--environment", localPreviewHugoEnvironment,
-		"--contentDir", runtime.ContentDir,
-		"--baseURL", previewURL,
 		"--noBuildLock",
+	}
+}
+
+func hugoListAllEnvironment(runtime config.SiteRuntime, previewURL string) []string {
+	return []string{
+		"HUGO_CONTENTDIR=" + runtime.ContentDir,
+		"HUGO_BASEURL=" + previewURL,
 	}
 }
 

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -94,6 +94,7 @@ func hugoListAllArgs(runtime config.SiteRuntime, previewURL string) []string {
 		"list",
 		"all",
 		"--source", ".",
+		"--environment", localPreviewHugoEnvironment,
 		"--contentDir", runtime.ContentDir,
 		"--baseURL", previewURL,
 		"--noBuildLock",

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -1,0 +1,133 @@
+package services
+
+import (
+	"context"
+	"hugo-cms/pkg/config"
+	"reflect"
+	"testing"
+)
+
+func TestNewPreviewURLResolverSupportsHugoOnly(t *testing.T) {
+	resolver, err := NewPreviewURLResolver("hugo")
+	if err != nil {
+		t.Fatalf("NewPreviewURLResolver(hugo) error = %v", err)
+	}
+	if resolver == nil {
+		t.Fatal("NewPreviewURLResolver(hugo) returned nil")
+	}
+	if _, err := NewPreviewURLResolver("eleventy"); err == nil {
+		t.Fatal("NewPreviewURLResolver(eleventy) should require a dedicated resolver")
+	}
+}
+
+func TestHugoPreviewURLResolverUsesShadowContentAndLocalOrigin(t *testing.T) {
+	runtime := config.SiteRuntime{
+		ID:           "tech",
+		RepoPath:     "/repo",
+		ContentDir:   "/tmp/shadow/tech/content",
+		Generator:    "hugo",
+		LocalPreview: config.LocalPreviewConfig{URL: "https://tech.preview.example.com/preview/"},
+	}
+	workspace := LocalPreviewWorkspace{
+		SiteID:      "tech",
+		DraftID:     "draft-1",
+		ArticlePath: "posts/one.md",
+		ContentDir:  runtime.ContentDir,
+		Revision:    9,
+	}
+	var gotRuntime config.SiteRuntime
+	var gotPreviewURL string
+	resolver := &hugoPreviewURLResolver{run: func(_ context.Context, got config.SiteRuntime, previewURL string) ([]byte, error) {
+		gotRuntime = got
+		gotPreviewURL = previewURL
+		return []byte("path,slug,title,date,expiryDate,publishDate,draft,permalink\ncontent/posts/one.md,custom,\"One, article\",,,,,https://production.example.com/preview/custom/\n"), nil
+	}}
+
+	got, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/one.md")
+	if err != nil {
+		t.Fatalf("ResolveArticleURL() error = %v", err)
+	}
+	if got != "https://tech.preview.example.com/preview/custom/" {
+		t.Fatalf("resolved URL = %q", got)
+	}
+	if gotRuntime.ContentDir != workspace.ContentDir {
+		t.Fatalf("resolver content directory = %q, want %q", gotRuntime.ContentDir, workspace.ContentDir)
+	}
+	if gotPreviewURL != runtime.LocalPreview.URL {
+		t.Fatalf("resolver preview URL = %q, want %q", gotPreviewURL, runtime.LocalPreview.URL)
+	}
+}
+
+func TestHugoListAllArgsUseShadowContentAndNoBuildLock(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: "/tmp/shadow/content"}
+	want := []string{
+		"list", "all", "--source", ".", "--contentDir", "/tmp/shadow/content",
+		"--baseURL", "https://tech.preview.example.com/", "--noBuildLock",
+	}
+	if got := hugoListAllArgs(runtime, "https://tech.preview.example.com/"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("hugoListAllArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseHugoListAllMatchesContentPathAndHandlesCSV(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: "/tmp/shadow/content"}
+	output := []byte("\ufeffpath,slug,title,date,expiryDate,publishDate,draft,permalink\r\n" +
+		"content/posts/one.md,custom,\"One, article\",,,,,https://example.com/custom/\r\n")
+	permalink, err := parseHugoListAll(output, runtime, "posts/one.md")
+	if err != nil {
+		t.Fatalf("parseHugoListAll() error = %v", err)
+	}
+	if permalink != "https://example.com/custom/" {
+		t.Fatalf("permalink = %q", permalink)
+	}
+}
+
+func TestParseHugoListAllMatchesRelativeAndAbsoluteContentPaths(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: `C:\preview\tech\content`}
+	for _, listedPath := range []string{
+		"posts/one.md",
+		"content/posts/one.md",
+		`C:\preview\tech\content\posts\one.md`,
+	} {
+		output := []byte("path,url\n" + listedPath + ",/posts/one/\n")
+		got, err := parseHugoListAll(output, runtime, "posts/one.md")
+		if err != nil {
+			t.Fatalf("parseHugoListAll(%q) error = %v", listedPath, err)
+		}
+		if got != "/posts/one/" {
+			t.Fatalf("parseHugoListAll(%q) = %q", listedPath, got)
+		}
+	}
+}
+
+func TestHugoPreviewURLResolverRejectsMismatchedArticle(t *testing.T) {
+	resolver := &hugoPreviewURLResolver{run: func(context.Context, config.SiteRuntime, string) ([]byte, error) {
+		t.Fatal("Hugo should not run for a mismatched article")
+		return nil, nil
+	}}
+	runtime := config.SiteRuntime{ID: "tech", ContentDir: "/tmp/content", LocalPreview: config.LocalPreviewConfig{URL: "https://tech.preview.example.com/"}}
+	workspace := LocalPreviewWorkspace{ArticlePath: "posts/one.md", ContentDir: "/tmp/content"}
+	if _, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md"); err == nil {
+		t.Fatal("ResolveArticleURL() should reject a mismatched article")
+	}
+}
+
+func TestLocalPreviewArticleURLRewritesOnlyOrigin(t *testing.T) {
+	got, err := localPreviewArticleURL("https://tech.preview.example.com/preview/", "https://production.example.com/preview/posts/one/?draft=1")
+	if err != nil {
+		t.Fatalf("localPreviewArticleURL() error = %v", err)
+	}
+	if got != "https://tech.preview.example.com/preview/posts/one/?draft=1" {
+		t.Fatalf("URL = %q", got)
+	}
+	got, err = localPreviewArticleURL("https://tech.preview.example.com/preview/", "posts/one/?draft=1#section")
+	if err != nil {
+		t.Fatalf("localPreviewArticleURL() relative error = %v", err)
+	}
+	if got != "https://tech.preview.example.com/preview/posts/one/?draft=1#section" {
+		t.Fatalf("relative URL = %q", got)
+	}
+	if _, err := localPreviewArticleURL("https://tech.preview.example.com/", "javascript:alert(1)"); err == nil {
+		t.Fatal("localPreviewArticleURL() should reject non-HTTP schemes")
+	}
+}

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -61,7 +61,8 @@ func TestHugoPreviewURLResolverUsesShadowContentAndLocalOrigin(t *testing.T) {
 func TestHugoListAllArgsUseShadowContentAndNoBuildLock(t *testing.T) {
 	runtime := config.SiteRuntime{ContentDir: "/tmp/shadow/content"}
 	want := []string{
-		"list", "all", "--source", ".", "--contentDir", "/tmp/shadow/content",
+		"list", "all", "--source", ".", "--environment", localPreviewHugoEnvironment,
+		"--contentDir", "/tmp/shadow/content",
 		"--baseURL", "https://tech.preview.example.com/", "--noBuildLock",
 	}
 	if got := hugoListAllArgs(runtime, "https://tech.preview.example.com/"); !reflect.DeepEqual(got, want) {

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -59,14 +59,20 @@ func TestHugoPreviewURLResolverUsesShadowContentAndLocalOrigin(t *testing.T) {
 }
 
 func TestHugoListAllArgsUseShadowContentAndNoBuildLock(t *testing.T) {
-	runtime := config.SiteRuntime{ContentDir: "/tmp/shadow/content"}
 	want := []string{
 		"list", "all", "--source", ".", "--environment", localPreviewHugoEnvironment,
-		"--contentDir", "/tmp/shadow/content",
-		"--baseURL", "https://tech.preview.example.com/", "--noBuildLock",
+		"--noBuildLock",
 	}
-	if got := hugoListAllArgs(runtime, "https://tech.preview.example.com/"); !reflect.DeepEqual(got, want) {
+	if got := hugoListAllArgs(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("hugoListAllArgs() = %#v, want %#v", got, want)
+	}
+	runtime := config.SiteRuntime{ContentDir: "/tmp/shadow/content"}
+	wantEnvironment := []string{
+		"HUGO_CONTENTDIR=/tmp/shadow/content",
+		"HUGO_BASEURL=https://tech.preview.example.com/",
+	}
+	if got := hugoListAllEnvironment(runtime, "https://tech.preview.example.com/"); !reflect.DeepEqual(got, wantEnvironment) {
+		t.Fatalf("hugoListAllEnvironment() = %#v, want %#v", got, wantEnvironment)
 	}
 }
 

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -247,14 +247,15 @@ export async function updateLocalPreviewContent(payload, draftID, revision, sign
     return await res.json();
 }
 
-export async function resolveLocalPreviewArticleURL(draftID, path) {
+export async function resolveLocalPreviewArticleURL(draftID, path, signal) {
     const res = await fetchWithCSRF(withSite('/admin/api/preview/local/navigate'), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             ...siteHeaders()
         },
-        body: JSON.stringify({ draft_id: draftID, path })
+        body: JSON.stringify({ draft_id: draftID, path }),
+        signal
     });
     if (!res.ok) throw await responseError(res, "Local Live Preview URL resolution failed");
     return await res.json();

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -247,7 +247,7 @@ export async function updateLocalPreviewContent(payload, draftID, revision, sign
     return await res.json();
 }
 
-export async function navigateLocalPreviewContent(draftID, path) {
+export async function resolveLocalPreviewArticleURL(draftID, path) {
     const res = await fetchWithCSRF(withSite('/admin/api/preview/local/navigate'), {
         method: 'POST',
         headers: {
@@ -256,9 +256,13 @@ export async function navigateLocalPreviewContent(draftID, path) {
         },
         body: JSON.stringify({ draft_id: draftID, path })
     });
-    if (!res.ok) throw await responseError(res, "Local Live Preview navigation failed");
+    if (!res.ok) throw await responseError(res, "Local Live Preview URL resolution failed");
     return await res.json();
 }
+
+// Backward-compatible name for integrations that still use the pre-#44 API
+// helper. The endpoint now resolves and returns the article URL directly.
+export const navigateLocalPreviewContent = resolveLocalPreviewArticleURL;
 
 export async function releaseLocalPreviewContent(draftID) {
     const res = await fetchWithCSRF(withSite('/admin/api/preview/local/release'), {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -8,7 +8,6 @@ import {
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
     shouldRetryLocalPreviewNavigation,
-    shouldResyncLocalPreviewAfterInitialLoad,
     shouldUseLocalPreviewSplitDefault,
 } from './local_preview.js';
 
@@ -29,10 +28,10 @@ let localPreviewHeartbeatTimer = null;
 let localPreviewController = null;
 let localPreviewOperationInProgress = false;
 let localPreviewFrameController = null;
-let localPreviewNeedsInitialNavigation = false;
-let localPreviewInitialNavigationInFlight = false;
-let localPreviewInitialNavigationAttempts = 0;
-let localPreviewInitialNavigationRetryTimer = null;
+let localPreviewArticleURL = "";
+let localPreviewURLResolutionGeneration = 0;
+let localPreviewFrontMatterKey = "";
+let localPreviewHasFrontMatterKey = false;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
@@ -126,6 +125,7 @@ async function init() {
     window.showMarkdownFallback = () => switchView('markdown');
     window.stopLocalLivePreview = stopLocalLivePreview;
     window.reclaimLocalLivePreview = reclaimLocalLivePreview;
+    window.refreshLocalPreviewArticleURL = refreshLocalPreviewArticleURL;
 
     console.log("Hugo CMS Initialized");
 }
@@ -133,6 +133,10 @@ async function init() {
 async function loadSiteData() {
     stopLocalPreviewMonitoring();
     localPreviewSessionID = "";
+    localPreviewArticleURL = "";
+    localPreviewURLResolutionGeneration += 1;
+    localPreviewFrontMatterKey = "";
+    localPreviewHasFrontMatterKey = false;
     localPreviewState = null;
 
     cmsConfig = await API.fetchConfig();
@@ -215,9 +219,12 @@ async function loadFile(path) {
     }
 
     localPreviewSessionID = "";
+    localPreviewArticleURL = "";
+    localPreviewURLResolutionGeneration += 1;
+    localPreviewFrontMatterKey = "";
+    localPreviewHasFrontMatterKey = false;
     if (localPreviewEnabled) {
         localPreviewFrameController?.resetDismissed();
-        requestLocalPreviewInitialNavigation();
         updateLocalPreviewAvailability();
         UI.switchView(shouldUseLocalPreviewSplitDefault({
             enabled: localPreviewEnabled,
@@ -225,10 +232,13 @@ async function loadFile(path) {
         }) ? 'split' : 'edit');
         try {
             await ensureLocalPreviewSession();
-            showEmbeddedLocalPreview({ reload: true });
-        } catch (_) {
-            // Editor already reports 409 conflicts; status panel provides the
-            // persistent recovery action when the old session becomes stale.
+            const articleURL = await resolveLocalPreviewArticleURL();
+            if (Editor.getCurrentPath() === path && !articleURL) {
+                throw new Error('generatorから記事URLを取得できませんでした');
+            }
+            if (Editor.getCurrentPath() === path) showEmbeddedLocalPreview({ reload: true });
+        } catch (error) {
+            showLocalPreviewResolutionError(error);
         }
         await refreshLocalPreviewStatus();
     }
@@ -259,6 +269,10 @@ function localPreviewURL() {
     return UI.safeExternalURL(cmsConfig?._cms?.local_preview?.url || "");
 }
 
+function currentLocalPreviewURL() {
+    return Editor.getCurrentPath() ? localPreviewArticleURL : localPreviewURL();
+}
+
 function isNarrowViewport() {
     if (typeof window.matchMedia === 'function') {
         return window.matchMedia('(max-width: 768px)').matches;
@@ -282,7 +296,7 @@ function initializeLocalPreviewFrame() {
     const frame = document.getElementById('local-preview-frame');
     if (!frame || localPreviewFrameController) return;
     localPreviewFrameController = createLocalPreviewFrameController({
-        getURL: localPreviewURL,
+        getURL: currentLocalPreviewURL,
         wrapper: document.getElementById('local-preview-embed'),
         frame,
         button: document.getElementById('local-preview-embed-btn'),
@@ -311,64 +325,6 @@ function handleLocalPreviewReadyMessage(event) {
 
 function handleLocalPreviewFrameLoad() {
     localPreviewFrameController?.handleLoad();
-    if (!shouldResyncLocalPreviewAfterInitialLoad({
-        pending: localPreviewNeedsInitialNavigation,
-        enabled: localPreviewEnabled,
-        hasCurrentPath: Boolean(Editor.getCurrentPath()),
-    })) return;
-
-    if (localPreviewInitialNavigationInFlight) return;
-    if (localPreviewInitialNavigationAttempts >= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS) return;
-    if (localPreviewInitialNavigationRetryTimer !== null) {
-        clearTimeout(localPreviewInitialNavigationRetryTimer);
-        localPreviewInitialNavigationRetryTimer = null;
-    }
-    localPreviewInitialNavigationInFlight = true;
-    const requestPath = Editor.getCurrentPath();
-    const requestSessionID = localPreviewSessionID;
-    if (!requestSessionID) {
-        localPreviewInitialNavigationInFlight = false;
-        return;
-    }
-    const requestAttempt = ++localPreviewInitialNavigationAttempts;
-    API.navigateLocalPreviewContent(requestSessionID, requestPath)
-        .then(() => {
-            if (Editor.getCurrentPath() === requestPath && localPreviewSessionID === requestSessionID) {
-                localPreviewNeedsInitialNavigation = false;
-                localPreviewInitialNavigationAttempts = 0;
-            }
-            return refreshLocalPreviewStatus();
-        })
-        .catch((error) => {
-            if (shouldRetryLocalPreviewNavigation({ error, attempt: requestAttempt })) {
-                localPreviewInitialNavigationRetryTimer = setTimeout(() => {
-                    localPreviewInitialNavigationRetryTimer = null;
-                    if (
-                        localPreviewNeedsInitialNavigation &&
-                        Editor.getCurrentPath() === requestPath &&
-                        localPreviewSessionID === requestSessionID
-                    ) {
-                        handleLocalPreviewFrameLoad();
-                    }
-                }, localPreviewNavigationRetryDelay(requestAttempt));
-                return undefined;
-            }
-            localPreviewInitialNavigationAttempts = LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS;
-            return refreshLocalPreviewStatus();
-        })
-        .finally(() => {
-            // Keep the pending flag until the content update succeeds, while
-            // the in-flight guard prevents repeated iframe load events from
-            // duplicating the request.
-            localPreviewInitialNavigationInFlight = false;
-            if (
-                localPreviewNeedsInitialNavigation &&
-                localPreviewSessionID &&
-                (Editor.getCurrentPath() !== requestPath || localPreviewSessionID !== requestSessionID)
-            ) {
-                handleLocalPreviewFrameLoad();
-            }
-        });
 }
 
 function updateLocalPreviewAvailability() {
@@ -380,6 +336,7 @@ function updateLocalPreviewAvailability() {
 }
 
 function showEmbeddedLocalPreview(options = {}) {
+    if (Editor.getCurrentPath() && !localPreviewArticleURL) return false;
     const shown = localPreviewFrameController?.show(options) === true;
     if (shown) updateLocalPreviewAvailability();
     return shown;
@@ -389,24 +346,78 @@ function showLocalPreviewFrameError(message) {
     localPreviewFrameController?.showError(message);
 }
 
-function requestLocalPreviewInitialNavigation() {
-    localPreviewNeedsInitialNavigation = true;
-    localPreviewInitialNavigationAttempts = 0;
-    if (localPreviewInitialNavigationRetryTimer !== null) {
-        clearTimeout(localPreviewInitialNavigationRetryTimer);
-        localPreviewInitialNavigationRetryTimer = null;
-    }
+function showLocalPreviewResolutionError(error) {
+    const message = `記事URLを解決できません: ${error?.message || 'generatorからURLを取得できませんでした。'}`;
+    const messageEl = document.getElementById('local-preview-message');
+    if (messageEl) messageEl.textContent = message;
+    showLocalPreviewFrameError(message);
 }
 
 function closeEmbeddedLocalPreview(options = {}) {
-    localPreviewNeedsInitialNavigation = false;
-    localPreviewInitialNavigationAttempts = 0;
-    if (localPreviewInitialNavigationRetryTimer !== null) {
-        clearTimeout(localPreviewInitialNavigationRetryTimer);
-        localPreviewInitialNavigationRetryTimer = null;
-    }
     localPreviewFrameController?.close(options);
     updateLocalPreviewAvailability();
+}
+
+function isLocalPreviewArticleURL(value) {
+    const rootURL = localPreviewURL();
+    if (!rootURL || !value) return false;
+    try {
+        return new URL(value).origin === new URL(rootURL).origin;
+    } catch (_) {
+        return false;
+    }
+}
+
+async function resolveLocalPreviewArticleURL() {
+    if (!localPreviewEnabled || !Editor.getCurrentPath() || !localPreviewSessionID) return null;
+    const requestPath = Editor.getCurrentPath();
+    const requestSessionID = localPreviewSessionID;
+    const requestGeneration = localPreviewURLResolutionGeneration;
+    for (let attempt = 1; attempt <= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS; attempt++) {
+        if (
+            Editor.getCurrentPath() !== requestPath ||
+            localPreviewSessionID !== requestSessionID ||
+            localPreviewURLResolutionGeneration !== requestGeneration
+        ) return null;
+        try {
+            const result = await API.resolveLocalPreviewArticleURL(requestSessionID, requestPath);
+            const articleURL = UI.safeExternalURL(result?.article_url || "");
+            if (!isLocalPreviewArticleURL(articleURL)) throw new Error('generator returned an invalid local preview URL');
+            if (
+                Editor.getCurrentPath() !== requestPath ||
+                localPreviewSessionID !== requestSessionID ||
+                localPreviewURLResolutionGeneration !== requestGeneration
+            ) return null;
+            localPreviewArticleURL = articleURL;
+            return articleURL;
+        } catch (error) {
+            if (!shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
+            await new Promise(resolve => setTimeout(resolve, localPreviewNavigationRetryDelay(attempt)));
+        }
+    }
+    return null;
+}
+
+async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") {
+    if (updateResult?.session_id) localPreviewSessionID = updateResult.session_id;
+    if (localPreviewHasFrontMatterKey && localPreviewFrontMatterKey === frontMatterKey && localPreviewArticleURL) {
+        return localPreviewArticleURL;
+    }
+    localPreviewFrontMatterKey = frontMatterKey;
+    localPreviewHasFrontMatterKey = true;
+    localPreviewURLResolutionGeneration += 1;
+    localPreviewArticleURL = "";
+    if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
+    try {
+        const articleURL = await resolveLocalPreviewArticleURL();
+        if (articleURL && Editor.getCurrentPath() && !localPreviewFrameController?.isDismissed()) {
+            showEmbeddedLocalPreview();
+        }
+        return articleURL;
+    } catch (error) {
+        showLocalPreviewResolutionError(error);
+        return null;
+    }
 }
 
 function localPreviewStatusClass(status) {
@@ -551,16 +562,22 @@ async function refreshLocalPreviewStatus() {
 }
 
 async function openLocalLivePreview() {
-    const url = localPreviewURL();
-    if (!localPreviewEnabled || !url) {
+    if (!localPreviewEnabled || !localPreviewURL()) {
         UI.showToast('Local Live Preview is not configured', 'warning');
         return;
     }
     try {
-        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        if (Editor.getCurrentPath()) {
+            await ensureLocalPreviewSession();
+            const articleURL = await resolveLocalPreviewArticleURL();
+            if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
+        }
+        const url = currentLocalPreviewURL();
+        if (!url) throw new Error('記事URLを解決できませんでした');
         window.open(url, '_blank', 'noopener');
         setTimeout(() => refreshLocalPreviewStatus(), 500);
     } catch (e) {
+        showLocalPreviewResolutionError(e);
         UI.showToast('Local Live Previewを開けません: ' + e.message, 'error');
     }
 }
@@ -575,15 +592,18 @@ async function toggleEmbeddedLocalPreview() {
         return;
     }
 
-    const url = localPreviewURL();
-    if (!url) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
+    if (!localPreviewURL()) return UI.showToast('Local Live Preview URL is unavailable', 'warning');
     try {
         localPreviewFrameController?.resetDismissed();
-        requestLocalPreviewInitialNavigation();
-        if (Editor.getCurrentPath()) await ensureLocalPreviewSession();
+        if (Editor.getCurrentPath()) {
+            await ensureLocalPreviewSession();
+            const articleURL = await resolveLocalPreviewArticleURL();
+            if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
+        }
         showEmbeddedLocalPreview({ reload: true });
         setTimeout(() => refreshLocalPreviewStatus(), 500);
     } catch (e) {
+        showLocalPreviewResolutionError(e);
         UI.showToast('埋め込みpreviewを開始できません: ' + e.message, 'error');
     }
 }
@@ -594,6 +614,10 @@ async function stopLocalLivePreview() {
     try {
         const released = await Editor.releaseLocalLivePreview();
         localPreviewSessionID = "";
+        localPreviewArticleURL = "";
+        localPreviewURLResolutionGeneration += 1;
+        localPreviewFrontMatterKey = "";
+        localPreviewHasFrontMatterKey = false;
         if (!released) await API.stopLocalPreviewContent("");
         closeEmbeddedLocalPreview();
         UI.showToast('Local Live Previewを停止しました', 'success');
@@ -612,14 +636,20 @@ async function reclaimLocalLivePreview() {
     try {
         await API.reclaimStaleLocalPreview();
         localPreviewSessionID = "";
+        localPreviewArticleURL = "";
+        localPreviewURLResolutionGeneration += 1;
+        localPreviewFrontMatterKey = "";
+        localPreviewHasFrontMatterKey = false;
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
-            requestLocalPreviewInitialNavigation();
             await ensureLocalPreviewSession();
+            const articleURL = await resolveLocalPreviewArticleURL();
+            if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
             showEmbeddedLocalPreview({ reload: true });
         }
         UI.showToast('Local Live Preview sessionを回収しました', 'success');
     } catch (e) {
+        showLocalPreviewResolutionError(e);
         UI.showToast('Local Live Previewを回収できません: ' + e.message, 'error');
     } finally {
         localPreviewOperationInProgress = false;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -31,7 +31,8 @@ let localPreviewFrameController = null;
 let localPreviewArticleURL = "";
 let localPreviewURLResolutionGeneration = 0;
 let localPreviewFrontMatterKey = "";
-let localPreviewHasFrontMatterKey = false;
+let localPreviewArticleURLKey = "";
+let localPreviewURLResolution = null;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_HEARTBEAT_MS = 30000;
@@ -130,13 +131,24 @@ async function init() {
     console.log("Hugo CMS Initialized");
 }
 
+function cancelLocalPreviewURLResolution() {
+    const resolution = localPreviewURLResolution;
+    localPreviewURLResolution = null;
+    resolution?.controller.abort();
+}
+
+function resetLocalPreviewArticleURL() {
+    cancelLocalPreviewURLResolution();
+    localPreviewURLResolutionGeneration += 1;
+    localPreviewArticleURL = "";
+    localPreviewArticleURLKey = "";
+    localPreviewFrontMatterKey = "";
+}
+
 async function loadSiteData() {
     stopLocalPreviewMonitoring();
     localPreviewSessionID = "";
-    localPreviewArticleURL = "";
-    localPreviewURLResolutionGeneration += 1;
-    localPreviewFrontMatterKey = "";
-    localPreviewHasFrontMatterKey = false;
+    resetLocalPreviewArticleURL();
     localPreviewState = null;
 
     cmsConfig = await API.fetchConfig();
@@ -219,10 +231,7 @@ async function loadFile(path) {
     }
 
     localPreviewSessionID = "";
-    localPreviewArticleURL = "";
-    localPreviewURLResolutionGeneration += 1;
-    localPreviewFrontMatterKey = "";
-    localPreviewHasFrontMatterKey = false;
+    resetLocalPreviewArticleURL();
     if (localPreviewEnabled) {
         localPreviewFrameController?.resetDismissed();
         updateLocalPreviewAvailability();
@@ -232,7 +241,7 @@ async function loadFile(path) {
         }) ? 'split' : 'edit');
         try {
             await ensureLocalPreviewSession();
-            const articleURL = await resolveLocalPreviewArticleURL();
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (Editor.getCurrentPath() === path && !articleURL) {
                 throw new Error('generatorから記事URLを取得できませんでした');
             }
@@ -368,48 +377,101 @@ function isLocalPreviewArticleURL(value) {
     }
 }
 
-async function resolveLocalPreviewArticleURL() {
+function localPreviewURLResolutionKey(frontMatterKey) {
+    return [API.getCurrentSite(), localPreviewSessionID, Editor.getCurrentPath(), frontMatterKey || ""].join("\u0000");
+}
+
+function localPreviewResolutionAbortError() {
+    const error = new Error('Local Preview URL resolution was cancelled');
+    error.name = 'AbortError';
+    return error;
+}
+
+function waitForLocalPreviewRetry(delay, signal) {
+    return new Promise((resolve, reject) => {
+        if (signal.aborted) {
+            reject(localPreviewResolutionAbortError());
+            return;
+        }
+        let timer = setTimeout(() => {
+            signal.removeEventListener('abort', cancel);
+            resolve();
+        }, delay);
+        function cancel() {
+            clearTimeout(timer);
+            timer = null;
+            signal.removeEventListener('abort', cancel);
+            reject(localPreviewResolutionAbortError());
+        }
+        signal.addEventListener('abort', cancel, { once: true });
+    });
+}
+
+function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterKey) {
     if (!localPreviewEnabled || !Editor.getCurrentPath() || !localPreviewSessionID) return null;
     const requestPath = Editor.getCurrentPath();
     const requestSessionID = localPreviewSessionID;
+    const requestKey = localPreviewURLResolutionKey(frontMatterKey);
+    if (localPreviewURLResolution?.key === requestKey) return localPreviewURLResolution.promise;
+
+    cancelLocalPreviewURLResolution();
+    localPreviewURLResolutionGeneration += 1;
     const requestGeneration = localPreviewURLResolutionGeneration;
-    for (let attempt = 1; attempt <= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS; attempt++) {
-        if (
-            Editor.getCurrentPath() !== requestPath ||
-            localPreviewSessionID !== requestSessionID ||
-            localPreviewURLResolutionGeneration !== requestGeneration
-        ) return null;
-        try {
-            const result = await API.resolveLocalPreviewArticleURL(requestSessionID, requestPath);
-            const articleURL = UI.safeExternalURL(result?.article_url || "");
-            if (!isLocalPreviewArticleURL(articleURL)) throw new Error('generator returned an invalid local preview URL');
+    const controller = new AbortController();
+
+    const resolution = {
+        controller,
+        key: requestKey,
+        promise: null,
+    };
+    resolution.promise = (async () => {
+        for (let attempt = 1; attempt <= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS; attempt++) {
+            if (controller.signal.aborted) throw localPreviewResolutionAbortError();
             if (
                 Editor.getCurrentPath() !== requestPath ||
                 localPreviewSessionID !== requestSessionID ||
                 localPreviewURLResolutionGeneration !== requestGeneration
             ) return null;
-            localPreviewArticleURL = articleURL;
-            return articleURL;
-        } catch (error) {
-            if (!shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
-            await new Promise(resolve => setTimeout(resolve, localPreviewNavigationRetryDelay(attempt)));
+            try {
+                const result = await API.resolveLocalPreviewArticleURL(requestSessionID, requestPath, controller.signal);
+                const articleURL = UI.safeExternalURL(result?.article_url || "");
+                if (!isLocalPreviewArticleURL(articleURL)) throw new Error('generator returned an invalid local preview URL');
+                if (
+                    Editor.getCurrentPath() !== requestPath ||
+                    localPreviewSessionID !== requestSessionID ||
+                    localPreviewURLResolutionGeneration !== requestGeneration
+                ) return null;
+                localPreviewArticleURL = articleURL;
+                localPreviewArticleURLKey = requestKey;
+                return articleURL;
+            } catch (error) {
+                if (error?.name === 'AbortError') throw error;
+                if (!shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
+                await waitForLocalPreviewRetry(localPreviewNavigationRetryDelay(attempt), controller.signal);
+            }
         }
-    }
-    return null;
+        return null;
+    })();
+    localPreviewURLResolution = resolution;
+    resolution.promise.then(
+        () => { if (localPreviewURLResolution === resolution) localPreviewURLResolution = null; },
+        () => { if (localPreviewURLResolution === resolution) localPreviewURLResolution = null; },
+    );
+    return resolution.promise;
 }
 
 async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") {
     if (updateResult?.session_id) localPreviewSessionID = updateResult.session_id;
-    if (localPreviewHasFrontMatterKey && localPreviewFrontMatterKey === frontMatterKey && localPreviewArticleURL) {
+    const requestKey = localPreviewURLResolutionKey(frontMatterKey);
+    if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey) {
         return localPreviewArticleURL;
     }
     localPreviewFrontMatterKey = frontMatterKey;
-    localPreviewHasFrontMatterKey = true;
-    localPreviewURLResolutionGeneration += 1;
     localPreviewArticleURL = "";
+    localPreviewArticleURLKey = "";
     if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
     try {
-        const articleURL = await resolveLocalPreviewArticleURL();
+        const articleURL = await resolveLocalPreviewArticleURL(frontMatterKey);
         if (articleURL && Editor.getCurrentPath() && !localPreviewFrameController?.isDismissed()) {
             showEmbeddedLocalPreview();
         }
@@ -569,7 +631,7 @@ async function openLocalLivePreview() {
     try {
         if (Editor.getCurrentPath()) {
             await ensureLocalPreviewSession();
-            const articleURL = await resolveLocalPreviewArticleURL();
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }
         const url = currentLocalPreviewURL();
@@ -597,7 +659,7 @@ async function toggleEmbeddedLocalPreview() {
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
             await ensureLocalPreviewSession();
-            const articleURL = await resolveLocalPreviewArticleURL();
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }
         showEmbeddedLocalPreview({ reload: true });
@@ -614,10 +676,7 @@ async function stopLocalLivePreview() {
     try {
         const released = await Editor.releaseLocalLivePreview();
         localPreviewSessionID = "";
-        localPreviewArticleURL = "";
-        localPreviewURLResolutionGeneration += 1;
-        localPreviewFrontMatterKey = "";
-        localPreviewHasFrontMatterKey = false;
+        resetLocalPreviewArticleURL();
         if (!released) await API.stopLocalPreviewContent("");
         closeEmbeddedLocalPreview();
         UI.showToast('Local Live Previewを停止しました', 'success');
@@ -636,14 +695,11 @@ async function reclaimLocalLivePreview() {
     try {
         await API.reclaimStaleLocalPreview();
         localPreviewSessionID = "";
-        localPreviewArticleURL = "";
-        localPreviewURLResolutionGeneration += 1;
-        localPreviewFrontMatterKey = "";
-        localPreviewHasFrontMatterKey = false;
+        resetLocalPreviewArticleURL();
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
             await ensureLocalPreviewSession();
-            const articleURL = await resolveLocalPreviewArticleURL();
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
             showEmbeddedLocalPreview({ reload: true });
         }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -26,6 +26,11 @@ export function getCurrentPath() {
     return currentPath;
 }
 
+export function getCurrentLocalPreviewFrontMatterKey() {
+    if (!currentPath) return "";
+    return JSON.stringify(getPayload().frontmatter ?? null);
+}
+
 function draftStorageKey(siteID, path) {
     return `hugo-cms:draft:${siteID}:${path}`;
 }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -258,11 +258,16 @@ export async function refreshLocalLivePreview() {
     localPreviewSessionPath = requestPath;
     const revision = ++localPreviewRevision;
     const payload = getPayload();
+    const frontMatterKey = JSON.stringify(payload.frontmatter ?? null);
 
     const request = API.updateLocalPreviewContent(payload, sessionID, revision);
     localPreviewInflight.add(request);
     try {
-        return await request;
+        const result = await request;
+        if (typeof window.refreshLocalPreviewArticleURL === 'function') {
+            window.refreshLocalPreviewArticleURL(result, frontMatterKey).catch(() => undefined);
+        }
+        return result;
     } catch (e) {
         if (e?.status === 409) {
             if (!localPreviewConflictNotified) {

--- a/static/js/local_preview.js
+++ b/static/js/local_preview.js
@@ -13,10 +13,6 @@ export function shouldAutoShowEmbeddedLocalPreview({ status, sessionOwned, hasCu
     return hasCurrentPath && sessionOwned === true && !dismissed && (status === 'starting' || status === 'ready');
 }
 
-export function shouldResyncLocalPreviewAfterInitialLoad({ pending, enabled, hasCurrentPath } = {}) {
-    return pending === true && enabled === true && hasCurrentPath === true;
-}
-
 export function shouldRetryLocalPreviewNavigation({ error, attempt } = {}) {
     if (!Number.isInteger(attempt) || attempt >= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS) return false;
     const status = error?.status;

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -31,7 +31,6 @@ const {
     shouldAutoShowEmbeddedLocalPreview,
     shouldCloseEmbeddedLocalPreview,
     shouldRetryLocalPreviewNavigation,
-    shouldResyncLocalPreviewAfterInitialLoad,
     shouldUseLocalPreviewSplitDefault,
 } = await import("./local_preview.js");
 const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
@@ -149,14 +148,7 @@ describe("embedded Local Preview state transitions", () => {
         assert.equal(shouldAutoShowEmbeddedLocalPreview({ status: "ready", sessionOwned: true, hasCurrentPath: true, dismissed: true }), false);
     });
 
-    it("resyncs the selected article only once after the initial iframe response", () => {
-        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: true, hasCurrentPath: true }), true);
-        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: false, enabled: true, hasCurrentPath: true }), false);
-        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: false, hasCurrentPath: true }), false);
-        assert.equal(shouldResyncLocalPreviewAfterInitialLoad({ pending: true, enabled: true, hasCurrentPath: false }), false);
-    });
-
-    it("retries transient initial navigation failures with bounded backoff", () => {
+    it("retries transient URL resolution failures with bounded backoff", () => {
         assert.equal(LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS, 3);
         assert.equal(shouldRetryLocalPreviewNavigation({ error: new TypeError("network"), attempt: 1 }), true);
         assert.equal(shouldRetryLocalPreviewNavigation({ error: { status: 503 }, attempt: 2 }), true);
@@ -355,7 +347,7 @@ describe("preview API contracts", () => {
         const article = { path: "posts/one.md", body: "# Draft", frontmatter: { title: "Draft" } };
         await API.renderMarkdownPreview(article);
         await API.updateLocalPreviewContent(article, "local-session", 7);
-        await API.navigateLocalPreviewContent("local-session", article.path);
+        await API.resolveLocalPreviewArticleURL("local-session", article.path);
         await API.releaseLocalPreviewContent("local-session");
         await API.fetchLocalPreviewStatus("local-session");
         await API.heartbeatLocalPreviewContent("local-session");


### PR DESCRIPTION
## 概要
- Hugoのhugo list allを使うPreviewURLResolverを追加し、shadow workspace上の未保存front matterを含めて記事URLを解決
- 解決済みURLをiframeと新規タブへ直接設定し、失敗時はpreview rootへフォールバックしないUIへ変更
- 初回navigationのfilesystem touchと--navigateToChanged依存を削除し、docs・テストを更新

## 検証
- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs

Refs #44