### PR TITLE
fix: Issue #48のEleventy Programmatic API誤用を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install Eleventy integration fixture
+        run: npm install --prefix scripts/fixtures/eleventy-programmatic --no-package-lock --ignore-scripts
+
       - name: Go test
         run: go test ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ hugo-cms.exe
 # OS Specific
 .DS_Store
 Thumbs.db
+node_modules/
 
 # Agent temp
 .gemini/

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -254,7 +254,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 2. **Local Live Preview**: 実際のgenerator/theme/layout/shortcode/CSS/JSを使う編集中確認
 3. **デプロイプレビュー**: 外部buildで特定commitを公開前に最終確認する
 
-Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、project-root overlay、`--to=json` metadata URL解決を同じ導線へ追加しています。
+Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsession lifecycleの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、project-root overlay、`--to=json` metadata URL解決を同じ導線へ追加し、Issue #48ではEleventy Programmatic APIの実際のUserConfig形に合わせたhook登録と実Eleventy統合テストを追加しています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/smoke-tests.md
+++ b/docs/guides/smoke-tests.md
@@ -115,6 +115,8 @@ sites:
 - 記事を保存できる
 - Buildがlockfileに対応するpackage manager経由で実行される
 - Dockerでは`tool-bootstrap`がlockfileに対応するfrozen installを完了してから明示Buildを実行できる
+- Local Live Previewの`--json` URL解決と`--serve` LiveReloadが、実際のEleventy 3.xで動作する
+- Local Live Previewの生成物がproduction repositoryの`public_dir`を変更しない
 
 ## 5. Docker
 

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"hugo-cms/pkg/config"
 	"hugo-cms/pkg/services"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -94,6 +95,7 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 	}
 	articleURL, err := dependencies.resolveArticleURL(c.Request.Context(), resolverRuntime, workspace, req.Path)
 	if err != nil {
+		slog.Error("Failed to resolve Local Live Preview article URL", "site", runtime.ID, "article_path", req.Path, "error", err)
 		ErrorInternal(c, "Failed to resolve Local Live Preview article URL")
 		return
 	}

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -52,18 +52,8 @@ function parseArguments(argv) {
 }
 
 function configureProjectDirectories(eleventyConfig, options, notify) {
-  eleventyConfig.userConfig.on("eleventy.beforeConfig", () => {
-    const directories = eleventyConfig.directories;
-    // The process cwd is a temporary project-root overlay. Keep Eleventy's
-    // normal project-relative resolution intact and replace only the two CMS
-    // controlled roots: content input and generated public output.
-    directories.setInput(options.input);
-    directories.setOutput(options.output);
-
-  });
-
   if (!options.json) {
-    eleventyConfig.userConfig.on("eleventy.after", notify);
+    eleventyConfig.on("eleventy.after", notify);
   }
 }
 

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -3,6 +3,8 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const childProcess = require("node:child_process");
+const http = require("node:http");
+const net = require("node:net");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
@@ -15,28 +17,116 @@ const {
   parseArguments,
 } = require("./eleventy-local-preview.cjs");
 
-test("keeps Eleventy directories project-root relative", () => {
+const integrationFixture = path.join(__dirname, "fixtures", "eleventy-programmatic");
+
+function hasRealEleventy() {
+  try {
+    require.resolve("@11ty/eleventy", { paths: [integrationFixture] });
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function createEleventyFixture() {
+  const project = fs.mkdtempSync(path.join(integrationFixture, ".tmp-"));
+  const input = path.join(project, "src");
+  const output = path.join(project, "public");
+  fs.mkdirSync(path.join(input, "posts"), { recursive: true });
+  fs.writeFileSync(path.join(project, "package.json"), '{"private":true}');
+  fs.writeFileSync(
+    path.join(input, "posts", "one.md"),
+    ["---", "title: One", "permalink: /custom/one/", "---", "", "# {{ title }}", ""].join("\n"),
+  );
+  return { project, input, output, article: path.join(input, "posts", "one.md") };
+}
+
+function removeEleventyFixture(fixture) {
+  fs.rmSync(fixture.project, { recursive: true, force: true });
+}
+
+function waitForExit(child) {
+  if (child.exitCode !== null) return Promise.resolve();
+  return new Promise((resolve) => child.once("exit", resolve));
+}
+
+function waitForHTTP(port, pathname) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + 15000;
+    const attempt = () => {
+      const request = http.get({ host: "127.0.0.1", port, path: pathname }, (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          if (response.statusCode === 200) {
+            resolve({ statusCode: response.statusCode, body: Buffer.concat(chunks).toString("utf8") });
+            return;
+          }
+          retry();
+        });
+      });
+      request.on("error", retry);
+      request.setTimeout(500, () => request.destroy());
+    };
+    const retry = () => {
+      if (Date.now() >= deadline) {
+        reject(new Error(`Timed out waiting for Eleventy preview at ${pathname}`));
+        return;
+      }
+      setTimeout(attempt, 100);
+    };
+    attempt();
+  });
+}
+
+function availablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = server.address().port;
+      server.close((error) => error ? reject(error) : resolve(port));
+    });
+  });
+}
+
+function connectReloadSocket(port) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const key = Buffer.from("homecms-eleventy-test").toString("base64");
+    let response = "";
+    const onData = (chunk) => {
+      response += chunk.toString("utf8");
+      if (response.includes("101 Switching Protocols")) {
+        socket.off("data", onData);
+        resolve(socket);
+      }
+    };
+    socket.on("connect", () => {
+      socket.write([
+        "GET /__hugo_cms_live_reload HTTP/1.1",
+        "Host: 127.0.0.1",
+        "Upgrade: websocket",
+        "Connection: Upgrade",
+        `Sec-WebSocket-Key: ${key}`,
+        "Sec-WebSocket-Version: 13",
+        "\r\n",
+      ].join("\r\n"));
+    });
+    socket.on("data", onData);
+    socket.once("error", reject);
+    socket.once("close", () => reject(new Error("Eleventy LiveReload socket closed before handshake")));
+  });
+}
+
+test("registers Eleventy hooks on the Programmatic API UserConfig", () => {
   const handlers = {};
-  const directories = {
-    input: "/production/src",
-    data: "/production/_data",
-    includes: "/production/_includes",
-    layouts: "/production/_layouts",
-    output: "/production/public",
-    setInput(value) { this.input = value; },
-    setOutput(value) { this.output = value; },
-  };
   configureProjectDirectories(
-    { directories, userConfig: { on(name, callback) { handlers[name] = callback; } } },
-    { input: "src", output: "/preview/public", json: true },
+    { on(name, callback) { handlers[name] = callback; } },
+    { json: false },
     () => {},
   );
-  handlers["eleventy.beforeConfig"]();
-  assert.equal(directories.input, "src");
-  assert.equal(directories.data, "/production/_data");
-  assert.equal(directories.includes, "/production/_includes");
-  assert.equal(directories.layouts, "/production/_layouts");
-  assert.equal(directories.output, "/preview/public");
+  assert.equal(typeof handlers["eleventy.after"], "function");
 });
 
 test("serves output index paths without allowing traversal", () => {
@@ -90,7 +180,6 @@ test("uses the project-root overlay in JSON mode", () => {
     const path = require("node:path");
     module.exports = class FakeEleventy {
       constructor(input, output, options) {
-        const handlers = {};
         const root = process.cwd();
         const directories = {
           input: path.resolve(root, input),
@@ -98,14 +187,8 @@ test("uses the project-root overlay in JSON mode", () => {
           includes: path.join(root, "_includes"),
           layouts: path.join(root, "_layouts"),
           output,
-          setInput(value) { this.input = path.resolve(root, value); },
-          setOutput(value) { this.output = value; },
         };
-        options.config({
-          directories,
-          userConfig: { on(name, callback) { handlers[name] = callback; } },
-        });
-        handlers["eleventy.beforeConfig"]();
+        options.config({ on() {} });
         this.directories = directories;
       }
       async toJSON() {
@@ -140,5 +223,67 @@ test("uses the project-root overlay in JSON mode", () => {
     assert.equal(entry.outputPath, output);
   } finally {
     fs.rmSync(project, { recursive: true, force: true });
+  }
+});
+
+test("resolves a real Eleventy 3.x project in JSON mode", { skip: !hasRealEleventy() }, () => {
+  const fixture = createEleventyFixture();
+  try {
+    const script = path.resolve(__dirname, "eleventy-local-preview.cjs");
+    const stdout = childProcess.execFileSync(process.execPath, [
+      script,
+      "--json",
+      "--input", "src",
+      "--output", fixture.output,
+    ], { cwd: fixture.project, encoding: "utf8" });
+    const entries = JSON.parse(stdout);
+    const entry = entries.find((candidate) => path.resolve(fixture.project, candidate.inputPath) === fixture.article);
+    assert.ok(entry, `Eleventy did not return metadata for ${fixture.article}`);
+    assert.equal(entry.url, "/custom/one/");
+  } finally {
+    removeEleventyFixture(fixture);
+  }
+});
+
+test("starts real Eleventy serve and broadcasts LiveReload", { skip: !hasRealEleventy() }, async () => {
+  const fixture = createEleventyFixture();
+  let child;
+  let reloadSocket;
+  try {
+    const port = await availablePort();
+    const script = path.resolve(__dirname, "eleventy-local-preview.cjs");
+    child = childProcess.spawn(process.execPath, [
+      script,
+      "--serve",
+      "--input", "src",
+      "--output", fixture.output,
+      "--port", String(port),
+      "--host", "127.0.0.1",
+    ], { cwd: fixture.project, stdio: ["ignore", "pipe", "pipe"] });
+    const page = await waitForHTTP(port, "/custom/one/");
+    assert.match(page.body, /__hugo_cms_reload\.js/);
+    reloadSocket = await connectReloadSocket(port);
+    const reload = new Promise((resolve, reject) => {
+      const deadline = setTimeout(() => reject(new Error("Timed out waiting for Eleventy LiveReload")), 15000);
+      reloadSocket.on("data", (chunk) => {
+        if (chunk.toString("utf8").includes('"type":"eleventy.reload"')) {
+          clearTimeout(deadline);
+          resolve();
+        }
+      });
+      reloadSocket.once("error", reject);
+    });
+    fs.writeFileSync(
+      fixture.article,
+      ["---", "title: Changed", "permalink: /custom/one/", "---", "", "# {{ title }}", ""].join("\n"),
+    );
+    await reload;
+  } finally {
+    reloadSocket?.destroy();
+    if (child) {
+      child.kill();
+      await waitForExit(child);
+    }
+    removeEleventyFixture(fixture);
   }
 });

--- a/scripts/fixtures/eleventy-programmatic/package.json
+++ b/scripts/fixtures/eleventy-programmatic/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "hugo-cms-eleventy-programmatic-fixture",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@11ty/eleventy": "3.1.2"
+  }
+}


### PR DESCRIPTION
## 概要

Issue #48のEleventy Local Live Preview URL解決失敗を修正します。

## 変更内容

- Programmatic APIのconfig callbackへ渡されるUserConfigに対して、leventyConfig.on()でhookを登録
- constructorのinput/output指定を尊重し、内部directoriesの直接変更を削除
- 実Eleventy 3.1.2を使う--json URL解決統合テストを追加
- 実Eleventy --serveのHTTP配信とLiveReload通知の統合テストを追加
- resolver失敗時にsite・記事パス・元エラーをserver logへ記録
- CIでintegration fixtureをインストール

## 検証

- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- Nodeテスト27件（実Eleventy統合テストを含む）

Closes #48