### PR TITLE
feat: Issue #46 EleventyのLocal Live Preview対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ WORKDIR /app
 COPY --from=builder /out/hugo-cms /app/hugo-cms
 COPY static /app/static
 COPY templates /app/templates
+COPY scripts /app/scripts
 COPY deploy/docker-tool-bootstrap.sh /usr/local/bin/docker-tool-bootstrap
 
 RUN chmod 0755 /app/hugo-cms /usr/local/bin/docker-tool-bootstrap \

--- a/docs/architecture/current-architecture.md
+++ b/docs/architecture/current-architecture.md
@@ -138,7 +138,7 @@ GIT_TOKEN=xxx
 
 `GeneratorAdapter`がプレビュー起動・停止・再起動、ビルド、コンテンツ作成を抽象化する。`SITE_GENERATOR`またはSite Registryのdefault site設定から`HugoAdapter`または`EleventyAdapter`を選択する。従来の関数名は互換ラッパーとして維持している。
 
-各Adapterはpreview serverを`SiteRuntime.PreviewURL`配下へmountする。Hugoは`--baseURL`、Eleventyは`--pathprefix`を使い、HTTP proxyは認証付きpreview pathとそのencoding/queryを維持したまま上流へ転送する。
+各Adapterはpreview serverを`SiteRuntime.PreviewURL`へproxyする。Hugoは`--baseURL`を使い、Eleventyはdev serverが返すroot-relative URLを使う。HTTP proxyは認証付きpreviewのpathとそのencoding/queryを維持したまま上流へ転送する。
 
 `ProcessManager`はプロセス終了を明示的に待ち、世代の異なる監視処理が新しいプロセス状態を消去しないよう管理する。
 

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -7,7 +7,9 @@ Issue #32のLocal Live Previewは段階的に実装する。
 - Phase 1 (#33): 設定model、derived URL、Host validation、process lifecycle/port reservation
 - Phase 2 (#34): Hugo lazy start/stop、loopback port、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継
 - Phase 3 (#35): shadow content workspace + editor debounce + content resource同期
-- Phase 4: UI/運用導線
+- Phase 4: UI/運用導線、generator別URL解決
+- Issue #46: Eleventy `--serve`、shadow input、generator metadata URL解決
+- Issue #37: 実blog・wildcard ingressでのHugo/Eleventy受け入れ確認は実環境で継続する
 
 Local Live PreviewはMarkdown本文プレビューとDeployment Previewを置き換えず、両者の中間を担う。
 
@@ -60,9 +62,9 @@ sites:
 
 HTTPSではport省略または`:443`、HTTPではport省略または`:80`だけを許可する。preview namespace内のinvalid/unknown HostはCMS admin routeへfall throughさせない。HostはSite Registry lookupにだけ使い、repository path、command、internal portへ変換しない。
 
-## Hugo process lifecycle
+## Generator process lifecycle
 
-`LocalPreviewManager`がsiteごとのHugo processを管理する。
+`LocalPreviewManager`がsiteごとのgenerator processを管理する。generatorごとの差異はprocess command factoryと`PreviewURLResolver`へ閉じ込め、lifecycle、port reservation、proxy、shutdownは共通化する。
 
 ```text
 stopped -> starting -> ready -> stopping -> stopped
@@ -98,7 +100,19 @@ hugo server
   --noHTTPCache
 ```
 
-記事選択時の初回起動では、shadow workspaceをHugoの`contentDir`として使い、`hugo list all`のCSVから選択記事の`permalink`を取得する。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決し、Hugo実装ではserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalinkやslugを再実装しない。以降の同一記事の編集はLiveReloadを利用する。
+Eleventyは対象siteのpackage managerを再利用し、production repositoryをcwdにしたままshadow contentを入力にする。
+
+```text
+<package-manager> exec eleventy
+  --serve
+  --input <shadow-content-dir>
+  --output <OS-temporary-output-dir>
+  --port <internal-port>
+```
+
+Eleventyの出力ディレクトリはproductionの`public`/`_site`を上書きしない。内部serverはloopback portだけでproxyから利用し、停止時にtemporary outputを削除する。Eleventy dev serverのwatch/live reloadをそのまま使う。
+
+記事選択時の初回起動では、shadow workspaceをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装は同じrepository cwdとshadow `--input`で`--to=json --quiet`を実行し、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
 
 ## Reverse proxy / LiveReload
 
@@ -122,7 +136,7 @@ Editor input
   -> 250ms debounce
   -> POST /admin/api/preview/local
   -> shadow content directory
-  -> Hugo watcher
+  -> generator watcher
   -> rebuild / LiveReload
 ```
 
@@ -140,7 +154,7 @@ OS temporary directory/
         ... mirrored site content ...
 ```
 
-Hugoのworking directory/source rootは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。
+generatorのworking directoryは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyもconfig、layout、data、passthrough assetは元repoから読み、`--input`だけをshadow directoryへ差し替え、生成出力はtemporary directoryへ分離する。
 
 workspaceは`PREVIEW_STATE_DIR`へ永続化しない。session releaseまたはCMS shutdown時に削除する。
 
@@ -168,7 +182,7 @@ static配下はHugoが元repositoryを直接参照するためshadow同期しな
 - 別siteは独立workspaceを利用可能
 - stale tabは別tabのworkspaceをreleaseできない
 
-article/site切替ではbrowserがin-flight update完了を待ってreleaseする。serverはHugo processを先に停止し、その後shadow directoryを削除する。
+article/site切替ではbrowserがin-flight update完了を待ってreleaseする。serverはgenerator processを先に停止し、その後shadow directoryを削除する。
 
 ブラウザtabを切替操作なしで閉じた場合の確実なlease解放はPhase 4の停止UI/lease運用で扱う。それまではCMS shutdownで全workspaceをcleanupする。
 
@@ -203,7 +217,7 @@ POST /admin/api/preview/local
 }
 ```
 
-初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存Hugo processを一度停止する。次のpreview hostname requestでshadow `contentDir`を使ってlazy startし、その後はHugo watcherが変更を拾う。
+初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存generator processを一度停止する。次のpreview hostname requestでshadow inputを使ってlazy startし、その後はgenerator watcherが変更を拾う。
 
 ### 初回記事URL解決
 
@@ -219,7 +233,7 @@ POST /admin/api/preview/local/navigate
 POST /admin/api/preview/local/release
 ```
 
-release時はHugo process停止後にworkspaceを削除する。active shadow sessionがなければ次のpreview requestは保存済みrepository contentを使う。
+release時はgenerator process停止後にworkspaceを削除する。active shadow sessionがなければ次のpreview requestは保存済みrepository contentを使う。Eleventyのtemporary outputも同時に削除する。
 
 ## Phase 4への契約
 

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -103,14 +103,16 @@ hugo server
 Eleventyは対象siteのpackage managerを再利用し、production repositoryをcwdにしたままshadow contentを入力にする。
 
 ```text
-<package-manager> exec eleventy
+<package-manager> exec node <CMS>/scripts/eleventy-local-preview.cjs
   --serve
   --input <shadow-content-dir>
+  --production-input <repository-content-dir>
   --output <OS-temporary-output-dir>
   --port <internal-port>
+  --host 127.0.0.1
 ```
 
-Eleventyの出力ディレクトリはproductionの`public`/`_site`を上書きしない。内部serverはloopback portだけでproxyから利用し、停止時にtemporary outputを削除する。Eleventy dev serverのwatch/live reloadをそのまま使う。
+CMSのNodeラッパーはEleventyのprogrammatic `watch`で再ビルドし、CMS側のHTTP/LiveReload WebSocket serverを実際に`127.0.0.1`へbindする。Eleventy標準Dev Serverのhost省略時のbind挙動や`HOST`環境変数には依存しない。出力ディレクトリはproductionの`public`/`_site`を上書きせず、停止時にtemporary outputを削除する。
 
 記事選択時の初回起動では、shadow workspaceをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装は同じrepository cwdとshadow `--input`で`--to=json --quiet`を実行し、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
 
@@ -154,7 +156,7 @@ OS temporary directory/
         ... mirrored site content ...
 ```
 
-generatorのworking directoryは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyもconfig、layout、data、passthrough assetは元repoから読み、`--input`だけをshadow directoryへ差し替え、生成出力はtemporary directoryへ分離する。
+generatorのworking directoryは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyはproduction inputで解決した`dir.includes`、`dir.layouts`、`dir.data`をshadow inputからの相対pathへ再配置し、`--input`だけをshadow directoryへ差し替える。これにより`../_includes`、input外のglobal data、input配下のdirectory data、passthrough assetもproduction側を参照し、生成出力はtemporary directoryへ分離する。
 
 workspaceは`PREVIEW_STATE_DIR`へ永続化しない。session releaseまたはCMS shutdown時に削除する。
 

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -8,7 +8,7 @@ Issue #32のLocal Live Previewは段階的に実装する。
 - Phase 2 (#34): Hugo lazy start/stop、loopback port、hostname reverse proxy、redirect補正、WebSocket/LiveReload中継
 - Phase 3 (#35): shadow content workspace + editor debounce + content resource同期
 - Phase 4: UI/運用導線、generator別URL解決
-- Issue #46: Eleventy `--serve`、shadow input、generator metadata URL解決
+- Issue #46: Eleventy `--serve`、project-root overlay、generator metadata URL解決
 - Issue #37: 実blog・wildcard ingressでのHugo/Eleventy受け入れ確認は実環境で継続する
 
 Local Live PreviewはMarkdown本文プレビューとDeployment Previewを置き換えず、両者の中間を担う。
@@ -100,21 +100,20 @@ hugo server
   --noHTTPCache
 ```
 
-Eleventyは対象siteのpackage managerを再利用し、production repositoryをcwdにしたままshadow contentを入力にする。
+Eleventyは対象siteのpackage managerを再利用し、production repositoryを基準に作ったtemporary project-root overlayをcwdにする。overlayでは既存の設定・依存関係・generator固有ディレクトリを参照し、`content_dir`と`public_dir`だけをpreview専用領域へ置き換える。
 
 ```text
 <package-manager> exec node <CMS>/scripts/eleventy-local-preview.cjs
   --serve
-  --input <shadow-content-dir>
-  --production-input <repository-content-dir>
-  --output <OS-temporary-output-dir>
+  --input <project-relative-content-dir>
+  --output <temporary-project-public-dir>
   --port <internal-port>
   --host 127.0.0.1
 ```
 
 CMSのNodeラッパーはEleventyのprogrammatic `watch`で再ビルドし、CMS側のHTTP/LiveReload WebSocket serverを実際に`127.0.0.1`へbindする。Eleventy標準Dev Serverのhost省略時のbind挙動や`HOST`環境変数には依存しない。出力ディレクトリはproductionの`public`/`_site`を上書きせず、停止時にtemporary outputを削除する。
 
-記事選択時の初回起動では、shadow workspaceをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装は同じrepository cwdとshadow `--input`で`--to=json --quiet`を実行し、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
+記事選択時の初回起動では、shadow workspaceを含むtemporary project-root overlayをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装はserve時と同じproject-root overlayと`--input`でJSONモードを実行し、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
 
 ## Reverse proxy / LiveReload
 
@@ -152,11 +151,14 @@ Editor input
 OS temporary directory/
   <site-id>/
     <local-preview-session-id>/
-      content/
-        ... mirrored site content ...
+      package.json, node_modules, eleventy.config.js ... production references
+      src/ or content/ ... shadow content_dir
+      _includes/, _data/, _layouts/ ... production references
+      public/ ... empty preview output directory
 ```
 
-generatorのworking directoryは元repositoryのまま維持する。Hugo config、theme/layout、static、assets、modulesは元repoから読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyはproduction inputで解決した`dir.includes`、`dir.layouts`、`dir.data`をshadow inputからの相対pathへ再配置し、`--input`だけをshadow directoryへ差し替える。これにより`../_includes`、input外のglobal data、input配下のdirectory data、passthrough assetもproduction側を参照し、生成出力はtemporary directoryへ分離する。
+Hugoは従来どおり元repositoryをsource rootとして読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyはtemporary project-root overlayをcwdにして`--input <content_dir>`、`--output <temporary-project-public-dir>`で実行する。overlayでは`content_dir`をshadowへmaterializeし、`public_dir`を空のpreview専用directoryにする。それ以外のroot-relativeなconfig、collection glob、includes/layouts/data、passthrough asset、pluginの相対pathはEleventy自身の通常のproject-root解決へ委譲する。生成出力はproductionのpublic directoryへ書き込まれない。
+repo外のabsolute pathや環境変数で指定された外部pathはこのoverlayの保証対象外とする。
 
 workspaceは`PREVIEW_STATE_DIR`へ永続化しない。session releaseまたはCMS shutdown時に削除する。
 
@@ -191,7 +193,8 @@ article/site切替ではbrowserがin-flight update完了を待ってreleaseす�
 ### filesystem境界
 
 - article/resource pathは既存`SafeJoin`境界で検証
-- shadow initial copyではsymlinkを拒否
+- shadow initial copyではcontent symlinkを拒否
+- Eleventy overlayのproduction directory referenceは一時overlay内だけに作成し、`content_dir`と`public_dir`はproductionから分離
 - regular fileだけをmirror
 - production contentはLocal Preview updateによって変更しない
 - site IDとsession IDは事前validation済みの値だけをworkspace pathに使用する
@@ -219,7 +222,7 @@ POST /admin/api/preview/local
 }
 ```
 
-初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存generator processを一度停止する。次のpreview hostname requestでshadow inputを使ってlazy startし、その後はgenerator watcherが変更を拾う。
+初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存generator processを一度停止する。次のpreview hostname requestでshadow workspaceを含むproject-root overlayを使ってlazy startし、その後はgenerator watcherが変更を拾う。
 
 ### 初回記事URL解決
 

--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -113,7 +113,7 @@ Eleventyは対象siteのpackage managerを再利用し、production repository�
 
 CMSのNodeラッパーはEleventyのprogrammatic `watch`で再ビルドし、CMS側のHTTP/LiveReload WebSocket serverを実際に`127.0.0.1`へbindする。Eleventy標準Dev Serverのhost省略時のbind挙動や`HOST`環境変数には依存しない。出力ディレクトリはproductionの`public`/`_site`を上書きせず、停止時にtemporary outputを削除する。
 
-記事選択時の初回起動では、shadow workspaceを含むtemporary project-root overlayをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装はserve時と同じproject-root overlayと`--input`でJSONモードを実行し、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
+記事選択時の初回起動では、shadow workspaceを含むtemporary project-root overlayをgeneratorの入力として使う。CMSはgeneratorに依存しない`PreviewURLResolver`契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装はserve時と同じdirectory構成を持つresolver専用project-root overlay/outputでJSONモードを実行し、稼働中previewの`public`を共有・resetせず、Eleventyが返す`inputPath`と`url`を対応づける。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
 
 ## Reverse proxy / LiveReload
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -286,7 +286,7 @@ mise exec -C <repository> -- npm exec -- node <CMS>/scripts/eleventy-local-previ
   --host 127.0.0.1
 ```
 
-Local Live PreviewではCMSのNodeラッパーがEleventyのprogrammatic `watch`を起動し、静的出力とLiveReloadをloopback serverから提供する。`--host 127.0.0.1`はラッパー自身の`server.listen`へ渡され、内部portがwildcard bindにならない。temporary project-root overlayでは既存のproject entryをproductionへ参照させ、`content_dir`だけactive shadow workspace、`public_dir`だけtemporary real directoryへ置換する。これにより`getFilteredByGlob("src/posts/**")`、passthrough、pluginのproject-root相対pathをEleventy自身の意味論で処理し、productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
+Local Live PreviewではCMSのNodeラッパーがEleventyのprogrammatic `watch`を起動し、静的出力とLiveReloadをloopback serverから提供する。`--host 127.0.0.1`はラッパー自身の`server.listen`へ渡され、内部portがwildcard bindにならない。temporary project-root overlayでは既存のproject entryをproductionへ参照させ、`content_dir`だけactive shadow workspace、`public_dir`だけtemporary real directoryへ置換する。これにより`getFilteredByGlob("src/posts/**")`、passthrough、pluginのproject-root相対pathをEleventy自身の意味論で処理し、productionの生成出力は変更しない。URL resolverは同じdirectory構成の専用overlay/outputを使うため、稼働中previewのpublicを削除・共有しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
 
 URL解決は同じラッパーのJSONモードでprogrammatic `toJSON()`を実行する。返却metadataの`inputPath`が選択記事に一致するentryから`url`を取得し、CMSはoriginだけをLocal Preview originへ書き換える。`permalink`、Data Cascade、computed data、paginationの計算はEleventyが担当する。
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -166,7 +166,7 @@ type PreviewURLResolver interface {
 }
 ```
 
-CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal Preview originへ変換する。Hugoでは`hugo list all`、Eleventyでは`eleventy --to=json`のgenerator metadataを使う。どちらもactive shadow workspaceを入力にし、保存前のFront Matterを含むgenerator自身のURL規則を利用する。
+CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal Preview originへ変換する。Hugoでは`hugo list all`、Eleventyではラッパーのprogrammatic `toJSON()`が返すgenerator metadataを使う。どちらもactive shadow workspaceを入力にし、保存前のFront Matterを含むgenerator自身のURL規則を利用する。
 
 ### Runtime Runner
 
@@ -205,7 +205,7 @@ flowchart LR
     Proxy --> Registry["Site Registry"]
     Registry --> Manager["Preview Manager"]
     Manager --> HugoProc["Hugo server (site A)"]
-    Manager --> EleventyProc["Eleventy --serve (site B)"]
+    Manager --> EleventyProc["Eleventy watch + loopback server (site B)"]
 ```
 
 preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:<preview-port>`をブラウザへ露出しないことで、previewプロセスのbind先をローカルに閉じ込めやすくする。
@@ -235,7 +235,7 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 | 標準コンテンツ | `content` | サイト設定による |
 | 標準出力 | `public` | `_site` |
 | メディア | `static`、Page Bundle等 | Passthrough Copy等 |
-| プレビュー | `hugo server` | `eleventy --serve` |
+| プレビュー | `hugo server` | CMS loopback server + Eleventy programmatic `watch` |
 | Front Matter | YAML、TOML、JSON | YAML、JSON、JavaScript等 |
 | URL決定 | slug、permalink、Page Kind等 | permalink、Data Cascade、pagination等 |
 
@@ -280,14 +280,16 @@ Eleventyはサイトの`package.json`にローカル依存関係として追加�
 標準的なプレビューコマンド:
 
 ```text
-mise exec -C <repository> -- npm exec -- eleventy \
+mise exec -C <repository> -- npm exec -- node <CMS>/scripts/eleventy-local-preview.cjs \
   --serve --input <shadow-content-dir> \
-  --output <OS-temporary-output-dir> --port=<allocated-port>
+  --production-input <repository-content-dir> \
+  --output <OS-temporary-output-dir> --port=<allocated-port> \
+  --host 127.0.0.1
 ```
 
-Eleventyは`--serve`と`--port`を提供している。Local Live Previewでは`--input`にactive shadow workspace、`--output`にOS temporary directoryを渡す。production repositoryをcwdにすることでconfig、layout、data、passthrough assetはサイト側の規則を利用し、productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
+Local Live PreviewではCMSのNodeラッパーがEleventyのprogrammatic `watch`を起動し、静的出力とLiveReloadをloopback serverから提供する。`--host 127.0.0.1`はラッパー自身の`server.listen`へ渡され、内部portがwildcard bindにならない。`--input`にactive shadow workspace、`--production-input`にproduction content root、`--output`にOS temporary directoryを渡す。production repositoryをcwdにすることでconfigをproduction inputで解決し、`dir.includes`、`dir.layouts`、`dir.data`、passthrough assetをproduction側へ固定したまま、unsaved contentだけをshadowから読む。productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
 
-URL解決は同じrepository cwdとshadow inputで`eleventy --to=json --quiet`を実行する。返却metadataの`inputPath`が選択記事に一致するentryから`url`を取得し、CMSはoriginだけをLocal Preview originへ書き換える。`permalink`、Data Cascade、computed data、paginationの計算はEleventyが担当する。
+URL解決は同じラッパーのJSONモードでprogrammatic `toJSON()`を実行する。返却metadataの`inputPath`が選択記事に一致するentryから`url`を取得し、CMSはoriginだけをLocal Preview originへ書き換える。`permalink`、Data Cascade、computed data、paginationの計算はEleventyが担当する。
 
 - <https://www.11ty.dev/docs/usage/>
 - <https://www.11ty.dev/docs/config/>

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -181,7 +181,7 @@ CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal
 
 未登録の任意コマンドをリポジトリ設定から直接実行してはならない。標準アダプターで対応できないサイト向けのカスタムコマンドは、管理者の明示承認と隔離環境を必須とする。
 
-generator processの作業ディレクトリは`cmd.Dir=repo_path`で一度だけ固定する。relativeな`repo_path`を子process内で再解決しないよう、miseは`mise exec -C . -- ...`、Hugoは`--source .`で実行する。Eleventyのpackage managerとHugoの`new content`も同じ作業ディレクトリを使う。
+generator processの作業ディレクトリは`cmd.Dir=repo_path`で一度だけ固定する。relativeな`repo_path`を子process内で再解決しないよう、miseは`mise exec -C . -- ...`、Hugoは`--source .`で実行する。EleventyのLocal Previewだけは、production repositoryを元にしたtemporary project-root overlayを`cmd.Dir`として使い、package managerとCMS helperを同じ作業ディレクトリから起動する。
 
 ### Preview Process Supervisor
 
@@ -281,13 +281,12 @@ Eleventyはサイトの`package.json`にローカル依存関係として追加�
 
 ```text
 mise exec -C <repository> -- npm exec -- node <CMS>/scripts/eleventy-local-preview.cjs \
-  --serve --input <shadow-content-dir> \
-  --production-input <repository-content-dir> \
-  --output <OS-temporary-output-dir> --port=<allocated-port> \
+  --serve --input <project-relative-content-dir> \
+  --output <temporary-project-public-dir> --port=<allocated-port> \
   --host 127.0.0.1
 ```
 
-Local Live PreviewではCMSのNodeラッパーがEleventyのprogrammatic `watch`を起動し、静的出力とLiveReloadをloopback serverから提供する。`--host 127.0.0.1`はラッパー自身の`server.listen`へ渡され、内部portがwildcard bindにならない。`--input`にactive shadow workspace、`--production-input`にproduction content root、`--output`にOS temporary directoryを渡す。production repositoryをcwdにすることでconfigをproduction inputで解決し、`dir.includes`、`dir.layouts`、`dir.data`、passthrough assetをproduction側へ固定したまま、unsaved contentだけをshadowから読む。productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
+Local Live PreviewではCMSのNodeラッパーがEleventyのprogrammatic `watch`を起動し、静的出力とLiveReloadをloopback serverから提供する。`--host 127.0.0.1`はラッパー自身の`server.listen`へ渡され、内部portがwildcard bindにならない。temporary project-root overlayでは既存のproject entryをproductionへ参照させ、`content_dir`だけactive shadow workspace、`public_dir`だけtemporary real directoryへ置換する。これにより`getFilteredByGlob("src/posts/**")`、passthrough、pluginのproject-root相対pathをEleventy自身の意味論で処理し、productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
 
 URL解決は同じラッパーのJSONモードでprogrammatic `toJSON()`を実行する。返却metadataの`inputPath`が選択記事に一致するentryから`url`を取得し、CMSはoriginだけをLocal Preview originへ書き換える。`permalink`、Data Cascade、computed data、paginationの計算はEleventyが担当する。
 

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -166,7 +166,7 @@ type PreviewURLResolver interface {
 }
 ```
 
-CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal Preview originへ変換する。Hugoでは`hugo list all`を使い、Eleventyなど他generatorのresolverは個別Issueで追加する。
+CMSはURL規則を再実装せず、generatorが返すURLのoriginだけをLocal Preview originへ変換する。Hugoでは`hugo list all`、Eleventyでは`eleventy --to=json`のgenerator metadataを使う。どちらもactive shadow workspaceを入力にし、保存前のFront Matterを含むgenerator自身のURL規則を利用する。
 
 ### Runtime Runner
 
@@ -210,7 +210,7 @@ flowchart LR
 
 preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:<preview-port>`をブラウザへ露出しないことで、previewプロセスのbind先をローカルに閉じ込めやすくする。
 
-すべてのGenerator Adapterはpreview processを`SiteRuntime.PreviewURL`配下へmountする。Hugoは`--baseURL`、Eleventyは`--pathprefix`を使用する。proxyは外向きrequestのpath、`RawPath`、queryを再構築せず上流へ渡す。これにより、サイト固有のsection、permalink、percent-encodingをproxyが推測せず、新しいadapterも同じroute契約で追加できる。
+すべてのGenerator Adapterはpreview processを`SiteRuntime.PreviewURL`へproxyする。Hugoは`--baseURL`を使い、Eleventyはgeneratorのdev serverが返すroot-relative pathをそのまま配信する。proxyは外向きrequestのpath、`RawPath`、queryを再構築せず上流へ渡す。これにより、サイト固有のsection、permalink、percent-encodingをproxyが推測せず、新しいadapterも同じroute契約で追加できる。
 
 ### Site Runtime Bridge
 
@@ -237,7 +237,7 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 | メディア | `static`、Page Bundle等 | Passthrough Copy等 |
 | プレビュー | `hugo server` | `eleventy --serve` |
 | Front Matter | YAML、TOML、JSON | YAML、JSON、JavaScript等 |
-| URL決定 | slug、permalink、Page Kind等 | permalink、Data Cascade等 |
+| URL決定 | slug、permalink、Page Kind等 | permalink、Data Cascade、pagination等 |
 
 ### Hugo Adapter
 
@@ -280,13 +280,19 @@ Eleventyはサイトの`package.json`にローカル依存関係として追加�
 標準的なプレビューコマンド:
 
 ```text
-mise exec -C <repository> -- npm run cms:preview -- --port=<allocated-port>
+mise exec -C <repository> -- npm exec -- eleventy \
+  --serve --input <shadow-content-dir> \
+  --output <OS-temporary-output-dir> --port=<allocated-port>
 ```
 
-Eleventyは入力・出力ディレクトリをサイト設定で変更でき、`--serve`と`--port`を提供している。previewでは`--pathprefix SiteRuntime.PreviewURL`も渡し、Hugoと同じ認証付きpreview route配下へmountする。
+Eleventyは`--serve`と`--port`を提供している。Local Live Previewでは`--input`にactive shadow workspace、`--output`にOS temporary directoryを渡す。production repositoryをcwdにすることでconfig、layout、data、passthrough assetはサイト側の規則を利用し、productionの生成出力は変更しない。CMSは`--pathprefix`やpermalinkを再実装せず、generatorが返すURLをそのままproxyする。
+
+URL解決は同じrepository cwdとshadow inputで`eleventy --to=json --quiet`を実行する。返却metadataの`inputPath`が選択記事に一致するentryから`url`を取得し、CMSはoriginだけをLocal Preview originへ書き換える。`permalink`、Data Cascade、computed data、paginationの計算はEleventyが担当する。
 
 - <https://www.11ty.dev/docs/usage/>
 - <https://www.11ty.dev/docs/config/>
+- <https://www.11ty.dev/docs/programmatic/>
+- <https://www.11ty.dev/docs/permalinks/>
 
 依存関係の取得はHTTPリクエスト処理中やapp起動時に行わない。Docker構成では管理者が`HUGO_CMS_REPOS`へUnixの`:`区切りで明示したrepoだけを、`docker compose --profile tools run --rm tool-bootstrap`で準備する。bootstrapはmise toolchainを導入したあと、lockfileに応じてnpm、pnpm、yarn、bunのfrozen installを実行し、成功した環境だけをプレビューへ使用する。
 
@@ -330,7 +336,7 @@ MarkdownのファイルパスからURLを文字列置換する現在の方式は
 1. コレクション設定の明示的なURLテンプレート
 2. Front Matterの`url`または`permalink`
 3. Generator Adapterによる解決
-4. 解決不能時はサイトルートを表示
+4. 解決不能時はサイトルートへフォールバックせずエラーを表示
 
 ## ジェネレーター判定
 

--- a/docs/architecture/preview-deployment-design.md
+++ b/docs/architecture/preview-deployment-design.md
@@ -91,13 +91,13 @@ production branchへ直接commit/pushする従来Publishは使用しない。rea
 
 ## Local Live Preview process / proxy
 
-Hugo processは最初のpreview requestでlazy startし、内部portはCMSが`14100-14999`から予約する。port利用可否をloopbackでprobeしたあとに起動し、bind race等でstartupに失敗した場合はslotを解放して別portで有限回retryする。
+generator processは最初のpreview requestでlazy startし、内部portはCMSが`14100-14999`から予約する。port利用可否をloopbackでprobeしたあとに起動し、bind race等でstartupに失敗した場合はslotを解放して別portで有限回retryする。
 
 Hugoにはexternal preview URLを`--baseURL`として渡し、`--appendPort=false`を使う。HTTPS previewではLiveReload portを443、HTTP previewでは80に固定し、internal portをbrowserへ露出させない。`--renderToMemory`、draft/future content、watchを有効にする。
 
 reverse proxyはpath prefixを加えずrequest pathをそのままHugoへ渡す。root-relative `/css/...`、`/js/...`、`/images/...`はsite自身のorigin rootから取得される。内部`127.0.0.1:<port>`または`localhost:<port>`を指すabsolute `Location`だけをexternal preview originへ書き換え、外部redirectは保持する。HTTP Upgradeを透過してHugo LiveReloadのWebSocketを通す。
 
-CMS shutdown時には起動済みHugo processを停止する。異常終了したprocessはfailed状態となり、次のrequestで再起動可能とする。
+CMS shutdown時には起動済みgenerator processを停止する。異常終了したprocessはfailed状態となり、次のrequestで再起動可能とする。
 
 ## ライフサイクルと競合
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、shadow input、`--to=json` metadata URL解決を同じ導線へ追加しています。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、project-root overlay、`--to=json` metadata URL解決を同じ導線へ追加しています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、Hugo watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、shadow input、`--to=json` metadata URL解決を同じ導線へ追加しています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -1,6 +1,6 @@
 # Local Live Preview設定ガイド
 
-> Issue #32ではPhase 1〜4が実装済みです。session lease/recovery、status/stop APIに加え、CMS内の埋め込みpreviewを主導線とするUIを提供します。
+> Issue #32ではPhase 1〜4が実装済みです。session lease/recovery、status/stop APIに加え、CMS内の埋め込みpreviewを主導線とするUIを提供します。実blogとwildcard ingressを使った受け入れ確認はIssue #37で追跡します。
 
 ## 基本設定
 
@@ -68,9 +68,9 @@ tech.preview.example.com:evil
 
 HTTP設定ではport省略または`:80`だけを許可します。HostはSite Registry lookupにだけ使います。
 
-## Hugo process
+## Generator process
 
-最初のpreview hostname requestでHugo serverをlazy startします。
+最初のpreview hostname requestで、siteの`generator`に対応した開発サーバーをlazy startします。現在はHugoとEleventyに対応しています。
 
 ```text
 hugo server
@@ -92,6 +92,18 @@ hugo server
 内部portは`14100-14999`から予約します。Hugoはloopbackだけへbindし、child environmentはgenerator allowlistを使います。
 
 CMS shutdown開始後は新規preview processを起動せず、HTTP serverをdrainしてからchild processを停止します。
+
+Eleventy siteでは、対象siteのlock fileから検出したpackage manager経由で次のように起動します。
+
+```text
+<package-manager> exec eleventy
+  --serve
+  --input <shadow-content-dir>
+  --output <temporary-preview-output-dir>
+  --port <internal-port>
+```
+
+Eleventyのconfig、layout、data、assetはproduction repositoryを作業ディレクトリとして読み込み、生成出力だけをOS temporary directoryへ分離します。Eleventy自身のdev server/watch/live reloadを使用するため、production working treeやGitへ生成物を書き込みません。
 
 ## Reverse proxy / LiveReload
 
@@ -118,11 +130,11 @@ POST /admin/api/preview/local
 Editor
   -> 250ms debounce
   -> shadow content workspace
-  -> Hugo watcher
+  -> generator watcher
   -> rebuild / LiveReload
 ```
 
-Hugoのsource rootは元repositoryのままです。theme/layout/config/static/assets/modulesは元repoを利用し、`--contentDir`だけshadow directoryのabsolute pathへ切り替えます。
+generatorの作業ディレクトリは元repositoryのままです。Hugoは`--contentDir`、Eleventyは`--input`だけshadow directoryのabsolute pathへ切り替え、theme/layout/config/data/static/assets/modulesなどgeneratorが管理する規則は元repoから読み込みます。Eleventyの生成出力はtemporary directoryへ分離します。
 
 既存の3秒autosaveは保存機能として残りますが、Local Previewの250ms update経路はproduction working tree/Git index/refへ書き込みません。
 
@@ -149,7 +161,7 @@ Local Preview ownership IDはbrowser document/tabのmemory上だけに保持し�
 - stale workspaceは明示的なreclaim APIでCMS再起動なしに回収可能
 - liveなsessionはreclaimできない
 
-recovery時もHugo processを先にstopしてからshadow workspaceを削除します。
+recovery時もgenerator processを先にstopしてからshadow workspaceを削除します。
 
 ## UI
 
@@ -170,7 +182,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 記事選択時はdesktopでは`Split`を初期viewにし、generatorが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、generatorのURL resolverへ解決を委譲します。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
 
-記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、serverと同じ`development` environmentでHugo `list all`を実行し、選択記事の`permalink`を取得します。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。これにより、記事を編集しなくてもHugo自身がslug、`url`、permalink、page bundle、languageの実ページURLを解決します。通常の本文編集ではiframeの現在URLを維持してLiveReloadを利用し、URLに影響するfront matter変更時だけ再解決します。
+記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyは`eleventy --to=json`の`inputPath`/`url` metadataを使います。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
 初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
 
@@ -199,11 +211,11 @@ CMS側iframeにはsandboxを付け、top-level navigation等を許可しませ�
 article/site切替時はin-flight update完了を待ってsessionをreleaseします。
 
 ```text
-Hugo process stop
+generator process stop
   -> shadow workspace delete
 ```
 
-CMS shutdownでもHugo child停止後にtemporary workspaceを削除します。workspaceは`PREVIEW_STATE_DIR`へ永続化しません。
+CMS shutdownでもgenerator child停止後にtemporary workspaceとEleventy temporary outputを削除します。workspaceは`PREVIEW_STATE_DIR`へ永続化しません。
 
 ## Hugo Modules
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -93,21 +93,21 @@ hugo server
 
 CMS shutdown開始後は新規preview processを起動せず、HTTP serverをdrainしてからchild processを停止します。
 
-Eleventy siteでは、対象siteのlock fileから検出したpackage manager経由で次のように起動します。
+Eleventy siteでは、対象siteのlock fileから検出したpackage manager経由で、production repositoryを元にしたtemporary project-root overlayをcwdとして次のように起動します。
 
 ```text
 <package-manager> exec node <CMS>/scripts/eleventy-local-preview.cjs
   --serve
-  --input <shadow-content-dir>
-  --production-input <repository-content-dir>
-  --output <temporary-preview-output-dir>
+  --input <project-relative-content-dir>
+  --output <temporary-project-public-dir>
   --port <internal-port>
   --host 127.0.0.1
 ```
 
-CMSのNodeラッパーはproduction repositoryをcwdにしてEleventyのprogrammatic `watch`を実行し、生成物をOS temporary directoryへ分離します。HTTP配信とLiveReload WebSocketはCMS側のloopback serverが担当し、実際のlistenerを`127.0.0.1`へ限定します。Eleventy標準Dev Serverの未指定hostや`HOST`環境変数には依存しません。
+CMSのNodeラッパーはtemporary project-root overlayをcwdにしてEleventyのprogrammatic `watch`を実行します。overlayでは`content_dir`をshadow workspaceへ、`public_dir`をtemporary outputへ置き換え、package.json、node_modules、config、includes/layouts/data、その他のproject-root相対パスはproduction repositoryを参照します。HTTP配信とLiveReload WebSocketはCMS側のloopback serverが担当し、実際のlistenerを`127.0.0.1`へ限定します。Eleventy標準Dev Serverの未指定hostや`HOST`環境変数には依存しません。
 
-Eleventy設定はproduction inputで一度解決し、`dir.includes`、`dir.layouts`、`dir.data`とpassthrough copyの基準をproduction repositoryに固定したうえで、inputだけをshadow directoryへ切り替えます。`../_includes`のようなinput外の相対設定、input配下のdirectory data、passthrough/static assetもproduction側を参照します。URL resolverも同じラッパーのJSONモードを使うため、`--serve`と同じdirectory解決条件になります。
+Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。URL resolverも同じoverlayとラッパーのJSONモードを使うため、`--serve`と同じdirectory解決条件になります。
+repo外のabsolute pathや環境変数で指定された外部pathはこのfilesystem overlayの保証対象外です。
 
 ## Reverse proxy / LiveReload
 
@@ -138,7 +138,7 @@ Editor
   -> rebuild / LiveReload
 ```
 
-generatorの作業ディレクトリは元repositoryのままです。Hugoは`--contentDir`、Eleventyはproduction inputで解決済みのinclude/layout/dataを保持したまま`--input`だけshadow directoryのabsolute pathへ切り替えます。theme/layout/config/data/static/assets/modulesなどgeneratorが管理する規則は元repoから読み込み、Eleventyの生成出力はtemporary directoryへ分離します。
+generatorの作業ディレクトリは、Hugoでは元repository、Eleventyでは一時project-root overlayです。Hugoは`--contentDir`をshadowへ差し替え、Eleventyはproject-relativeな`--input`と`--output`を使います。theme/layout/config/data/static/assets/modulesなどgeneratorが管理する規則は、それぞれ元repoまたはoverlay内のproduction referenceから読み込み、Eleventyの生成出力はtemporary directoryへ分離します。
 
 既存の3秒autosaveは保存機能として残りますが、Local Previewの250ms update経路はproduction working tree/Git index/refへ書き込みません。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -96,14 +96,18 @@ CMS shutdown開始後は新規preview processを起動せず、HTTP serverをdra
 Eleventy siteでは、対象siteのlock fileから検出したpackage manager経由で次のように起動します。
 
 ```text
-<package-manager> exec eleventy
+<package-manager> exec node <CMS>/scripts/eleventy-local-preview.cjs
   --serve
   --input <shadow-content-dir>
+  --production-input <repository-content-dir>
   --output <temporary-preview-output-dir>
   --port <internal-port>
+  --host 127.0.0.1
 ```
 
-Eleventyのconfig、layout、data、assetはproduction repositoryを作業ディレクトリとして読み込み、生成出力だけをOS temporary directoryへ分離します。Eleventy自身のdev server/watch/live reloadを使用するため、production working treeやGitへ生成物を書き込みません。
+CMSのNodeラッパーはproduction repositoryをcwdにしてEleventyのprogrammatic `watch`を実行し、生成物をOS temporary directoryへ分離します。HTTP配信とLiveReload WebSocketはCMS側のloopback serverが担当し、実際のlistenerを`127.0.0.1`へ限定します。Eleventy標準Dev Serverの未指定hostや`HOST`環境変数には依存しません。
+
+Eleventy設定はproduction inputで一度解決し、`dir.includes`、`dir.layouts`、`dir.data`とpassthrough copyの基準をproduction repositoryに固定したうえで、inputだけをshadow directoryへ切り替えます。`../_includes`のようなinput外の相対設定、input配下のdirectory data、passthrough/static assetもproduction側を参照します。URL resolverも同じラッパーのJSONモードを使うため、`--serve`と同じdirectory解決条件になります。
 
 ## Reverse proxy / LiveReload
 
@@ -134,7 +138,7 @@ Editor
   -> rebuild / LiveReload
 ```
 
-generatorの作業ディレクトリは元repositoryのままです。Hugoは`--contentDir`、Eleventyは`--input`だけshadow directoryのabsolute pathへ切り替え、theme/layout/config/data/static/assets/modulesなどgeneratorが管理する規則は元repoから読み込みます。Eleventyの生成出力はtemporary directoryへ分離します。
+generatorの作業ディレクトリは元repositoryのままです。Hugoは`--contentDir`、Eleventyはproduction inputで解決済みのinclude/layout/dataを保持したまま`--input`だけshadow directoryのabsolute pathへ切り替えます。theme/layout/config/data/static/assets/modulesなどgeneratorが管理する規則は元repoから読み込み、Eleventyの生成出力はtemporary directoryへ分離します。
 
 既存の3秒autosaveは保存機能として残りますが、Local Previewの250ms update経路はproduction working tree/Git index/refへ書き込みません。
 
@@ -182,7 +186,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 記事選択時はdesktopでは`Split`を初期viewにし、generatorが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、generatorのURL resolverへ解決を委譲します。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
 
-記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyは`eleventy --to=json`の`inputPath`/`url` metadataを使います。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
+記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyはラッパーのprogrammatic `toJSON()`が返す`inputPath`/`url` metadataを使います。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
 初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -106,7 +106,7 @@ Eleventy siteでは、対象siteのlock fileから検出したpackage manager経
 
 CMSのNodeラッパーはtemporary project-root overlayをcwdにしてEleventyのprogrammatic `watch`を実行します。overlayでは`content_dir`をshadow workspaceへ、`public_dir`をtemporary outputへ置き換え、package.json、node_modules、config、includes/layouts/data、その他のproject-root相対パスはproduction repositoryを参照します。HTTP配信とLiveReload WebSocketはCMS側のloopback serverが担当し、実際のlistenerを`127.0.0.1`へ限定します。Eleventy標準Dev Serverの未指定hostや`HOST`環境変数には依存しません。
 
-Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。URL resolverも同じoverlayとラッパーのJSONモードを使うため、`--serve`と同じdirectory解決条件になります。
+Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。URL resolverも同じ構成の専用temporary overlay/outputとラッパーのJSONモードを使うため、`--serve`と同じdirectory解決条件を保ちつつ、稼働中previewの`public`を削除・共有しません。
 repo外のabsolute pathや環境変数で指定された外部pathはこのfilesystem overlayの保証対象外です。
 
 ## Reverse proxy / LiveReload

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "type": "module",
   "scripts": {
     "test": "npm run test:js",
-    "test:js": "node --test static/js/*.test.mjs"
+    "test:js": "node --test static/js/*.test.mjs scripts/*.test.cjs"
   }
 }

--- a/pkg/config/site_runtime.go
+++ b/pkg/config/site_runtime.go
@@ -16,7 +16,10 @@ type SiteRuntime struct {
 	ContentDir string
 	// ProductionContentDir remains the repository-relative content directory
 	// when ContentDir is temporarily replaced by a local-preview shadow path.
-	ProductionContentDir   string
+	ProductionContentDir string
+	// LocalPreviewProjectDir is an ephemeral project root used by a generator's
+	// local preview. It is intentionally transient and is never persisted.
+	LocalPreviewProjectDir string
 	StaticDir              string
 	PublicDir              string
 	PublicPath             string

--- a/pkg/config/site_runtime.go
+++ b/pkg/config/site_runtime.go
@@ -20,23 +20,26 @@ type SiteRuntime struct {
 	// LocalPreviewProjectDir is an ephemeral project root used by a generator's
 	// local preview. It is intentionally transient and is never persisted.
 	LocalPreviewProjectDir string
-	StaticDir              string
-	PublicDir              string
-	PublicPath             string
-	PreviewURL             string
-	HugoServerPort         string
-	HugoServerBind         string
-	ArticleMediaDir        string
-	StaticMediaDir         string
-	SnippetPaths           []string
-	AppURL                 string
-	GitUserEmail           string
-	GitUserName            string
-	GitBranch              string
-	GitRemote              string
-	MarkdownPreviewEnabled bool
-	LocalPreview           LocalPreviewConfig
-	PreviewDeployment      DeploymentPreviewConfig
+	// LocalPreviewSourceRepoPath keeps the production repository path when
+	// RepoPath is temporarily replaced by a local-preview project overlay.
+	LocalPreviewSourceRepoPath string
+	StaticDir                  string
+	PublicDir                  string
+	PublicPath                 string
+	PreviewURL                 string
+	HugoServerPort             string
+	HugoServerBind             string
+	ArticleMediaDir            string
+	StaticMediaDir             string
+	SnippetPaths               []string
+	AppURL                     string
+	GitUserEmail               string
+	GitUserName                string
+	GitBranch                  string
+	GitRemote                  string
+	MarkdownPreviewEnabled     bool
+	LocalPreview               LocalPreviewConfig
+	PreviewDeployment          DeploymentPreviewConfig
 }
 
 func NewSiteRuntime(site SiteConfig) SiteRuntime {

--- a/pkg/config/site_runtime.go
+++ b/pkg/config/site_runtime.go
@@ -8,12 +8,15 @@ import "path/filepath"
 // process settings that are currently global, so services can gradually accept
 // explicit runtime data instead of reading mutable package globals.
 type SiteRuntime struct {
-	ID                     string
-	Name                   string
-	RepoPath               string
-	Generator              string
-	Runtime                string
-	ContentDir             string
+	ID         string
+	Name       string
+	RepoPath   string
+	Generator  string
+	Runtime    string
+	ContentDir string
+	// ProductionContentDir remains the repository-relative content directory
+	// when ContentDir is temporarily replaced by a local-preview shadow path.
+	ProductionContentDir   string
 	StaticDir              string
 	PublicDir              string
 	PublicPath             string
@@ -41,6 +44,7 @@ func NewSiteRuntime(site SiteConfig) SiteRuntime {
 		Generator:              site.Generator,
 		Runtime:                site.Runtime,
 		ContentDir:             site.ContentDir,
+		ProductionContentDir:   site.ContentDir,
 		StaticDir:              site.StaticDir,
 		PublicDir:              site.PublicDir,
 		PublicPath:             filepath.Join(site.RepoPath, site.PublicDir),
@@ -76,6 +80,7 @@ func CurrentSiteRuntime() SiteRuntime {
 		Generator:              SiteGenerator,
 		Runtime:                GeneratorRuntime,
 		ContentDir:             ContentDir,
+		ProductionContentDir:   ContentDir,
 		StaticDir:              StaticDir,
 		PublicDir:              PublicDir,
 		PublicPath:             PublicPath,

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -32,9 +32,9 @@ func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc 
 		}
 
 		// Phase 3 keeps unsaved editor content outside the production working
-		// tree. If this site has an active shadow workspace, point Hugo's
-		// contentDir at it while leaving configuration/theme/layout/static files
-		// rooted in the original repository.
+		// tree. If this site has an active shadow workspace, point the selected
+		// generator's input at it while leaving repository configuration,
+		// theme/layout, data, static and asset files rooted in the repository.
 		if workspaceManager, workspaceErr := services.DefaultLocalPreviewWorkspaceManager(); workspaceErr == nil {
 			if workspace, ok := workspaceManager.Active(site.ID); ok {
 				site.ContentDir = workspace.ContentDir

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -33,12 +33,16 @@ func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc 
 
 		runtime := config.NewSiteRuntime(site)
 		// Phase 3 keeps unsaved editor content outside the production working
-		// tree. If this site has an active shadow workspace, point the selected
-		// generator's input at it while retaining the production content root for
-		// configuration-relative includes, layouts and data.
+		// tree. Eleventy receives the workspace's project-root overlay so config,
+		// collections, passthrough and plugins keep their normal project-relative
+		// semantics.
 		if workspaceManager, workspaceErr := services.DefaultLocalPreviewWorkspaceManager(); workspaceErr == nil {
 			if workspace, ok := workspaceManager.Active(site.ID); ok {
 				runtime.ContentDir = workspace.ContentDir
+				if workspace.ProjectDir != "" {
+					runtime.RepoPath = workspace.ProjectDir
+					runtime.LocalPreviewProjectDir = workspace.ProjectDir
+				}
 			}
 		} else {
 			slog.Warn("Local preview shadow workspace unavailable; serving saved content", "site", site.ID, "error", workspaceErr)

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -40,6 +40,7 @@ func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc 
 			if workspace, ok := workspaceManager.Active(site.ID); ok {
 				runtime.ContentDir = workspace.ContentDir
 				if workspace.ProjectDir != "" {
+					runtime.LocalPreviewSourceRepoPath = runtime.RepoPath
 					runtime.RepoPath = workspace.ProjectDir
 					runtime.LocalPreviewProjectDir = workspace.ProjectDir
 				}

--- a/pkg/handlers/local_preview.go
+++ b/pkg/handlers/local_preview.go
@@ -31,19 +31,20 @@ func LocalPreviewIngress(manager *services.LocalPreviewManager) gin.HandlerFunc 
 			return
 		}
 
+		runtime := config.NewSiteRuntime(site)
 		// Phase 3 keeps unsaved editor content outside the production working
 		// tree. If this site has an active shadow workspace, point the selected
-		// generator's input at it while leaving repository configuration,
-		// theme/layout, data, static and asset files rooted in the repository.
+		// generator's input at it while retaining the production content root for
+		// configuration-relative includes, layouts and data.
 		if workspaceManager, workspaceErr := services.DefaultLocalPreviewWorkspaceManager(); workspaceErr == nil {
 			if workspace, ok := workspaceManager.Active(site.ID); ok {
-				site.ContentDir = workspace.ContentDir
+				runtime.ContentDir = workspace.ContentDir
 			}
 		} else {
 			slog.Warn("Local preview shadow workspace unavailable; serving saved content", "site", site.ID, "error", workspaceErr)
 		}
 
-		if err := manager.Proxy(c.Writer, c.Request, site); err != nil {
+		if err := manager.ProxyRuntime(c.Writer, c.Request, runtime); err != nil {
 			slog.Error("Local preview proxy failed", "site", site.ID, "error", err)
 			if !c.Writer.Written() {
 				c.AbortWithStatus(http.StatusBadGateway)

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -35,12 +35,6 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 		ErrorConflict(c, "Local Live Preview is disabled for this site")
 		return
 	}
-	generator := strings.TrimSpace(runtime.Generator)
-	if generator != "" && !strings.EqualFold(generator, "hugo") {
-		ErrorConflict(c, "Local Live Preview currently supports Hugo only")
-		return
-	}
-
 	var req localPreviewContentRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		ErrorBadRequest(c, "Invalid JSON")

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -87,6 +87,10 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 	}
 	resolverRuntime := runtime
 	resolverRuntime.ContentDir = workspace.ContentDir
+	if workspace.ProjectDir != "" {
+		resolverRuntime.RepoPath = workspace.ProjectDir
+		resolverRuntime.LocalPreviewProjectDir = workspace.ProjectDir
+	}
 	articleURL, err := dependencies.resolveArticleURL(c.Request.Context(), resolverRuntime, workspace, req.Path)
 	if err != nil {
 		ErrorInternal(c, "Failed to resolve Local Live Preview article URL")

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -88,6 +88,7 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 	resolverRuntime := runtime
 	resolverRuntime.ContentDir = workspace.ContentDir
 	if workspace.ProjectDir != "" {
+		resolverRuntime.LocalPreviewSourceRepoPath = resolverRuntime.RepoPath
 		resolverRuntime.RepoPath = workspace.ProjectDir
 		resolverRuntime.LocalPreviewProjectDir = workspace.ProjectDir
 	}

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -43,11 +43,6 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 		ErrorConflict(c, "Local Live Preview is disabled for this site")
 		return
 	}
-	if generator := strings.TrimSpace(runtime.Generator); generator != "" && !strings.EqualFold(generator, "hugo") {
-		ErrorConflict(c, "Local Live Preview currently supports Hugo only")
-		return
-	}
-
 	var req localPreviewNavigateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		ErrorBadRequest(c, "Invalid JSON")

--- a/pkg/services/eleventy_adapter.go
+++ b/pkg/services/eleventy_adapter.go
@@ -19,6 +19,21 @@ type eleventyPackageManager struct {
 	Args []string
 }
 
+func eleventyNodeCommandArgs(pm eleventyPackageManager, scriptPath string, args ...string) []string {
+	var commandArgs []string
+	switch pm.Name {
+	case "npm":
+		commandArgs = []string{"exec", "--", "node", scriptPath}
+	case "pnpm", "yarn":
+		commandArgs = []string{"exec", "node", scriptPath}
+	case "bun":
+		commandArgs = []string{"run", "node", scriptPath}
+	default:
+		commandArgs = []string{"node", scriptPath}
+	}
+	return append(commandArgs, args...)
+}
+
 func NewEleventyAdapter() *EleventyAdapter {
 	return &EleventyAdapter{}
 }

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -611,23 +611,30 @@ func eleventyLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime
 	if err != nil {
 		return nil, err
 	}
-	outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+	projectDir, outputDir, err := prepareEleventyLocalPreviewProject(runtime)
 	if err != nil {
 		return nil, err
-	}
-	if err := os.RemoveAll(outputDir); err != nil {
-		return nil, fmt.Errorf("reset Eleventy local preview output: %w", err)
-	}
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, fmt.Errorf("create Eleventy local preview output: %w", err)
 	}
 	args, err := eleventyLocalPreviewArgs(runtime, port, outputDir)
 	if err != nil {
+		if runtime.LocalPreviewProjectDir == "" {
+			_ = os.RemoveAll(projectDir)
+		}
 		return nil, err
 	}
+	commandRuntime := runtime
+	commandRuntime.RepoPath = projectDir
+	commandRuntime.ContentDir, err = eleventyLocalPreviewInputDir(runtime)
+	if err != nil {
+		if runtime.LocalPreviewProjectDir == "" {
+			_ = os.RemoveAll(projectDir)
+		}
+		return nil, err
+	}
+	commandRuntime.LocalPreviewProjectDir = projectDir
 	return generatorCommandContextWithEnv(
 		ctx,
-		runtime,
+		commandRuntime,
 		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development"},
 		pm.Bin,
 		eleventyNodeCommandArgs(pm, args[1], args[2:]...)...,
@@ -638,13 +645,10 @@ func eleventyLocalPreviewArgs(runtime config.SiteRuntime, port int, outputDir st
 	if port < 1 || port > 65535 {
 		return nil, fmt.Errorf("invalid local preview port %d", port)
 	}
-	if strings.TrimSpace(runtime.ContentDir) == "" {
-		return nil, fmt.Errorf("Eleventy local preview content directory is required")
-	}
 	if strings.TrimSpace(outputDir) == "" || !filepath.IsAbs(outputDir) {
 		return nil, fmt.Errorf("Eleventy local preview output directory must be absolute")
 	}
-	productionInput, err := eleventyProductionContentDir(runtime)
+	inputDir, err := eleventyLocalPreviewInputDir(runtime)
 	if err != nil {
 		return nil, err
 	}
@@ -655,29 +659,11 @@ func eleventyLocalPreviewArgs(runtime config.SiteRuntime, port int, outputDir st
 	return []string{
 		"node", scriptPath,
 		"--serve",
-		"--input", runtime.ContentDir,
-		"--production-input", productionInput,
+		"--input", inputDir,
 		"--output", outputDir,
 		"--port", strconv.Itoa(port),
 		"--host", LocalPreviewBindAddress,
 	}, nil
-}
-
-func eleventyProductionContentDir(runtime config.SiteRuntime) (string, error) {
-	contentDir := strings.TrimSpace(runtime.ProductionContentDir)
-	if contentDir == "" {
-		contentDir = strings.TrimSpace(runtime.ContentDir)
-	}
-	if contentDir == "" {
-		return "", fmt.Errorf("Eleventy production content directory is required")
-	}
-	if filepath.IsAbs(contentDir) {
-		return filepath.Clean(contentDir), nil
-	}
-	if strings.TrimSpace(runtime.RepoPath) == "" {
-		return "", fmt.Errorf("Eleventy production repository is required")
-	}
-	return filepath.Abs(filepath.Join(runtime.RepoPath, contentDir))
 }
 
 func eleventyLocalPreviewScriptPath() (string, error) {
@@ -703,7 +689,10 @@ func eleventyLocalPreviewScriptPath() (string, error) {
 	return "", fmt.Errorf("Eleventy local preview helper script is unavailable")
 }
 
-func eleventyLocalPreviewOutputDir(runtime config.SiteRuntime) (string, error) {
+func eleventyLocalPreviewProjectDir(runtime config.SiteRuntime) (string, error) {
+	if projectDir := strings.TrimSpace(runtime.LocalPreviewProjectDir); projectDir != "" {
+		return filepath.Abs(projectDir)
+	}
 	if strings.TrimSpace(runtime.ID) == "" {
 		return "", fmt.Errorf("Eleventy local preview site ID is required")
 	}
@@ -715,15 +704,73 @@ func eleventyLocalPreviewOutputDir(runtime config.SiteRuntime) (string, error) {
 	return filepath.Join(os.TempDir(), "hugo-cms-local-preview", fmt.Sprintf("%x", digest[:12])), nil
 }
 
+func eleventyLocalPreviewOutputDir(runtime config.SiteRuntime) (string, error) {
+	projectDir, err := eleventyLocalPreviewProjectDir(runtime)
+	if err != nil {
+		return "", err
+	}
+	publicDir, err := eleventyLocalPreviewPublicDir(runtime)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(projectDir, publicDir), nil
+}
+
+func prepareEleventyLocalPreviewProject(runtime config.SiteRuntime) (string, string, error) {
+	projectDir, err := eleventyLocalPreviewProjectDir(runtime)
+	if err != nil {
+		return "", "", err
+	}
+	inputDir, err := eleventyLocalPreviewInputDir(runtime)
+	if err != nil {
+		return "", "", err
+	}
+	publicDir, err := eleventyLocalPreviewPublicDir(runtime)
+	if err != nil {
+		return "", "", err
+	}
+
+	if runtime.LocalPreviewProjectDir == "" {
+		if err := os.RemoveAll(projectDir); err != nil {
+			return "", "", fmt.Errorf("reset Eleventy local preview project: %w", err)
+		}
+		contentSource := strings.TrimSpace(runtime.ContentDir)
+		if !filepath.IsAbs(contentSource) {
+			contentSource = filepath.Join(runtime.RepoPath, inputDir)
+		}
+		if err := createEleventyLocalPreviewProjectOverlay(runtime.RepoPath, projectDir, inputDir, publicDir, contentSource); err != nil {
+			_ = os.RemoveAll(projectDir)
+			return "", "", err
+		}
+	} else if info, err := os.Stat(projectDir); err != nil || !info.IsDir() {
+		return "", "", fmt.Errorf("Eleventy local preview project root is unavailable: %w", err)
+	}
+
+	outputDir := filepath.Join(projectDir, publicDir)
+	if err := os.RemoveAll(outputDir); err != nil {
+		return "", "", fmt.Errorf("reset Eleventy local preview output: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return "", "", fmt.Errorf("create Eleventy local preview output: %w", err)
+	}
+	return projectDir, outputDir, nil
+}
+
 func localPreviewProcessCleanup(runtime config.SiteRuntime) func() {
-	generator := strings.ToLower(strings.TrimSpace(runtime.Generator))
-	if generator != "eleventy" && generator != "11ty" {
+	if !isEleventyLocalPreviewGenerator(runtime.Generator) {
 		return func() {}
 	}
 	return func() {
-		outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+		if runtime.LocalPreviewProjectDir != "" {
+			outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+			if err == nil {
+				_ = os.RemoveAll(outputDir)
+			}
+			return
+		}
+		projectDir, err := eleventyLocalPreviewProjectDir(runtime)
 		if err == nil {
-			_ = os.RemoveAll(outputDir)
+			_ = os.RemoveAll(projectDir)
 		}
 	}
 }

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"hugo-cms/pkg/config"
@@ -10,7 +11,9 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -30,10 +33,11 @@ var errLocalPreviewShuttingDown = errors.New("local preview manager is shutting 
 type localPreviewCommandFactory func(context.Context, config.SiteRuntime, int, string) (*exec.Cmd, error)
 
 type managedLocalPreviewProcess struct {
-	cmd    *exec.Cmd
-	cancel context.CancelFunc
-	done   chan struct{}
-	stderr *cappedBuffer
+	cmd     *exec.Cmd
+	cancel  context.CancelFunc
+	done    chan struct{}
+	stderr  *cappedBuffer
+	cleanup func()
 
 	mu      sync.RWMutex
 	waitErr error
@@ -107,7 +111,7 @@ func (b *cappedBuffer) String() string {
 	return string(append([]byte(nil), b.buf...))
 }
 
-// LocalPreviewManager owns Hugo preview child processes and connects the
+// LocalPreviewManager owns generator preview child processes and connects the
 // Phase 1 lifecycle contract to lazy startup, readiness probing and proxying.
 // It intentionally does not own TLS or viewer authentication; those remain
 // preview-ingress responsibilities.
@@ -133,7 +137,7 @@ func NewLocalPreviewManager(lifecycle *LocalPreviewLifecycle) *LocalPreviewManag
 		lifecycle:      lifecycle,
 		processes:      make(map[string]*managedLocalPreviewProcess),
 		siteLocks:      make(map[string]*sync.Mutex),
-		commandFactory: hugoLocalPreviewCommand,
+		commandFactory: generatorLocalPreviewCommand,
 		startupTimeout: defaultLocalPreviewStartupTimeout,
 		probeInterval:  defaultLocalPreviewProbeInterval,
 		startAttempts:  defaultLocalPreviewStartAttempts,
@@ -204,9 +208,8 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
 		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", site.ID)
 	}
-	generator := strings.TrimSpace(site.Generator)
-	if generator != "" && !strings.EqualFold(generator, "hugo") {
-		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview currently supports Hugo only, got %q", site.Generator)
+	if !localPreviewGeneratorSupported(site.Generator) {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview is not supported for generator %q", site.Generator)
 	}
 
 	previewURL := strings.TrimSpace(site.Preview.LocalPreview.URL)
@@ -301,9 +304,11 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 
 func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int, previewURL string) (*managedLocalPreviewProcess, error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	cleanup := localPreviewProcessCleanup(runtime)
 	cmd, err := m.commandFactory(ctx, runtime, port, previewURL)
 	if err != nil {
 		cancel()
+		cleanup()
 		return nil, err
 	}
 
@@ -315,19 +320,22 @@ func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int,
 	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		cancel()
+		cleanup()
 		return nil, err
 	}
 
 	process := &managedLocalPreviewProcess{
-		cmd:    cmd,
-		cancel: cancel,
-		done:   make(chan struct{}),
-		stderr: stderr,
+		cmd:     cmd,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+		stderr:  stderr,
+		cleanup: cleanup,
 	}
 	m.setProcess(runtime.ID, process)
 
 	go func() {
 		process.setWaitErr(cmd.Wait())
+		process.cleanup()
 		close(process.done)
 		m.handleProcessExit(runtime.ID, process)
 	}()
@@ -562,12 +570,103 @@ func localPreviewPortAvailable(port int) bool {
 	return true
 }
 
+func generatorLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime, port int, previewURL string) (*exec.Cmd, error) {
+	switch strings.ToLower(strings.TrimSpace(runtime.Generator)) {
+	case "", "hugo":
+		return hugoLocalPreviewCommand(ctx, runtime, port, previewURL)
+	case "eleventy", "11ty":
+		return eleventyLocalPreviewCommand(ctx, runtime, port)
+	default:
+		return nil, fmt.Errorf("local live preview is not supported for generator %q", runtime.Generator)
+	}
+}
+
+func localPreviewGeneratorSupported(generator string) bool {
+	switch strings.ToLower(strings.TrimSpace(generator)) {
+	case "", "hugo", "eleventy", "11ty":
+		return true
+	default:
+		return false
+	}
+}
+
 func hugoLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime, port int, previewURL string) (*exec.Cmd, error) {
 	args, err := hugoLocalPreviewArgs(runtime, port, previewURL)
 	if err != nil {
 		return nil, err
 	}
 	return generatorCommandContext(ctx, runtime, "hugo", args...), nil
+}
+
+func eleventyLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime, port int) (*exec.Cmd, error) {
+	pm, err := detectEleventyPackageManager(runtime.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.RemoveAll(outputDir); err != nil {
+		return nil, fmt.Errorf("reset Eleventy local preview output: %w", err)
+	}
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("create Eleventy local preview output: %w", err)
+	}
+	args, err := eleventyLocalPreviewArgs(runtime, port, outputDir)
+	if err != nil {
+		return nil, err
+	}
+	return generatorCommandContextWithEnv(
+		ctx,
+		runtime,
+		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development", "HOST=" + LocalPreviewBindAddress},
+		pm.Bin,
+		append(append([]string{}, pm.Args...), args...)...,
+	), nil
+}
+
+func eleventyLocalPreviewArgs(runtime config.SiteRuntime, port int, outputDir string) ([]string, error) {
+	if port < 1 || port > 65535 {
+		return nil, fmt.Errorf("invalid local preview port %d", port)
+	}
+	if strings.TrimSpace(runtime.ContentDir) == "" {
+		return nil, fmt.Errorf("Eleventy local preview content directory is required")
+	}
+	if strings.TrimSpace(outputDir) == "" || !filepath.IsAbs(outputDir) {
+		return nil, fmt.Errorf("Eleventy local preview output directory must be absolute")
+	}
+	return []string{
+		"--serve",
+		"--input", runtime.ContentDir,
+		"--output", outputDir,
+		"--port", strconv.Itoa(port),
+	}, nil
+}
+
+func eleventyLocalPreviewOutputDir(runtime config.SiteRuntime) (string, error) {
+	if strings.TrimSpace(runtime.ID) == "" {
+		return "", fmt.Errorf("Eleventy local preview site ID is required")
+	}
+	repoPath, err := filepath.Abs(strings.TrimSpace(runtime.RepoPath))
+	if err != nil {
+		return "", fmt.Errorf("resolve Eleventy local preview repository: %w", err)
+	}
+	digest := sha256.Sum256([]byte(filepath.Clean(repoPath) + "\x00" + runtime.ID))
+	return filepath.Join(os.TempDir(), "hugo-cms-local-preview", fmt.Sprintf("%x", digest[:12])), nil
+}
+
+func localPreviewProcessCleanup(runtime config.SiteRuntime) func() {
+	generator := strings.ToLower(strings.TrimSpace(runtime.Generator))
+	if generator != "eleventy" && generator != "11ty" {
+		return func() {}
+	}
+	return func() {
+		outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+		if err == nil {
+			_ = os.RemoveAll(outputDir)
+		}
+	}
 }
 
 func hugoLocalPreviewArgs(runtime config.SiteRuntime, port int, previewURL string) ([]string, error) {

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -202,27 +202,30 @@ func (m *LocalPreviewManager) Status(siteID string) (LocalPreviewProcessSlot, bo
 }
 
 func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewProcessSlot, error) {
+	return m.ensureReadyRuntime(config.NewSiteRuntime(site))
+}
+
+func (m *LocalPreviewManager) ensureReadyRuntime(runtime config.SiteRuntime) (LocalPreviewProcessSlot, error) {
 	if m.isShuttingDown() {
 		return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 	}
-	if site.Preview.LocalPreview.Enabled == nil || !*site.Preview.LocalPreview.Enabled {
-		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", site.ID)
+	if runtime.LocalPreview.Enabled == nil || !*runtime.LocalPreview.Enabled {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local preview is disabled for site %q", runtime.ID)
 	}
-	if !localPreviewGeneratorSupported(site.Generator) {
-		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview is not supported for generator %q", site.Generator)
+	if !localPreviewGeneratorSupported(runtime.Generator) {
+		return LocalPreviewProcessSlot{}, fmt.Errorf("local live preview is not supported for generator %q", runtime.Generator)
 	}
 
-	previewURL := strings.TrimSpace(site.Preview.LocalPreview.URL)
+	previewURL := strings.TrimSpace(runtime.LocalPreview.URL)
 	if previewURL == "" {
 		var err error
-		previewURL, err = config.LocalPreviewURL(site.ID)
+		previewURL, err = config.LocalPreviewURL(runtime.ID)
 		if err != nil {
 			return LocalPreviewProcessSlot{}, err
 		}
 	}
-	runtime := config.NewSiteRuntime(site)
 
-	lock := m.siteLock(site.ID)
+	lock := m.siteLock(runtime.ID)
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -230,22 +233,22 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 		return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 	}
 
-	if slot, ok := m.lifecycle.Get(site.ID); ok {
-		process := m.process(site.ID)
+	if slot, ok := m.lifecycle.Get(runtime.ID); ok {
+		process := m.process(runtime.ID)
 		switch slot.State {
 		case LocalPreviewReady:
 			if process != nil && !process.exited() {
 				return slot, nil
 			}
-			_, _ = m.lifecycle.Transition(site.ID, LocalPreviewFailed, errors.New("local preview process is not running"))
+			_, _ = m.lifecycle.Transition(runtime.ID, LocalPreviewFailed, errors.New("local preview process is not running"))
 		case LocalPreviewFailed:
 			// Cleanup below before allocating another port.
 		case LocalPreviewStopped:
 			// Release the stale reservation below.
 		case LocalPreviewStarting, LocalPreviewStopping:
-			return LocalPreviewProcessSlot{}, fmt.Errorf("local preview for site %q is unexpectedly %s", site.ID, slot.State)
+			return LocalPreviewProcessSlot{}, fmt.Errorf("local preview for site %q is unexpectedly %s", runtime.ID, slot.State)
 		}
-		m.cleanupFailedSlotLocked(site.ID, process, nil)
+		m.cleanupFailedSlotLocked(runtime.ID, process, nil)
 	}
 
 	var lastErr error
@@ -254,43 +257,43 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 		}
 
-		slot, err := m.lifecycle.Reserve(site.ID, localPreviewPortAvailable)
+		slot, err := m.lifecycle.Reserve(runtime.ID, localPreviewPortAvailable)
 		if err != nil {
 			return LocalPreviewProcessSlot{}, err
 		}
-		if _, err := m.lifecycle.Transition(site.ID, LocalPreviewStarting, nil); err != nil {
+		if _, err := m.lifecycle.Transition(runtime.ID, LocalPreviewStarting, nil); err != nil {
 			return LocalPreviewProcessSlot{}, err
 		}
 
 		process, err := m.startProcess(runtime, slot.Port, previewURL)
 		if err != nil {
 			lastErr = err
-			m.cleanupFailedSlotLocked(site.ID, process, err)
+			m.cleanupFailedSlotLocked(runtime.ID, process, err)
 			continue
 		}
 		if m.isShuttingDown() {
-			m.cleanupFailedSlotLocked(site.ID, process, errLocalPreviewShuttingDown)
+			m.cleanupFailedSlotLocked(runtime.ID, process, errLocalPreviewShuttingDown)
 			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 		}
 
 		if err := m.waitUntilReady(process, slot.Port); err != nil {
 			lastErr = err
-			m.cleanupFailedSlotLocked(site.ID, process, err)
+			m.cleanupFailedSlotLocked(runtime.ID, process, err)
 			continue
 		}
 
-		readySlot, err := m.lifecycle.Transition(site.ID, LocalPreviewReady, nil)
+		readySlot, err := m.lifecycle.Transition(runtime.ID, LocalPreviewReady, nil)
 		if err != nil {
-			m.cleanupFailedSlotLocked(site.ID, process, err)
+			m.cleanupFailedSlotLocked(runtime.ID, process, err)
 			return LocalPreviewProcessSlot{}, err
 		}
 		if m.isShuttingDown() {
-			m.cleanupFailedSlotLocked(site.ID, process, errLocalPreviewShuttingDown)
+			m.cleanupFailedSlotLocked(runtime.ID, process, errLocalPreviewShuttingDown)
 			return LocalPreviewProcessSlot{}, errLocalPreviewShuttingDown
 		}
 		if process.exited() {
 			lastErr = process.processError()
-			m.cleanupFailedSlotLocked(site.ID, process, lastErr)
+			m.cleanupFailedSlotLocked(runtime.ID, process, lastErr)
 			continue
 		}
 		return readySlot, nil
@@ -299,7 +302,7 @@ func (m *LocalPreviewManager) EnsureReady(site config.SiteConfig) (LocalPreviewP
 	if lastErr == nil {
 		lastErr = errors.New("local preview failed to start")
 	}
-	return LocalPreviewProcessSlot{}, fmt.Errorf("failed to start local preview for site %q after %d attempts: %w", site.ID, m.startAttempts, lastErr)
+	return LocalPreviewProcessSlot{}, fmt.Errorf("failed to start local preview for site %q after %d attempts: %w", runtime.ID, m.startAttempts, lastErr)
 }
 
 func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int, previewURL string) (*managedLocalPreviewProcess, error) {
@@ -313,7 +316,8 @@ func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int,
 	}
 
 	stderr := newCappedBuffer(localPreviewStderrLimit)
-	// Hugo may emit useful startup/build diagnostics to either stream. Keep the
+	// Generator processes may emit useful startup/build diagnostics to either
+	// stream. Keep the
 	// bounded tail of both without allowing child output to grow memory without
 	// limit or leak CMS secrets through the browser response.
 	cmd.Stdout = stderr
@@ -493,11 +497,15 @@ func (m *LocalPreviewManager) Shutdown(ctx context.Context) error {
 }
 
 func (m *LocalPreviewManager) Proxy(w http.ResponseWriter, r *http.Request, site config.SiteConfig) error {
-	slot, err := m.EnsureReady(site)
+	return m.ProxyRuntime(w, r, config.NewSiteRuntime(site))
+}
+
+func (m *LocalPreviewManager) ProxyRuntime(w http.ResponseWriter, r *http.Request, runtime config.SiteRuntime) error {
+	slot, err := m.ensureReadyRuntime(runtime)
 	if err != nil {
 		return err
 	}
-	proxy, err := newLocalPreviewReverseProxy(site, slot.Port)
+	proxy, err := newLocalPreviewReverseProxy(runtime, slot.Port)
 	if err != nil {
 		return err
 	}
@@ -505,11 +513,11 @@ func (m *LocalPreviewManager) Proxy(w http.ResponseWriter, r *http.Request, site
 	return nil
 }
 
-func newLocalPreviewReverseProxy(site config.SiteConfig, port int) (*httputil.ReverseProxy, error) {
-	previewURL := strings.TrimSpace(site.Preview.LocalPreview.URL)
+func newLocalPreviewReverseProxy(runtime config.SiteRuntime, port int) (*httputil.ReverseProxy, error) {
+	previewURL := strings.TrimSpace(runtime.LocalPreview.URL)
 	if previewURL == "" {
 		var err error
-		previewURL, err = config.LocalPreviewURL(site.ID)
+		previewURL, err = config.LocalPreviewURL(runtime.ID)
 		if err != nil {
 			return nil, err
 		}
@@ -546,7 +554,7 @@ func newLocalPreviewReverseProxy(site config.SiteConfig, port int) (*httputil.Re
 			return nil
 		},
 		ErrorHandler: func(writer http.ResponseWriter, _ *http.Request, proxyErr error) {
-			slog.Error("Local preview upstream error", "site", site.ID, "error", proxyErr)
+			slog.Error("Local preview upstream error", "site", runtime.ID, "error", proxyErr)
 			http.Error(writer, "local preview upstream unavailable", http.StatusBadGateway)
 		},
 	}
@@ -620,9 +628,9 @@ func eleventyLocalPreviewCommand(ctx context.Context, runtime config.SiteRuntime
 	return generatorCommandContextWithEnv(
 		ctx,
 		runtime,
-		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development", "HOST=" + LocalPreviewBindAddress},
+		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development"},
 		pm.Bin,
-		append(append([]string{}, pm.Args...), args...)...,
+		eleventyNodeCommandArgs(pm, args[1], args[2:]...)...,
 	), nil
 }
 
@@ -636,12 +644,63 @@ func eleventyLocalPreviewArgs(runtime config.SiteRuntime, port int, outputDir st
 	if strings.TrimSpace(outputDir) == "" || !filepath.IsAbs(outputDir) {
 		return nil, fmt.Errorf("Eleventy local preview output directory must be absolute")
 	}
+	productionInput, err := eleventyProductionContentDir(runtime)
+	if err != nil {
+		return nil, err
+	}
+	scriptPath, err := eleventyLocalPreviewScriptPath()
+	if err != nil {
+		return nil, err
+	}
 	return []string{
+		"node", scriptPath,
 		"--serve",
 		"--input", runtime.ContentDir,
+		"--production-input", productionInput,
 		"--output", outputDir,
 		"--port", strconv.Itoa(port),
+		"--host", LocalPreviewBindAddress,
 	}, nil
+}
+
+func eleventyProductionContentDir(runtime config.SiteRuntime) (string, error) {
+	contentDir := strings.TrimSpace(runtime.ProductionContentDir)
+	if contentDir == "" {
+		contentDir = strings.TrimSpace(runtime.ContentDir)
+	}
+	if contentDir == "" {
+		return "", fmt.Errorf("Eleventy production content directory is required")
+	}
+	if filepath.IsAbs(contentDir) {
+		return filepath.Clean(contentDir), nil
+	}
+	if strings.TrimSpace(runtime.RepoPath) == "" {
+		return "", fmt.Errorf("Eleventy production repository is required")
+	}
+	return filepath.Abs(filepath.Join(runtime.RepoPath, contentDir))
+}
+
+func eleventyLocalPreviewScriptPath() (string, error) {
+	const scriptName = "eleventy-local-preview.cjs"
+	candidates := make([]string, 0, 2)
+	if executable, err := os.Executable(); err == nil {
+		candidates = append(candidates, filepath.Join(filepath.Dir(executable), "scripts", scriptName))
+	}
+	if workingDirectory, err := os.Getwd(); err == nil {
+		for current := workingDirectory; ; current = filepath.Dir(current) {
+			candidates = append(candidates, filepath.Join(current, "scripts", scriptName))
+			parent := filepath.Dir(current)
+			if parent == current {
+				break
+			}
+		}
+	}
+	for _, candidate := range candidates {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("Eleventy local preview helper script is unavailable")
 }
 
 func eleventyLocalPreviewOutputDir(runtime config.SiteRuntime) (string, error) {

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -66,8 +66,8 @@ func TestHugoLocalPreviewArgsRejectsURLPort(t *testing.T) {
 }
 
 func TestEleventyLocalPreviewArgs(t *testing.T) {
-	runtime := config.SiteRuntime{ContentDir: `C:\preview\tech\content`}
-	outputDir := `C:\Temp\hugo-cms-local-preview\output`
+	runtime := config.SiteRuntime{ContentDir: filepath.Join(t.TempDir(), "content")}
+	outputDir := filepath.Join(t.TempDir(), "hugo-cms-local-preview", "output")
 	got, err := eleventyLocalPreviewArgs(runtime, 14123, outputDir)
 	if err != nil {
 		t.Fatalf("eleventyLocalPreviewArgs() error = %v", err)

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -66,17 +66,29 @@ func TestHugoLocalPreviewArgsRejectsURLPort(t *testing.T) {
 }
 
 func TestEleventyLocalPreviewArgs(t *testing.T) {
-	runtime := config.SiteRuntime{ContentDir: filepath.Join(t.TempDir(), "content")}
+	repo := t.TempDir()
+	runtime := config.SiteRuntime{
+		RepoPath:             repo,
+		ContentDir:           filepath.Join(t.TempDir(), "shadow", "content"),
+		ProductionContentDir: "content",
+	}
 	outputDir := filepath.Join(t.TempDir(), "hugo-cms-local-preview", "output")
 	got, err := eleventyLocalPreviewArgs(runtime, 14123, outputDir)
 	if err != nil {
 		t.Fatalf("eleventyLocalPreviewArgs() error = %v", err)
 	}
+	scriptPath, err := eleventyLocalPreviewScriptPath()
+	if err != nil {
+		t.Fatalf("eleventyLocalPreviewScriptPath() error = %v", err)
+	}
 	want := []string{
+		"node", scriptPath,
 		"--serve",
 		"--input", runtime.ContentDir,
+		"--production-input", filepath.Join(repo, "content"),
 		"--output", outputDir,
 		"--port", "14123",
+		"--host", LocalPreviewBindAddress,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("eleventyLocalPreviewArgs() = %#v, want %#v", got, want)
@@ -89,7 +101,26 @@ func TestEleventyLocalPreviewArgsRejectsRelativeOutput(t *testing.T) {
 	}
 }
 
-func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackEnv(t *testing.T) {
+func TestEleventyNodeCommandArgsUsesDetectedPackageManager(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		pm   eleventyPackageManager
+		want []string
+	}{
+		{name: "npm", pm: eleventyPackageManager{Name: "npm"}, want: []string{"exec", "--", "node", "helper.cjs", "--json"}},
+		{name: "pnpm", pm: eleventyPackageManager{Name: "pnpm"}, want: []string{"exec", "node", "helper.cjs", "--json"}},
+		{name: "yarn", pm: eleventyPackageManager{Name: "yarn"}, want: []string{"exec", "node", "helper.cjs", "--json"}},
+		{name: "bun", pm: eleventyPackageManager{Name: "bun"}, want: []string{"run", "node", "helper.cjs", "--json"}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := eleventyNodeCommandArgs(testCase.pm, "helper.cjs", "--json"); !reflect.DeepEqual(got, testCase.want) {
+				t.Fatalf("eleventyNodeCommandArgs() = %#v, want %#v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackServer(t *testing.T) {
 	repo := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"devDependencies":{"@11ty/eleventy":"^3.0.0"}}`), 0644); err != nil {
 		t.Fatal(err)
@@ -98,10 +129,11 @@ func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackEnv(t *
 		t.Fatal(err)
 	}
 	runtime := config.SiteRuntime{
-		ID:         "daily-blog",
-		RepoPath:   repo,
-		Generator:  "eleventy",
-		ContentDir: filepath.Join(repo, "content"),
+		ID:                   "daily-blog",
+		RepoPath:             repo,
+		Generator:            "eleventy",
+		ContentDir:           filepath.Join(t.TempDir(), "shadow", "content"),
+		ProductionContentDir: "content",
 	}
 	cleanup := localPreviewProcessCleanup(runtime)
 	t.Cleanup(cleanup)
@@ -111,13 +143,10 @@ func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackEnv(t *
 		t.Fatalf("eleventyLocalPreviewCommand() error = %v", err)
 	}
 	joined := strings.Join(cmd.Args, " ")
-	for _, want := range []string{"npm", "exec", "--", "eleventy", "--serve", "--input", runtime.ContentDir, "--output", "--port", "14123"} {
+	for _, want := range []string{"npm", "exec", "--", "node", "eleventy-local-preview.cjs", "--serve", "--input", runtime.ContentDir, "--production-input", filepath.Join(repo, "content"), "--output", "--port", "14123", "--host", LocalPreviewBindAddress} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("command args = %q, missing %q", joined, want)
 		}
-	}
-	if !containsEnv(cmd.Env, "HOST", LocalPreviewBindAddress) {
-		t.Fatalf("command environment does not force loopback HOST: %#v", cmd.Env)
 	}
 }
 
@@ -311,16 +340,6 @@ func testLocalPreviewCommand(ctx context.Context, _ config.SiteRuntime, port int
 		"HUGO_CMS_LOCAL_PREVIEW_PORT="+strconv.Itoa(port),
 	)
 	return cmd, nil
-}
-
-func containsEnv(environment []string, key, value string) bool {
-	want := key + "=" + value
-	for _, entry := range environment {
-		if entry == want {
-			return true
-		}
-	}
-	return false
 }
 
 func TestLocalPreviewHelperProcess(t *testing.T) {

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -84,8 +84,7 @@ func TestEleventyLocalPreviewArgs(t *testing.T) {
 	want := []string{
 		"node", scriptPath,
 		"--serve",
-		"--input", runtime.ContentDir,
-		"--production-input", filepath.Join(repo, "content"),
+		"--input", "content",
 		"--output", outputDir,
 		"--port", "14123",
 		"--host", LocalPreviewBindAddress,
@@ -122,6 +121,9 @@ func TestEleventyNodeCommandArgsUsesDetectedPackageManager(t *testing.T) {
 
 func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackServer(t *testing.T) {
 	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "content"), 0755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"devDependencies":{"@11ty/eleventy":"^3.0.0"}}`), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -132,7 +134,7 @@ func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackServer(
 		ID:                   "daily-blog",
 		RepoPath:             repo,
 		Generator:            "eleventy",
-		ContentDir:           filepath.Join(t.TempDir(), "shadow", "content"),
+		ContentDir:           "content",
 		ProductionContentDir: "content",
 	}
 	cleanup := localPreviewProcessCleanup(runtime)
@@ -143,10 +145,13 @@ func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackServer(
 		t.Fatalf("eleventyLocalPreviewCommand() error = %v", err)
 	}
 	joined := strings.Join(cmd.Args, " ")
-	for _, want := range []string{"npm", "exec", "--", "node", "eleventy-local-preview.cjs", "--serve", "--input", runtime.ContentDir, "--production-input", filepath.Join(repo, "content"), "--output", "--port", "14123", "--host", LocalPreviewBindAddress} {
+	for _, want := range []string{"npm", "exec", "--", "node", "eleventy-local-preview.cjs", "--serve", "--input", "content", "--output", "--port", "14123", "--host", LocalPreviewBindAddress} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("command args = %q, missing %q", joined, want)
 		}
+	}
+	if cmd.Dir == repo || !strings.Contains(cmd.Dir, "hugo-cms-local-preview") {
+		t.Fatalf("command dir = %q, want an isolated Eleventy project root", cmd.Dir)
 	}
 }
 

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -61,6 +62,72 @@ func TestHugoLocalPreviewArgsUsesHTTPReloadPort(t *testing.T) {
 func TestHugoLocalPreviewArgsRejectsURLPort(t *testing.T) {
 	if _, err := hugoLocalPreviewArgs(config.SiteRuntime{ContentDir: "content"}, 14123, "https://tech.preview.example.com:8443/"); err == nil {
 		t.Fatal("hugoLocalPreviewArgs() should reject an external URL port")
+	}
+}
+
+func TestEleventyLocalPreviewArgs(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: `C:\preview\tech\content`}
+	outputDir := `C:\Temp\hugo-cms-local-preview\output`
+	got, err := eleventyLocalPreviewArgs(runtime, 14123, outputDir)
+	if err != nil {
+		t.Fatalf("eleventyLocalPreviewArgs() error = %v", err)
+	}
+	want := []string{
+		"--serve",
+		"--input", runtime.ContentDir,
+		"--output", outputDir,
+		"--port", "14123",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("eleventyLocalPreviewArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestEleventyLocalPreviewArgsRejectsRelativeOutput(t *testing.T) {
+	if _, err := eleventyLocalPreviewArgs(config.SiteRuntime{ContentDir: "content"}, 14123, "_site"); err == nil {
+		t.Fatal("eleventyLocalPreviewArgs() should reject a relative output directory")
+	}
+}
+
+func TestEleventyLocalPreviewCommandUsesDetectedPackageManagerAndLoopbackEnv(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"devDependencies":{"@11ty/eleventy":"^3.0.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{
+		ID:         "daily-blog",
+		RepoPath:   repo,
+		Generator:  "eleventy",
+		ContentDir: filepath.Join(repo, "content"),
+	}
+	cleanup := localPreviewProcessCleanup(runtime)
+	t.Cleanup(cleanup)
+
+	cmd, err := eleventyLocalPreviewCommand(context.Background(), runtime, 14123)
+	if err != nil {
+		t.Fatalf("eleventyLocalPreviewCommand() error = %v", err)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"npm", "exec", "--", "eleventy", "--serve", "--input", runtime.ContentDir, "--output", "--port", "14123"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("command args = %q, missing %q", joined, want)
+		}
+	}
+	if !containsEnv(cmd.Env, "HOST", LocalPreviewBindAddress) {
+		t.Fatalf("command environment does not force loopback HOST: %#v", cmd.Env)
+	}
+}
+
+func TestLocalPreviewManagerSupportsEleventy(t *testing.T) {
+	manager, site := newTestLocalPreviewManager(t)
+	site.Generator = "eleventy"
+	defer shutdownTestLocalPreviewManager(t, manager)
+
+	if _, err := manager.EnsureReady(site); err != nil {
+		t.Fatalf("EnsureReady() error = %v", err)
 	}
 }
 
@@ -244,6 +311,16 @@ func testLocalPreviewCommand(ctx context.Context, _ config.SiteRuntime, port int
 		"HUGO_CMS_LOCAL_PREVIEW_PORT="+strconv.Itoa(port),
 	)
 	return cmd, nil
+}
+
+func containsEnv(environment []string, key, value string) bool {
+	want := key + "=" + value
+	for _, entry := range environment {
+		if entry == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLocalPreviewHelperProcess(t *testing.T) {

--- a/pkg/services/local_preview_project.go
+++ b/pkg/services/local_preview_project.go
@@ -1,0 +1,223 @@
+package services
+
+import (
+	"fmt"
+	"hugo-cms/pkg/config"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goRuntime "runtime"
+	"strings"
+)
+
+func isEleventyLocalPreviewGenerator(generator string) bool {
+	switch strings.ToLower(strings.TrimSpace(generator)) {
+	case "eleventy", "11ty":
+		return true
+	default:
+		return false
+	}
+}
+
+func eleventyLocalPreviewInputDir(runtime config.SiteRuntime) (string, error) {
+	inputDir := strings.TrimSpace(runtime.ProductionContentDir)
+	if inputDir == "" {
+		inputDir = strings.TrimSpace(runtime.ContentDir)
+	}
+	if inputDir == "" {
+		return "", fmt.Errorf("Eleventy local preview content directory is required")
+	}
+	if filepath.IsAbs(inputDir) {
+		repoPath, err := filepath.Abs(strings.TrimSpace(runtime.RepoPath))
+		if err != nil {
+			return "", fmt.Errorf("resolve Eleventy local preview repository: %w", err)
+		}
+		relative, err := filepath.Rel(repoPath, filepath.Clean(inputDir))
+		if err != nil || !isSafeLocalPreviewRelativePath(relative) {
+			return "", fmt.Errorf("Eleventy local preview content directory must be inside the project repository")
+		}
+		inputDir = relative
+	}
+	inputDir = filepath.Clean(inputDir)
+	if !isSafeLocalPreviewRelativePath(inputDir) {
+		return "", fmt.Errorf("invalid Eleventy local preview content directory %q", inputDir)
+	}
+	return inputDir, nil
+}
+
+func eleventyLocalPreviewPublicDir(runtime config.SiteRuntime) (string, error) {
+	publicDir := strings.TrimSpace(runtime.PublicDir)
+	if publicDir == "" {
+		publicDir = "public"
+	}
+	publicDir = filepath.Clean(publicDir)
+	if !isSafeLocalPreviewRelativePath(publicDir) {
+		return "", fmt.Errorf("invalid Eleventy local preview public directory %q", publicDir)
+	}
+	return publicDir, nil
+}
+
+func isSafeLocalPreviewRelativePath(value string) bool {
+	if value == "" || value == "." || filepath.IsAbs(value) {
+		return false
+	}
+	return value != ".." && !strings.HasPrefix(value, ".."+string(filepath.Separator))
+}
+
+func isLocalPreviewPathAncestor(ancestor, target string) bool {
+	relative, err := filepath.Rel(ancestor, target)
+	return err == nil && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+// createEleventyLocalPreviewProjectOverlay creates a project-root filesystem
+// view. Configuration, package metadata and non-special directories remain
+// production references; content and public are materialized in the supplied
+// temporary project root so generators cannot write those trees back to the
+// production repository.
+func createEleventyLocalPreviewProjectOverlay(sourceRoot, projectRoot, inputDir, publicDir, contentSource string) error {
+	sourceRoot, err := filepath.Abs(strings.TrimSpace(sourceRoot))
+	if err != nil {
+		return fmt.Errorf("resolve Eleventy project repository: %w", err)
+	}
+	projectRoot, err = filepath.Abs(strings.TrimSpace(projectRoot))
+	if err != nil {
+		return fmt.Errorf("resolve Eleventy preview project root: %w", err)
+	}
+	contentSource, err = filepath.Abs(strings.TrimSpace(contentSource))
+	if err != nil {
+		return fmt.Errorf("resolve Eleventy preview content source: %w", err)
+	}
+	if filepath.Clean(sourceRoot) == filepath.Clean(projectRoot) {
+		return fmt.Errorf("Eleventy preview project root must differ from production repository")
+	}
+	if !isSafeLocalPreviewRelativePath(inputDir) || !isSafeLocalPreviewRelativePath(publicDir) {
+		return fmt.Errorf("Eleventy preview project directories must be safe relative paths")
+	}
+	if inputDir == publicDir || isLocalPreviewPathAncestor(inputDir, publicDir) || isLocalPreviewPathAncestor(publicDir, inputDir) {
+		return fmt.Errorf("Eleventy preview content and public directories must not overlap")
+	}
+	if info, err := os.Stat(sourceRoot); err != nil {
+		return fmt.Errorf("stat Eleventy project repository: %w", err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("Eleventy project repository must be a directory")
+	}
+	if info, err := os.Stat(contentSource); err != nil {
+		return fmt.Errorf("stat Eleventy preview content source: %w", err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("Eleventy preview content source must be a directory")
+	}
+	if err := os.MkdirAll(projectRoot, 0755); err != nil {
+		return fmt.Errorf("create Eleventy preview project root: %w", err)
+	}
+	if err := materializeEleventyPreviewTree(sourceRoot, projectRoot, ".", inputDir, publicDir, contentSource); err != nil {
+		return err
+	}
+	if err := ensureEleventyPreviewDirectory(projectRoot, inputDir, contentSource); err != nil {
+		return err
+	}
+	if err := ensureEleventyPreviewDirectory(projectRoot, publicDir, ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+func materializeEleventyPreviewTree(sourceRoot, projectRoot, relative, inputDir, publicDir, contentSource string) error {
+	if relative == inputDir {
+		destination := filepath.Join(projectRoot, relative)
+		return copyLocalPreviewContentTree(contentSource, destination)
+	}
+	if relative == publicDir {
+		return os.MkdirAll(filepath.Join(projectRoot, relative), 0755)
+	}
+
+	sourcePath := sourceRoot
+	destinationPath := projectRoot
+	if relative != "." {
+		sourcePath = filepath.Join(sourceRoot, relative)
+		destinationPath = filepath.Join(projectRoot, relative)
+	}
+
+	if relative != "." && (isLocalPreviewPathAncestor(relative, inputDir) || isLocalPreviewPathAncestor(relative, publicDir)) {
+		if err := os.MkdirAll(destinationPath, 0755); err != nil {
+			return fmt.Errorf("create Eleventy preview directory %s: %w", relative, err)
+		}
+		entries, err := os.ReadDir(sourcePath)
+		if os.IsNotExist(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read Eleventy preview directory %s: %w", relative, err)
+		}
+		for _, entry := range entries {
+			if err := materializeEleventyPreviewTree(sourceRoot, projectRoot, filepath.Join(relative, entry.Name()), inputDir, publicDir, contentSource); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if relative == "." {
+		entries, err := os.ReadDir(sourcePath)
+		if err != nil {
+			return fmt.Errorf("read Eleventy project repository: %w", err)
+		}
+		for _, entry := range entries {
+			if entry.Name() == ".git" {
+				continue
+			}
+			if err := materializeEleventyPreviewTree(sourceRoot, projectRoot, entry.Name(), inputDir, publicDir, contentSource); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if entryInfo, err := os.Lstat(sourcePath); err != nil {
+		return fmt.Errorf("stat Eleventy preview source %s: %w", relative, err)
+	} else if entryInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("Eleventy preview production symlinks are not supported: %s", relative)
+	} else if entryInfo.IsDir() {
+		return linkEleventyPreviewDirectory(sourcePath, destinationPath)
+	} else if entryInfo.Mode().IsRegular() {
+		if err := os.MkdirAll(filepath.Dir(destinationPath), 0755); err != nil {
+			return err
+		}
+		return copyLocalPreviewFile(sourcePath, destinationPath, entryInfo.Mode().Perm())
+	}
+	return fmt.Errorf("unsupported Eleventy preview production file type: %s", relative)
+}
+
+func ensureEleventyPreviewDirectory(projectRoot, relative, source string) error {
+	destination := filepath.Join(projectRoot, relative)
+	if info, err := os.Stat(destination); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("Eleventy preview path is not a directory: %s", relative)
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.MkdirAll(destination, 0755); err != nil {
+		return fmt.Errorf("create Eleventy preview directory %s: %w", relative, err)
+	}
+	if source != "" {
+		return copyLocalPreviewContentTree(source, destination)
+	}
+	return nil
+}
+
+func linkEleventyPreviewDirectory(source, destination string) error {
+	if err := os.MkdirAll(filepath.Dir(destination), 0755); err != nil {
+		return err
+	}
+	if err := os.Symlink(source, destination); err == nil {
+		return nil
+	} else if goRuntime.GOOS != "windows" {
+		return fmt.Errorf("link Eleventy preview directory %s: %w", destination, err)
+	}
+
+	command := exec.Command("cmd.exe", "/d", "/s", "/c", fmt.Sprintf("mklink /J %q %q", destination, source))
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("link Eleventy preview directory %s: %w (%s)", destination, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}

--- a/pkg/services/local_preview_project_test.go
+++ b/pkg/services/local_preview_project_test.go
@@ -1,0 +1,86 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEleventyLocalPreviewProjectOverlayKeepsProjectRelativePaths(t *testing.T) {
+	repo := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(repo, "src", "posts"),
+		filepath.Join(repo, "_includes"),
+		filepath.Join(repo, "_data"),
+		filepath.Join(repo, "_layouts"),
+		filepath.Join(repo, "public"),
+	} {
+		if err := os.MkdirAll(directory, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "posts", "production.md"), []byte("production"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "_includes", "post.njk"), []byte("include"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "_data", "site.json"), []byte(`{"name":"daily-blog"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "public", "production.html"), []byte("must not be copied"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"devDependencies":{"@11ty/eleventy":"^3.0.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	shadow := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(shadow, "posts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shadow, "posts", "draft.md"), []byte("unsaved"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	if err := os.RemoveAll(project); err != nil {
+		t.Fatal(err)
+	}
+	if err := createEleventyLocalPreviewProjectOverlay(repo, project, "src", "public", shadow); err != nil {
+		t.Fatalf("createEleventyLocalPreviewProjectOverlay() error = %v", err)
+	}
+
+	assertFileContent(t, filepath.Join(project, "src", "posts", "draft.md"), "unsaved")
+	if _, err := os.Stat(filepath.Join(project, "src", "posts", "production.md")); !os.IsNotExist(err) {
+		t.Fatalf("production content leaked into shadow input: %v", err)
+	}
+	assertFileContent(t, filepath.Join(project, "_includes", "post.njk"), "include")
+	assertFileContent(t, filepath.Join(project, "_data", "site.json"), `{"name":"daily-blog"}`)
+	if _, err := os.Stat(filepath.Join(project, "public", "production.html")); !os.IsNotExist(err) {
+		t.Fatalf("production public output leaked into preview output: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(project, "public", "generated"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "public", "generated", "image.txt"), []byte("preview"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "public", "generated", "image.txt")); !os.IsNotExist(err) {
+		t.Fatalf("preview output modified production public directory: %v", err)
+	}
+
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if string(content) != want {
+		t.Fatalf("content at %s = %q, want %q", path, content, want)
+	}
+}

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -51,9 +51,9 @@ type localPreviewReclaimState struct {
 }
 
 // LocalPreviewWorkspaceManager owns ephemeral shadow content directories. The
-// original repository remains the Hugo source root for configuration, theme,
-// layouts, static files and assets; only contentDir is redirected to this
-// workspace.
+// original repository remains the generator source root for configuration,
+// theme, layouts, static files and assets; only the content input is redirected
+// to this workspace.
 type LocalPreviewWorkspaceManager struct {
 	root             string
 	mu               sync.Mutex
@@ -266,7 +266,8 @@ func (m *LocalPreviewWorkspaceManager) Status(siteID string) (LocalPreviewWorksp
 
 // SyncContentResource mirrors a content-directory resource change made through
 // the normal CMS media API into an already-active shadow workspace. Static
-// resources do not need this because Hugo still uses the original source root.
+// resources do not need this because generators still use the original source
+// root for static files.
 func (m *LocalPreviewWorkspaceManager) SyncContentResource(runtime config.SiteRuntime, repoPath string, deleted bool) (bool, error) {
 	if runtime.ID == "" {
 		return false, fmt.Errorf("local preview site ID is required")
@@ -349,8 +350,8 @@ func (m *LocalPreviewWorkspaceManager) Release(siteID, draftID string) (bool, er
 // ClaimStale atomically marks an expired workspace as reclaiming. While the
 // claim is held, heartbeat/update/release/resource-sync operations for the same
 // site cannot mutate or revive the session. This claim must be acquired before
-// stopping Hugo so a racing heartbeat cannot leave a fresh session with a
-// stopped process.
+// stopping the generator so a racing heartbeat cannot leave a fresh session
+// with a stopped process.
 func (m *LocalPreviewWorkspaceManager) ClaimStale(siteID string) (LocalPreviewReclaim, bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -395,8 +396,8 @@ func (m *LocalPreviewWorkspaceManager) FinishReclaim(claim LocalPreviewReclaim) 
 }
 
 // CancelReclaim releases a stale claim without removing the workspace. It is
-// used when Hugo cannot be stopped; the expired session remains stale and can
-// be reclaimed again, but it still cannot be revived by heartbeat/update.
+// used when the generator cannot be stopped; the expired session remains stale
+// and can be reclaimed again, but it still cannot be revived by heartbeat/update.
 func (m *LocalPreviewWorkspaceManager) CancelReclaim(claim LocalPreviewReclaim) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -32,6 +32,7 @@ type LocalPreviewWorkspace struct {
 	DraftID     string
 	ArticlePath string
 	ContentDir  string
+	ProjectDir  string
 	Revision    uint64
 	LastSeenAt  time.Time
 }
@@ -50,10 +51,10 @@ type localPreviewReclaimState struct {
 	token   uint64
 }
 
-// LocalPreviewWorkspaceManager owns ephemeral shadow content directories. The
-// original repository remains the generator source root for configuration,
-// theme, layouts, static files and assets; only the content input is redirected
-// to this workspace.
+// LocalPreviewWorkspaceManager owns ephemeral shadow content directories and,
+// for Eleventy, a temporary project-root overlay. Hugo keeps the original
+// repository as its generator source root; Eleventy receives production
+// project references with only content/public materialized into the overlay.
 type LocalPreviewWorkspaceManager struct {
 	root             string
 	mu               sync.Mutex
@@ -188,11 +189,28 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 		}
 	} else {
 		workspaceRoot := filepath.Join(m.root, runtime.ID, draftID)
-		contentDir := filepath.Join(workspaceRoot, "content")
 		if err := os.RemoveAll(workspaceRoot); err != nil {
 			return LocalPreviewWorkspace{}, false, false, fmt.Errorf("reset local preview workspace: %w", err)
 		}
-		if err := copyLocalPreviewContentTree(sourceContentDir, contentDir); err != nil {
+
+		contentDir := filepath.Join(workspaceRoot, "content")
+		projectDir := ""
+		if isEleventyLocalPreviewGenerator(runtime.Generator) {
+			inputDir, err := eleventyLocalPreviewInputDir(runtime)
+			if err != nil {
+				return LocalPreviewWorkspace{}, false, false, err
+			}
+			publicDir, err := eleventyLocalPreviewPublicDir(runtime)
+			if err != nil {
+				return LocalPreviewWorkspace{}, false, false, err
+			}
+			contentDir = filepath.Join(workspaceRoot, inputDir)
+			if err := createEleventyLocalPreviewProjectOverlay(runtime.RepoPath, workspaceRoot, inputDir, publicDir, sourceContentDir); err != nil {
+				_ = os.RemoveAll(workspaceRoot)
+				return LocalPreviewWorkspace{}, false, false, err
+			}
+			projectDir = workspaceRoot
+		} else if err := copyLocalPreviewContentTree(sourceContentDir, contentDir); err != nil {
 			_ = os.RemoveAll(workspaceRoot)
 			return LocalPreviewWorkspace{}, false, false, err
 		}
@@ -201,6 +219,7 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 			DraftID:     draftID,
 			ArticlePath: filepath.ToSlash(articlePath),
 			ContentDir:  contentDir,
+			ProjectDir:  projectDir,
 			LastSeenAt:  now,
 		}
 		created = true
@@ -266,8 +285,8 @@ func (m *LocalPreviewWorkspaceManager) Status(siteID string) (LocalPreviewWorksp
 
 // SyncContentResource mirrors a content-directory resource change made through
 // the normal CMS media API into an already-active shadow workspace. Static
-// resources do not need this because generators still use the original source
-// root for static files.
+// resources do not need this because the generator overlay still references
+// the production static tree.
 func (m *LocalPreviewWorkspaceManager) SyncContentResource(runtime config.SiteRuntime, repoPath string, deleted bool) (bool, error) {
 	if runtime.ID == "" {
 		return false, fmt.Errorf("local preview site ID is required")

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -224,7 +224,7 @@ func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftI
 
 // Heartbeat renews a live lease without changing content. Once the lease has
 // expired, the browser must reclaim/restart instead of reviving a session whose
-// Hugo process may already be stopping.
+// generator process may already be stopping.
 func (m *LocalPreviewWorkspaceManager) Heartbeat(siteID, draftID string) (LocalPreviewWorkspace, error) {
 	if err := validateDraftID(draftID); err != nil {
 		return LocalPreviewWorkspace{}, err
@@ -407,7 +407,7 @@ func (m *LocalPreviewWorkspaceManager) CancelReclaim(claim LocalPreviewReclaim) 
 }
 
 // ReleaseStale atomically claims and removes an expired workspace. Callers that
-// must stop the Hugo process before deleting the workspace should use
+// must stop the generator process before deleting the workspace should use
 // ClaimStale followed by FinishReclaim instead.
 func (m *LocalPreviewWorkspaceManager) ReleaseStale(siteID string) (bool, error) {
 	claim, claimed, err := m.ClaimStale(siteID)

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -58,6 +58,66 @@ func TestLocalPreviewWorkspaceMirrorsAndUpdatesContent(t *testing.T) {
 	}
 }
 
+func TestEleventyLocalPreviewWorkspaceUsesProjectRootOverlay(t *testing.T) {
+	repo := t.TempDir()
+	for _, directory := range []string{
+		filepath.Join(repo, "src", "posts"),
+		filepath.Join(repo, "_includes"),
+		filepath.Join(repo, "_data"),
+		filepath.Join(repo, "public"),
+	} {
+		if err := os.MkdirAll(directory, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "src", "posts", "one.md"), []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "_includes", "post.njk"), []byte("include"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"devDependencies":{"@11ty/eleventy":"^3.0.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "package-lock.json"), []byte(`{"lockfileVersion":3}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{
+		ID:                   "daily",
+		RepoPath:             repo,
+		Generator:            "eleventy",
+		ContentDir:           "src",
+		ProductionContentDir: "src",
+		PublicDir:            "public",
+	}
+	workspace, created, applied, err := manager.Update(runtime, "draft-1", "posts/one.md", 1, []byte("draft"))
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if !created || !applied || workspace.ProjectDir == "" {
+		t.Fatalf("created=%v applied=%v project=%q", created, applied, workspace.ProjectDir)
+	}
+	if workspace.ContentDir != filepath.Join(workspace.ProjectDir, "src") {
+		t.Fatalf("content dir = %q, want project-relative src under %q", workspace.ContentDir, workspace.ProjectDir)
+	}
+	assertFileContent(t, filepath.Join(workspace.ProjectDir, "src", "posts", "one.md"), "draft")
+	assertFileContent(t, filepath.Join(workspace.ProjectDir, "_includes", "post.njk"), "include")
+	if _, err := os.Stat(filepath.Join(workspace.ProjectDir, "public", "production.html")); !os.IsNotExist(err) {
+		t.Fatalf("production public files leaked into workspace: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, "src", "posts", "one.md")); err != nil {
+		t.Fatalf("production content disappeared: %v", err)
+	}
+	if _, err := manager.Release(runtime.ID, "draft-1"); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
 func TestLocalPreviewWorkspaceRejectsStaleRevision(t *testing.T) {
 	repo := makeLocalPreviewWorkspaceRepo(t)
 	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -296,27 +296,32 @@ func runEleventyJSON(ctx context.Context, runtime config.SiteRuntime) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
-	productionInput, err := eleventyProductionContentDir(runtime)
+	projectDir, outputDir, err := prepareEleventyLocalPreviewProject(runtime)
 	if err != nil {
 		return nil, err
 	}
+	cleanup := localPreviewProcessCleanup(runtime)
+	defer cleanup()
 	scriptPath, err := eleventyLocalPreviewScriptPath()
 	if err != nil {
 		return nil, err
 	}
-	outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+	inputDir, err := eleventyLocalPreviewInputDir(runtime)
 	if err != nil {
 		return nil, err
 	}
+	commandRuntime := runtime
+	commandRuntime.RepoPath = projectDir
+	commandRuntime.ContentDir = inputDir
+	commandRuntime.LocalPreviewProjectDir = projectDir
 	args := eleventyNodeCommandArgs(pm, scriptPath,
 		"--json",
-		"--input", runtime.ContentDir,
-		"--production-input", productionInput,
+		"--input", inputDir,
 		"--output", outputDir,
 	)
 	cmd := generatorCommandContextWithEnv(
 		ctx,
-		runtime,
+		commandRuntime,
 		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development"},
 		pm.Bin,
 		args...,

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -9,6 +9,7 @@ import (
 	"hugo-cms/pkg/config"
 	"io"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -292,21 +293,27 @@ func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Contex
 }
 
 func runEleventyJSON(ctx context.Context, runtime config.SiteRuntime) ([]byte, error) {
-	pm, err := detectEleventyPackageManager(runtime.RepoPath)
+	projectDir, outputDir, cleanup, err := prepareEleventyResolverProject(runtime)
 	if err != nil {
 		return nil, err
 	}
-	projectDir, outputDir, err := prepareEleventyLocalPreviewProject(runtime)
-	if err != nil {
-		return nil, err
-	}
-	cleanup := localPreviewProcessCleanup(runtime)
 	defer cleanup()
+
+	sourceRepoPath := strings.TrimSpace(runtime.LocalPreviewSourceRepoPath)
+	if sourceRepoPath == "" {
+		sourceRepoPath = runtime.RepoPath
+	}
+	pm, err := detectEleventyPackageManager(sourceRepoPath)
+	if err != nil {
+		return nil, err
+	}
 	scriptPath, err := eleventyLocalPreviewScriptPath()
 	if err != nil {
 		return nil, err
 	}
-	inputDir, err := eleventyLocalPreviewInputDir(runtime)
+	inputRuntime := runtime
+	inputRuntime.RepoPath = sourceRepoPath
+	inputDir, err := eleventyLocalPreviewInputDir(inputRuntime)
 	if err != nil {
 		return nil, err
 	}
@@ -327,6 +334,39 @@ func runEleventyJSON(ctx context.Context, runtime config.SiteRuntime) ([]byte, e
 		args...,
 	)
 	return cmd.Output()
+}
+
+func prepareEleventyResolverProject(runtime config.SiteRuntime) (string, string, func(), error) {
+	sourceRepoPath := strings.TrimSpace(runtime.LocalPreviewSourceRepoPath)
+	if sourceRepoPath == "" {
+		sourceRepoPath = runtime.RepoPath
+	}
+	inputRuntime := runtime
+	inputRuntime.RepoPath = sourceRepoPath
+	inputDir, err := eleventyLocalPreviewInputDir(inputRuntime)
+	if err != nil {
+		return "", "", func() {}, err
+	}
+	publicDir, err := eleventyLocalPreviewPublicDir(runtime)
+	if err != nil {
+		return "", "", func() {}, err
+	}
+
+	projectDir, err := os.MkdirTemp("", "hugo-cms-eleventy-resolver-*")
+	if err != nil {
+		return "", "", func() {}, fmt.Errorf("create Eleventy resolver project: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(projectDir) }
+
+	contentSource := strings.TrimSpace(runtime.ContentDir)
+	if !filepath.IsAbs(contentSource) {
+		contentSource = filepath.Join(sourceRepoPath, inputDir)
+	}
+	if err := createEleventyLocalPreviewProjectOverlay(sourceRepoPath, projectDir, inputDir, publicDir, contentSource); err != nil {
+		cleanup()
+		return "", "", func() {}, err
+	}
+	return projectDir, filepath.Join(projectDir, publicDir), cleanup, nil
 }
 
 type eleventyPreviewJSONEntry struct {

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"hugo-cms/pkg/config"
 	"io"
@@ -28,6 +29,8 @@ func NewPreviewURLResolver(generator string) (PreviewURLResolver, error) {
 	switch strings.ToLower(strings.TrimSpace(generator)) {
 	case "", "hugo":
 		return &hugoPreviewURLResolver{}, nil
+	case "eleventy", "11ty":
+		return &eleventyPreviewURLResolver{}, nil
 	default:
 		return nil, fmt.Errorf("preview URL resolution is not supported for generator %q", generator)
 	}
@@ -56,6 +59,7 @@ func (resolver *hugoPreviewURLResolver) ResolveArticleURL(ctx context.Context, r
 	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
 		return "", fmt.Errorf("preview workspace article does not match request")
 	}
+	runtime.ContentDir = workspace.ContentDir
 	previewURL, err := localPreviewResolverURL(runtime)
 	if err != nil {
 		return "", err
@@ -236,3 +240,152 @@ func localPreviewArticleURL(previewURL, resolvedURL string) (string, error) {
 }
 
 var _ PreviewURLResolver = (*hugoPreviewURLResolver)(nil)
+
+type eleventyPreviewURLResolver struct {
+	run func(context.Context, config.SiteRuntime) ([]byte, error)
+}
+
+func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Context, runtime config.SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (string, error) {
+	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
+	if articlePath == "." || filepath.IsAbs(articlePath) {
+		return "", fmt.Errorf("invalid preview article path")
+	}
+	if workspace.ContentDir == "" {
+		return "", fmt.Errorf("preview workspace content directory is required")
+	}
+	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
+		return "", fmt.Errorf("preview workspace article does not match request")
+	}
+	runtime.ContentDir = workspace.ContentDir
+	previewURL, err := localPreviewResolverURL(runtime)
+	if err != nil {
+		return "", err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, previewURLResolveTimeout)
+	defer cancel()
+
+	run := resolver.run
+	if run == nil {
+		run = runEleventyJSON
+	}
+	output, err := run(ctx, runtime)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("eleventy URL resolution timed out after %s", previewURLResolveTimeout)
+		}
+		return "", fmt.Errorf("eleventy URL resolution failed: %w", err)
+	}
+	resolvedURL, err := parseEleventyJSON(output, runtime, articlePath)
+	if err != nil {
+		return "", err
+	}
+	return localPreviewArticleURL(previewURL, resolvedURL)
+}
+
+func runEleventyJSON(ctx context.Context, runtime config.SiteRuntime) ([]byte, error) {
+	pm, err := detectEleventyPackageManager(runtime.RepoPath)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]string{}, pm.Args...)
+	args = append(args,
+		"--input", runtime.ContentDir,
+		"--to=json",
+		"--quiet",
+	)
+	cmd := generatorCommandContextWithEnv(
+		ctx,
+		runtime,
+		[]string{"NODE_ENV=development", "ELEVENTY_ENV=development"},
+		pm.Bin,
+		args...,
+	)
+	return cmd.Output()
+}
+
+type eleventyPreviewJSONEntry struct {
+	InputPath  string          `json:"inputPath"`
+	URL        json.RawMessage `json:"url"`
+	OutputPath string          `json:"outputPath"`
+	Data       struct {
+		Page struct {
+			InputPath string          `json:"inputPath"`
+			URL       json.RawMessage `json:"url"`
+		} `json:"page"`
+	} `json:"data"`
+}
+
+func parseEleventyJSON(output []byte, runtime config.SiteRuntime, articlePath string) (string, error) {
+	var entries []eleventyPreviewJSONEntry
+	if err := json.Unmarshal(output, &entries); err != nil {
+		return "", fmt.Errorf("parse eleventy JSON output: %w", err)
+	}
+	for _, entry := range entries {
+		inputPath := entry.InputPath
+		if strings.TrimSpace(inputPath) == "" {
+			inputPath = entry.Data.Page.InputPath
+		}
+		if !eleventyInputPathMatches(runtime.ContentDir, articlePath, inputPath) {
+			continue
+		}
+		resolvedURL := jsonStringValue(entry.URL)
+		if resolvedURL == "" {
+			resolvedURL = jsonStringValue(entry.Data.Page.URL)
+		}
+		if resolvedURL == "" {
+			continue
+		}
+		return resolvedURL, nil
+	}
+	return "", fmt.Errorf("eleventy did not resolve article %q", articlePath)
+}
+
+func jsonStringValue(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" || string(raw) == "false" {
+		return ""
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func eleventyInputPathMatches(inputDir, articlePath, listedPath string) bool {
+	target := normalizePreviewPath(articlePath)
+	candidate := normalizePreviewPath(listedPath)
+	if target == "" || candidate == "" {
+		return false
+	}
+	if candidate == target {
+		return true
+	}
+	inputDir = strings.TrimSpace(inputDir)
+	if inputDir == "" {
+		return false
+	}
+	inputBase := normalizePreviewPath(filepath.Base(filepath.Clean(inputDir)))
+	if inputBase != "" && (candidate == inputBase+"/"+target || strings.HasSuffix(candidate, "/"+inputBase+"/"+target)) {
+		return true
+	}
+	expected := normalizePreviewPath(filepath.Join(inputDir, filepath.FromSlash(articlePath)))
+	return expected != "" && candidate == expected
+}
+
+func normalizePreviewPath(value string) string {
+	value = strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if value == "" {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "./")
+	value = strings.TrimSuffix(path.Clean(value), "/")
+	if value == "." {
+		return ""
+	}
+	return value
+}
+
+var _ PreviewURLResolver = (*eleventyPreviewURLResolver)(nil)

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -367,11 +367,12 @@ func eleventyInputPathMatches(inputDir, articlePath, listedPath string) bool {
 	if inputDir == "" {
 		return false
 	}
-	inputBase := normalizePreviewPath(filepath.Base(filepath.Clean(inputDir)))
+	normalizedInputDir := normalizePreviewPath(inputDir)
+	inputBase := path.Base(normalizedInputDir)
 	if inputBase != "" && (candidate == inputBase+"/"+target || strings.HasSuffix(candidate, "/"+inputBase+"/"+target)) {
 		return true
 	}
-	expected := normalizePreviewPath(filepath.Join(inputDir, filepath.FromSlash(articlePath)))
+	expected := path.Join(normalizedInputDir, target)
 	return expected != "" && candidate == expected
 }
 

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -59,6 +59,9 @@ func (resolver *hugoPreviewURLResolver) ResolveArticleURL(ctx context.Context, r
 	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
 		return "", fmt.Errorf("preview workspace article does not match request")
 	}
+	if strings.TrimSpace(runtime.ProductionContentDir) == "" {
+		runtime.ProductionContentDir = runtime.ContentDir
+	}
 	runtime.ContentDir = workspace.ContentDir
 	previewURL, err := localPreviewResolverURL(runtime)
 	if err != nil {
@@ -256,6 +259,9 @@ func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Contex
 	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
 		return "", fmt.Errorf("preview workspace article does not match request")
 	}
+	if strings.TrimSpace(runtime.ProductionContentDir) == "" {
+		runtime.ProductionContentDir = runtime.ContentDir
+	}
 	runtime.ContentDir = workspace.ContentDir
 	previewURL, err := localPreviewResolverURL(runtime)
 	if err != nil {
@@ -290,11 +296,23 @@ func runEleventyJSON(ctx context.Context, runtime config.SiteRuntime) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
-	args := append([]string{}, pm.Args...)
-	args = append(args,
+	productionInput, err := eleventyProductionContentDir(runtime)
+	if err != nil {
+		return nil, err
+	}
+	scriptPath, err := eleventyLocalPreviewScriptPath()
+	if err != nil {
+		return nil, err
+	}
+	outputDir, err := eleventyLocalPreviewOutputDir(runtime)
+	if err != nil {
+		return nil, err
+	}
+	args := eleventyNodeCommandArgs(pm, scriptPath,
+		"--json",
 		"--input", runtime.ContentDir,
-		"--to=json",
-		"--quiet",
+		"--production-input", productionInput,
+		"--output", outputDir,
 	)
 	cmd := generatorCommandContextWithEnv(
 		ctx,

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -7,16 +7,15 @@ import (
 	"testing"
 )
 
-func TestNewPreviewURLResolverSupportsHugoOnly(t *testing.T) {
-	resolver, err := NewPreviewURLResolver("hugo")
-	if err != nil {
-		t.Fatalf("NewPreviewURLResolver(hugo) error = %v", err)
-	}
-	if resolver == nil {
-		t.Fatal("NewPreviewURLResolver(hugo) returned nil")
-	}
-	if _, err := NewPreviewURLResolver("eleventy"); err == nil {
-		t.Fatal("NewPreviewURLResolver(eleventy) should require a dedicated resolver")
+func TestNewPreviewURLResolverSupportsConfiguredGenerators(t *testing.T) {
+	for _, generator := range []string{"hugo", "eleventy", "11ty"} {
+		resolver, err := NewPreviewURLResolver(generator)
+		if err != nil {
+			t.Fatalf("NewPreviewURLResolver(%q) error = %v", generator, err)
+		}
+		if resolver == nil {
+			t.Fatalf("NewPreviewURLResolver(%q) returned nil", generator)
+		}
 	}
 }
 
@@ -113,6 +112,61 @@ func TestHugoPreviewURLResolverRejectsMismatchedArticle(t *testing.T) {
 		return nil, nil
 	}}
 	runtime := config.SiteRuntime{ID: "tech", ContentDir: "/tmp/content", LocalPreview: config.LocalPreviewConfig{URL: "https://tech.preview.example.com/"}}
+	workspace := LocalPreviewWorkspace{ArticlePath: "posts/one.md", ContentDir: "/tmp/content"}
+	if _, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md"); err == nil {
+		t.Fatal("ResolveArticleURL() should reject a mismatched article")
+	}
+}
+
+func TestEleventyPreviewURLResolverUsesGeneratorMetadataAndLocalOrigin(t *testing.T) {
+	runtime := config.SiteRuntime{
+		ID:           "daily-blog",
+		RepoPath:     "/repo",
+		ContentDir:   "/tmp/shadow/daily-blog/content",
+		Generator:    "eleventy",
+		LocalPreview: config.LocalPreviewConfig{URL: "https://daily-blog.preview.example.com/preview/"},
+	}
+	workspace := LocalPreviewWorkspace{
+		SiteID:      runtime.ID,
+		DraftID:     "draft-1",
+		ArticlePath: "posts/one.md",
+		ContentDir:  runtime.ContentDir,
+		Revision:    3,
+	}
+	resolver := &eleventyPreviewURLResolver{run: func(_ context.Context, got config.SiteRuntime) ([]byte, error) {
+		if got.ContentDir != workspace.ContentDir {
+			t.Fatalf("resolver content directory = %q, want %q", got.ContentDir, workspace.ContentDir)
+		}
+		return []byte(`[{"inputPath":"/tmp/shadow/daily-blog/content/posts/one.md","outputPath":"/tmp/output/custom/index.html","url":"https://production.example.com/custom/"}]`), nil
+	}}
+
+	got, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, workspace.ArticlePath)
+	if err != nil {
+		t.Fatalf("ResolveArticleURL() error = %v", err)
+	}
+	if got != "https://daily-blog.preview.example.com/custom/" {
+		t.Fatalf("resolved URL = %q", got)
+	}
+}
+
+func TestParseEleventyJSONMatchesRelativeInputAndDataPageURL(t *testing.T) {
+	runtime := config.SiteRuntime{ContentDir: `C:\preview\daily-blog\content`}
+	output := []byte(`[{"inputPath":"content/posts/one.md","data":{"page":{"url":"/posts/one/"}}}]`)
+	got, err := parseEleventyJSON(output, runtime, "posts/one.md")
+	if err != nil {
+		t.Fatalf("parseEleventyJSON() error = %v", err)
+	}
+	if got != "/posts/one/" {
+		t.Fatalf("parseEleventyJSON() = %q", got)
+	}
+}
+
+func TestEleventyPreviewURLResolverRejectsMismatchedArticle(t *testing.T) {
+	resolver := &eleventyPreviewURLResolver{run: func(context.Context, config.SiteRuntime) ([]byte, error) {
+		t.Fatal("Eleventy should not run for a mismatched article")
+		return nil, nil
+	}}
+	runtime := config.SiteRuntime{ID: "daily-blog", ContentDir: "/tmp/content", LocalPreview: config.LocalPreviewConfig{URL: "https://daily-blog.preview.example.com/"}}
 	workspace := LocalPreviewWorkspace{ArticlePath: "posts/one.md", ContentDir: "/tmp/content"}
 	if _, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md"); err == nil {
 		t.Fatal("ResolveArticleURL() should reject a mismatched article")

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -3,6 +3,8 @@ package services
 import (
 	"context"
 	"hugo-cms/pkg/config"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -146,6 +148,62 @@ func TestEleventyPreviewURLResolverUsesGeneratorMetadataAndLocalOrigin(t *testin
 	}
 	if got != "https://daily-blog.preview.example.com/custom/" {
 		t.Fatalf("resolved URL = %q", got)
+	}
+}
+
+func TestEleventyResolverUsesDedicatedProjectAndOutput(t *testing.T) {
+	production := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(production, "src", "posts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(production, "public"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(production, "src", "posts", "one.md"), []byte("production"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	shadow := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(shadow, "posts"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(shadow, "posts", "one.md"), []byte("draft"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	liveProject := t.TempDir()
+	if err := createEleventyLocalPreviewProjectOverlay(production, liveProject, "src", "public", shadow); err != nil {
+		t.Fatalf("create live overlay: %v", err)
+	}
+	liveOutput := filepath.Join(liveProject, "public")
+	if err := os.WriteFile(filepath.Join(liveOutput, "existing.html"), []byte("live"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := config.SiteRuntime{
+		RepoPath:                   liveProject,
+		ContentDir:                 filepath.Join(liveProject, "src"),
+		ProductionContentDir:       "src",
+		PublicDir:                  "public",
+		LocalPreviewProjectDir:     liveProject,
+		LocalPreviewSourceRepoPath: production,
+	}
+	resolverProject, resolverOutput, cleanup, err := prepareEleventyResolverProject(runtime)
+	if err != nil {
+		t.Fatalf("prepareEleventyResolverProject() error = %v", err)
+	}
+	defer cleanup()
+	if resolverProject == liveProject || resolverOutput == liveOutput {
+		t.Fatalf("resolver reused live project/output: project=%q output=%q", resolverProject, resolverOutput)
+	}
+	if _, err := os.Stat(filepath.Join(liveOutput, "existing.html")); err != nil {
+		t.Fatalf("live output was removed by resolver preparation: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(resolverOutput, "resolved.html"), []byte("resolver"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(liveOutput, "resolved.html")); !os.IsNotExist(err) {
+		t.Fatalf("resolver output leaked into live output: %v", err)
 	}
 }
 

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -42,8 +42,8 @@ function parseArguments(argv) {
     }
     throw new Error(`Unknown Eleventy local preview argument: ${argument}`);
   }
-  if (!options.input || !options.productionInput) {
-    throw new Error("--input and --production-input are required");
+  if (!options.input) {
+    throw new Error("--input is required");
   }
   if (!options.json && (!options.output || !options.port || !options.host)) {
     throw new Error("--output, --port and --host are required for local preview serving");
@@ -51,28 +51,13 @@ function parseArguments(argv) {
   return options;
 }
 
-function relativeDirectory(from, target) {
-  const relative = path.relative(path.resolve(from), path.resolve(target));
-  return relative || ".";
-}
-
 function configureProjectDirectories(eleventyConfig, options, notify) {
   eleventyConfig.userConfig.on("eleventy.beforeConfig", () => {
     const directories = eleventyConfig.directories;
-    const productionInput = directories.input;
-    const productionData = directories.data;
-    const productionIncludes = directories.includes;
-    const productionLayouts = directories.layouts;
-
-    // Read the user's configuration against the production repository first,
-    // then replace only the input/output roots. Rebased directory values keep
-    // ../_includes, global data and layout paths anchored to the repository.
+    // The process cwd is a temporary project-root overlay. Keep Eleventy's
+    // normal project-relative resolution intact and replace only the two CMS
+    // controlled roots: content input and generated public output.
     directories.setInput(options.input);
-    directories.setData(relativeDirectory(options.input, productionData));
-    directories.setIncludes(relativeDirectory(options.input, productionIncludes));
-    if (productionLayouts) {
-      directories.setLayouts(relativeDirectory(options.input, productionLayouts));
-    }
     directories.setOutput(options.output);
 
   });
@@ -269,7 +254,7 @@ async function main(argv = process.argv.slice(2)) {
   let server;
   let stopping = false;
   const notify = () => server?.broadcast({ type: "eleventy.reload" });
-  const eleventy = new Eleventy(options.productionInput, options.output, {
+  const eleventy = new Eleventy(options.input, options.output, {
     source: "script",
     runMode: options.json ? "build" : "serve",
     quietMode: options.json,
@@ -311,5 +296,4 @@ module.exports = {
   findOutputFile,
   listen,
   parseArguments,
-  relativeDirectory,
 };

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const http = require("node:http");
+const path = require("node:path");
+const { createRequire } = require("node:module");
+
+const RELOAD_SCRIPT_PATH = "/__hugo_cms_reload.js";
+const RELOAD_SOCKET_PATH = "/__hugo_cms_live_reload";
+const RELOAD_SCRIPT = `(() => {
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  const socket = new WebSocket(protocol + "//" + location.host + "${RELOAD_SOCKET_PATH}");
+  socket.addEventListener("message", (event) => {
+    try {
+      const message = JSON.parse(event.data);
+      if (message.type === "eleventy.reload") location.reload();
+    } catch (_) {
+      // Ignore malformed development notifications.
+    }
+  });
+})();`;
+
+function parseArguments(argv) {
+  const options = { json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (argument === "--serve") {
+      options.serve = true;
+      continue;
+    }
+    if (argument.startsWith("--") && index + 1 < argv.length) {
+      const key = argument.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      options[key] = argv[++index];
+      continue;
+    }
+    throw new Error(`Unknown Eleventy local preview argument: ${argument}`);
+  }
+  if (!options.input || !options.productionInput) {
+    throw new Error("--input and --production-input are required");
+  }
+  if (!options.json && (!options.output || !options.port || !options.host)) {
+    throw new Error("--output, --port and --host are required for local preview serving");
+  }
+  return options;
+}
+
+function relativeDirectory(from, target) {
+  const relative = path.relative(path.resolve(from), path.resolve(target));
+  return relative || ".";
+}
+
+function configureProjectDirectories(eleventyConfig, options, notify) {
+  eleventyConfig.userConfig.on("eleventy.beforeConfig", () => {
+    const directories = eleventyConfig.directories;
+    const productionInput = directories.input;
+    const productionData = directories.data;
+    const productionIncludes = directories.includes;
+    const productionLayouts = directories.layouts;
+
+    // Read the user's configuration against the production repository first,
+    // then replace only the input/output roots. Rebased directory values keep
+    // ../_includes, global data and layout paths anchored to the repository.
+    directories.setInput(options.input);
+    directories.setData(relativeDirectory(options.input, productionData));
+    directories.setIncludes(relativeDirectory(options.input, productionIncludes));
+    if (productionLayouts) {
+      directories.setLayouts(relativeDirectory(options.input, productionLayouts));
+    }
+    directories.setOutput(options.output);
+
+  });
+
+  if (!options.json) {
+    eleventyConfig.userConfig.on("eleventy.after", notify);
+  }
+}
+
+function getEleventyClass() {
+  const projectRequire = createRequire(path.join(process.cwd(), "package.json"));
+  const loaded = projectRequire("@11ty/eleventy");
+  return loaded.Eleventy || loaded.default || loaded;
+}
+
+function contentType(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+  const types = {
+    ".css": "text/css; charset=utf-8",
+    ".gif": "image/gif",
+    ".html": "text/html; charset=utf-8",
+    ".ico": "image/x-icon",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".js": "text/javascript; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".txt": "text/plain; charset=utf-8",
+    ".webp": "image/webp",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+  };
+  return types[extension] || "application/octet-stream";
+}
+
+function findOutputFile(outputRoot, pathname) {
+  let decodedPath;
+  try {
+    decodedPath = decodeURIComponent(pathname);
+  } catch (_) {
+    return { error: 400 };
+  }
+  const root = path.resolve(outputRoot);
+  const relativePath = decodedPath.replace(/^[/\\]+/, "");
+  const candidate = path.resolve(root, relativePath);
+  if (candidate !== root && !candidate.startsWith(`${root}${path.sep}`)) {
+    return { error: 400 };
+  }
+
+  try {
+    const info = fs.statSync(candidate);
+    if (info.isFile()) return { filePath: candidate, redirect: null };
+    if (info.isDirectory()) {
+      if (!pathname.endsWith("/")) return { redirect: `${pathname}/` };
+      const indexPath = path.join(candidate, "index.html");
+      if (fs.existsSync(indexPath)) return { filePath: indexPath, redirect: null };
+    }
+  } catch (_) {
+    // Continue with Eleventy’s extension and trailing-slash conventions.
+  }
+
+  const htmlPath = `${candidate}.html`;
+  if (fs.existsSync(htmlPath)) return { filePath: htmlPath, redirect: null };
+  const indexPath = path.join(candidate, "index.html");
+  if (fs.existsSync(indexPath)) {
+    return pathname.endsWith("/")
+      ? { filePath: indexPath, redirect: null }
+      : { redirect: `${pathname}/` };
+  }
+  return { error: 404 };
+}
+
+function injectReloadScript(body) {
+  const tag = `<script src="${RELOAD_SCRIPT_PATH}"></script>`;
+  if (body.includes("</head>")) return body.replace("</head>", `${tag}</head>`);
+  if (body.includes("</body>")) return body.replace("</body>", `${tag}</body>`);
+  return `${body}${tag}`;
+}
+
+function websocketFrame(message) {
+  const payload = Buffer.from(JSON.stringify(message));
+  if (payload.length < 126) {
+    return Buffer.concat([Buffer.from([0x81, payload.length]), payload]);
+  }
+  if (payload.length < 65536) {
+    const header = Buffer.alloc(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(payload.length, 2);
+    return Buffer.concat([header, payload]);
+  }
+  throw new Error("Eleventy local preview reload message is too large");
+}
+
+function createLoopbackServer(outputRoot) {
+  const clients = new Set();
+  const server = http.createServer((request, response) => {
+    const requestURL = new URL(request.url || "/", "http://127.0.0.1/");
+    if (requestURL.pathname === RELOAD_SCRIPT_PATH) {
+      const body = Buffer.from(RELOAD_SCRIPT);
+      response.writeHead(200, { "Content-Type": "text/javascript; charset=utf-8", "Content-Length": body.length });
+      if (request.method !== "HEAD") response.end(body);
+      else response.end();
+      return;
+    }
+
+    const match = findOutputFile(outputRoot, requestURL.pathname);
+    if (match.error) {
+      response.writeHead(match.error, { "Content-Type": "text/plain; charset=utf-8" });
+      response.end(match.error === 404 ? "Not found" : "Invalid path");
+      return;
+    }
+    if (match.redirect) {
+      response.writeHead(301, { Location: match.redirect });
+      response.end();
+      return;
+    }
+
+    let body = fs.readFileSync(match.filePath);
+    const type = contentType(match.filePath);
+    if (type.startsWith("text/html")) {
+      body = Buffer.from(injectReloadScript(body.toString("utf8")));
+    }
+    response.writeHead(200, {
+      "Cache-Control": "no-store",
+      "Content-Length": body.length,
+      "Content-Type": type,
+    });
+    if (request.method !== "HEAD") response.end(body);
+    else response.end();
+  });
+
+  server.on("upgrade", (request, socket) => {
+    const requestURL = new URL(request.url || "/", "http://127.0.0.1/");
+    const key = request.headers["sec-websocket-key"];
+    if (requestURL.pathname !== RELOAD_SOCKET_PATH || typeof key !== "string") {
+      socket.destroy();
+      return;
+    }
+    const accept = crypto.createHash("sha1").update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`).digest("base64");
+    socket.write([
+      "HTTP/1.1 101 Switching Protocols",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      `Sec-WebSocket-Accept: ${accept}`,
+      "\r\n",
+    ].join("\r\n"));
+    clients.add(socket);
+    socket.on("close", () => clients.delete(socket));
+    socket.on("error", () => clients.delete(socket));
+  });
+
+  server.broadcast = (message) => {
+    const frame = websocketFrame(message);
+    for (const client of clients) {
+      if (!client.destroyed) client.write(frame);
+    }
+  };
+
+  server.closeAll = () => {
+    for (const client of clients) client.destroy();
+    clients.clear();
+  };
+  return server;
+}
+
+function listen(server, port, host) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host, port: Number(port) });
+  });
+}
+
+async function closeServer(server) {
+  if (!server) return;
+  server.closeAll();
+  if (!server.listening) return;
+  await new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArguments(argv);
+  const Eleventy = getEleventyClass();
+  let server;
+  let stopping = false;
+  const notify = () => server?.broadcast({ type: "eleventy.reload" });
+  const eleventy = new Eleventy(options.productionInput, options.output, {
+    source: "script",
+    runMode: options.json ? "build" : "serve",
+    quietMode: options.json,
+    config: (eleventyConfig) => configureProjectDirectories(eleventyConfig, options, notify),
+  });
+
+  if (options.json) {
+    const result = await eleventy.toJSON();
+    process.stdout.write(JSON.stringify(result));
+    return;
+  }
+
+  await eleventy.init();
+  await eleventy.watch();
+  server = createLoopbackServer(options.output);
+  await listen(server, options.port, options.host);
+
+  const shutdown = async () => {
+    if (stopping) return;
+    stopping = true;
+    await eleventy.stopWatch();
+    await closeServer(server);
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error?.stack || error);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  configureProjectDirectories,
+  createLoopbackServer,
+  findOutputFile,
+  listen,
+  parseArguments,
+  relativeDirectory,
+};

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -9,23 +9,34 @@ const test = require("node:test");
 
 const {
   createLoopbackServer,
+  configureProjectDirectories,
   findOutputFile,
   listen,
   parseArguments,
-  relativeDirectory,
 } = require("./eleventy-local-preview.cjs");
 
-test("rebases production Eleventy directories from a shadow input", () => {
-  const shadowInput = path.join(os.tmpdir(), "homecms-shadow", "content");
-  const productionInput = path.join(os.tmpdir(), "daily-blog", "content");
-  assert.equal(
-    relativeDirectory(shadowInput, path.join(productionInput, "../_includes")),
-    path.relative(shadowInput, path.join(productionInput, "../_includes")),
+test("keeps Eleventy directories project-root relative", () => {
+  const handlers = {};
+  const directories = {
+    input: "/production/src",
+    data: "/production/_data",
+    includes: "/production/_includes",
+    layouts: "/production/_layouts",
+    output: "/production/public",
+    setInput(value) { this.input = value; },
+    setOutput(value) { this.output = value; },
+  };
+  configureProjectDirectories(
+    { directories, userConfig: { on(name, callback) { handlers[name] = callback; } } },
+    { input: "src", output: "/preview/public", json: true },
+    () => {},
   );
-  assert.equal(
-    path.resolve(shadowInput, relativeDirectory(shadowInput, path.join(productionInput, "_data"))),
-    path.join(productionInput, "_data"),
-  );
+  handlers["eleventy.beforeConfig"]();
+  assert.equal(directories.input, "src");
+  assert.equal(directories.data, "/production/_data");
+  assert.equal(directories.includes, "/production/_includes");
+  assert.equal(directories.layouts, "/production/_layouts");
+  assert.equal(directories.output, "/preview/public");
 });
 
 test("serves output index paths without allowing traversal", () => {
@@ -56,22 +67,23 @@ test("binds the preview server to loopback", async () => {
   }
 });
 
-test("requires production input for the shadow command", () => {
+test("requires an input directory", () => {
   assert.throws(
-    () => parseArguments(["--serve", "--input", "/tmp/shadow", "--output", "/tmp/output", "--port", "14123"]),
-    /--input and --production-input are required/,
+    () => parseArguments(["--serve", "--output", "/tmp/output", "--port", "14123"]),
+    /--input is required/,
   );
 });
 
-test("uses the same production-relative directories in JSON mode", () => {
+test("uses the project-root overlay in JSON mode", () => {
   const project = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-fixture-"));
   const packageDir = path.join(project, "node_modules", "@11ty", "eleventy");
-  const productionInput = path.join(project, "content");
-  const shadowInput = path.join(project, "shadow", "content");
-  const output = path.join(project, "preview-output");
+  const input = path.join(project, "src");
+  const output = path.join(project, "public");
   fs.mkdirSync(packageDir, { recursive: true });
-  fs.mkdirSync(productionInput, { recursive: true });
-  fs.mkdirSync(shadowInput, { recursive: true });
+  fs.mkdirSync(path.join(input, "posts"), { recursive: true });
+  fs.mkdirSync(path.join(project, "_data"), { recursive: true });
+  fs.mkdirSync(path.join(project, "_includes"), { recursive: true });
+  fs.mkdirSync(path.join(project, "_layouts"), { recursive: true });
   fs.writeFileSync(path.join(project, "package.json"), "{}");
   fs.writeFileSync(path.join(packageDir, "package.json"), '{"main":"index.js"}');
   fs.writeFileSync(path.join(packageDir, "index.js"), `
@@ -79,16 +91,14 @@ test("uses the same production-relative directories in JSON mode", () => {
     module.exports = class FakeEleventy {
       constructor(input, output, options) {
         const handlers = {};
+        const root = process.cwd();
         const directories = {
-          input,
-          data: path.join(input, "_data"),
-          includes: path.join(input, "../_includes"),
-          layouts: path.join(input, "../_layouts"),
+          input: path.resolve(root, input),
+          data: path.join(root, "_data"),
+          includes: path.join(root, "_includes"),
+          layouts: path.join(root, "_layouts"),
           output,
-          setInput(value) { this.input = value; },
-          setData(value) { this.data = path.resolve(this.input, value); },
-          setIncludes(value) { this.includes = path.resolve(this.input, value); },
-          setLayouts(value) { this.layouts = path.resolve(this.input, value); },
+          setInput(value) { this.input = path.resolve(root, value); },
           setOutput(value) { this.output = value; },
         };
         options.config({
@@ -119,13 +129,12 @@ test("uses the same production-relative directories in JSON mode", () => {
     const stdout = childProcess.execFileSync(process.execPath, [
       script,
       "--json",
-      "--input", shadowInput,
-      "--production-input", productionInput,
+      "--input", "src",
       "--output", output,
     ], { cwd: project, encoding: "utf8" });
     const [entry] = JSON.parse(stdout);
-    assert.equal(entry.inputPath, path.join(shadowInput, "posts/one.md"));
-    assert.equal(entry.data.directories.data, path.join(productionInput, "_data"));
+    assert.equal(entry.inputPath, path.join(input, "posts/one.md"));
+    assert.equal(entry.data.directories.data, path.join(project, "_data"));
     assert.equal(entry.data.directories.includes, path.join(project, "_includes"));
     assert.equal(entry.data.directories.layouts, path.join(project, "_layouts"));
     assert.equal(entry.outputPath, output);

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -1,0 +1,135 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const childProcess = require("node:child_process");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  createLoopbackServer,
+  findOutputFile,
+  listen,
+  parseArguments,
+  relativeDirectory,
+} = require("./eleventy-local-preview.cjs");
+
+test("rebases production Eleventy directories from a shadow input", () => {
+  const shadowInput = path.join(os.tmpdir(), "homecms-shadow", "content");
+  const productionInput = path.join(os.tmpdir(), "daily-blog", "content");
+  assert.equal(
+    relativeDirectory(shadowInput, path.join(productionInput, "../_includes")),
+    path.relative(shadowInput, path.join(productionInput, "../_includes")),
+  );
+  assert.equal(
+    path.resolve(shadowInput, relativeDirectory(shadowInput, path.join(productionInput, "_data"))),
+    path.join(productionInput, "_data"),
+  );
+});
+
+test("serves output index paths without allowing traversal", () => {
+  const output = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-output-"));
+  fs.mkdirSync(path.join(output, "posts"));
+  fs.writeFileSync(path.join(output, "posts", "index.html"), "ok");
+  try {
+    assert.equal(findOutputFile(output, "/posts/").filePath, path.join(output, "posts", "index.html"));
+    assert.equal(findOutputFile(output, "/posts").redirect, "/posts/");
+    assert.equal(findOutputFile(output, "/../secret").error, 400);
+  } finally {
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+});
+
+test("binds the preview server to loopback", async () => {
+  const output = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-output-"));
+  const server = createLoopbackServer(output);
+  try {
+    await listen(server, 0, "127.0.0.1");
+    assert.equal(server.address().address, "127.0.0.1");
+  } finally {
+    await new Promise((resolve) => {
+      server.closeAll();
+      server.close(() => resolve());
+    });
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+});
+
+test("requires production input for the shadow command", () => {
+  assert.throws(
+    () => parseArguments(["--serve", "--input", "/tmp/shadow", "--output", "/tmp/output", "--port", "14123"]),
+    /--input and --production-input are required/,
+  );
+});
+
+test("uses the same production-relative directories in JSON mode", () => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-fixture-"));
+  const packageDir = path.join(project, "node_modules", "@11ty", "eleventy");
+  const productionInput = path.join(project, "content");
+  const shadowInput = path.join(project, "shadow", "content");
+  const output = path.join(project, "preview-output");
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.mkdirSync(productionInput, { recursive: true });
+  fs.mkdirSync(shadowInput, { recursive: true });
+  fs.writeFileSync(path.join(project, "package.json"), "{}");
+  fs.writeFileSync(path.join(packageDir, "package.json"), '{"main":"index.js"}');
+  fs.writeFileSync(path.join(packageDir, "index.js"), `
+    const path = require("node:path");
+    module.exports = class FakeEleventy {
+      constructor(input, output, options) {
+        const handlers = {};
+        const directories = {
+          input,
+          data: path.join(input, "_data"),
+          includes: path.join(input, "../_includes"),
+          layouts: path.join(input, "../_layouts"),
+          output,
+          setInput(value) { this.input = value; },
+          setData(value) { this.data = path.resolve(this.input, value); },
+          setIncludes(value) { this.includes = path.resolve(this.input, value); },
+          setLayouts(value) { this.layouts = path.resolve(this.input, value); },
+          setOutput(value) { this.output = value; },
+        };
+        options.config({
+          directories,
+          userConfig: { on(name, callback) { handlers[name] = callback; } },
+        });
+        handlers["eleventy.beforeConfig"]();
+        this.directories = directories;
+      }
+      async toJSON() {
+        return [{
+          inputPath: path.join(this.directories.input, "posts/one.md"),
+          outputPath: this.directories.output,
+          data: {
+            directories: {
+              data: this.directories.data,
+              includes: this.directories.includes,
+              layouts: this.directories.layouts,
+            },
+          },
+        }];
+      }
+    };
+  `);
+
+  try {
+    const script = path.resolve(__dirname, "eleventy-local-preview.cjs");
+    const stdout = childProcess.execFileSync(process.execPath, [
+      script,
+      "--json",
+      "--input", shadowInput,
+      "--production-input", productionInput,
+      "--output", output,
+    ], { cwd: project, encoding: "utf8" });
+    const [entry] = JSON.parse(stdout);
+    assert.equal(entry.inputPath, path.join(shadowInput, "posts/one.md"));
+    assert.equal(entry.data.directories.data, path.join(productionInput, "_data"));
+    assert.equal(entry.data.directories.includes, path.join(project, "_includes"));
+    assert.equal(entry.data.directories.layouts, path.join(project, "_layouts"));
+    assert.equal(entry.outputPath, output);
+  } finally {
+    fs.rmSync(project, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 概要
- Eleventyの--serveを使ったLocal Live Previewを追加
- package manager検出、shadow content、テンポラリ出力、loopback起動と終了時クリーンアップを実装
- Eleventyの--to=jsonメタデータからpermalink/Data Cascade/paginationを解決し、ローカルoriginへ書き換え
- 既存の画面遷移・セッション動作をEleventyにも適用
- 設計・運用ドキュメントを更新

## 確認
- go test ./...
- go vet ./...
- git diff --check

Closes #46