### PR TITLE
feat: site単位のLocal Live Preview runtimeへ移行

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -150,17 +150,16 @@ Editor input
 ```text
 OS temporary directory/
   <site-id>/
-    <local-preview-session-id>/
-      package.json, node_modules, eleventy.config.js ... production references
-      src/ or content/ ... shadow content_dir
-      _includes/, _data/, _layouts/ ... production references
-      public/ ... empty preview output directory
+    package.json, node_modules, eleventy.config.js ... production references
+    src/ or content/ ... shadow content_dir
+    _includes/, _data/, _layouts/ ... production references
+    public/ ... empty preview output directory
 ```
 
 Hugoは従来どおり元repositoryをsource rootとして読み、`--contentDir`だけをshadow directoryのabsolute pathへ差し替える。Eleventyはtemporary project-root overlayをcwdにして`--input <content_dir>`、`--output <temporary-project-public-dir>`で実行する。overlayでは`content_dir`をshadowへmaterializeし、`public_dir`を空のpreview専用directoryにする。それ以外のroot-relativeなconfig、collection glob、includes/layouts/data、passthrough asset、pluginの相対pathはEleventy自身の通常のproject-root解決へ委譲する。生成出力はproductionのpublic directoryへ書き込まれない。
 repo外のabsolute pathや環境変数で指定された外部pathはこのoverlayの保証対象外とする。
 
-workspaceは`PREVIEW_STATE_DIR`へ永続化しない。session releaseまたはCMS shutdown時に削除する。
+workspaceは`PREVIEW_STATE_DIR`へ永続化しない。site runtimeの明示的なrelease、stale reclaim、idle timeoutまたはCMS shutdown時に削除する。idle timeoutは`HUGO_CMS_LOCAL_PREVIEW_IDLE_TIMEOUT`で指定し、初期値は30分、`0`で無効化する。editorのsession IDはworkspaceの物理パスではなく、site runtimeの所有権だけを表す。
 
 ### editor update ordering
 
@@ -182,11 +181,11 @@ static配下はHugoが元repositoryを直接参照するためshadow同期しな
 初期実装では**同一siteにつきactive Local Live Preview sessionは1つ**とする。
 
 - 同一siteへの別tab/session update -> `409 Conflict`
-- active sessionと異なるarticle path -> conflict
+- active sessionと異なるarticle path -> 同じsite workspaceへ反映
 - 別siteは独立workspaceを利用可能
 - stale tabは別tabのworkspaceをreleaseできない
 
-article/site切替ではbrowserがin-flight update完了を待ってreleaseする。serverはrelease claimでsessionをreleasing状態にしてからgenerator processを停止し、workspace rootを一意なcleanup領域へrenameして論理的にdetachする。その後のshadow directoryの物理削除は非同期で行い、cleanup中のpreview requestや更新が古いworkspaceを再利用しないようにする。Ingressはworkspace snapshot取得からprocess/portとproxy targetの準備完了まで同じsiteのread gateを保持し、release/reclaimのwrite gateとTOCTOU raceにならないようにする。準備後のHTTP/WebSocket streamingはgate外で実行する。
+article切替ではbrowserがproduction saveとin-flight update完了を待ち、同じsite workspaceへ選択pathを反映する。generator process、Eleventy project overlay、shadow workspaceは再作成しない。serverはarticle update時に現在記事のpath/revision metadataを更新し、watch rebuild後に要求pathのURLを解決する。site切替、明示的な停止、stale reclaim、idle timeoutではrelease claimでsessionをreleasing状態にしてからgenerator processを停止し、workspace rootを一意なcleanup領域へrenameして論理的にdetachする。その後のshadow directoryの物理削除は非同期で行い、cleanup中のpreview requestや更新が古いworkspaceを再利用しないようにする。Ingressはworkspace snapshot取得からprocess/portとproxy targetの準備完了まで同じsiteのread gateを保持し、release/reclaimのwrite gateとTOCTOU raceにならないようにする。準備後のHTTP/WebSocket streamingはgate外で実行する。
 
 ブラウザtabを切替操作なしで閉じた場合の確実なlease解放はPhase 4の停止UI/lease運用で扱う。それまではCMS shutdownで全workspaceをcleanupする。
 
@@ -222,7 +221,7 @@ POST /admin/api/preview/local
 }
 ```
 
-初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存generator processを一度停止する。次のpreview hostname requestでshadow workspaceを含むproject-root overlayを使ってlazy startし、その後はgenerator watcherが変更を拾う。
+初回updateでworkspaceを作った場合、保存済みcontentを使っていた既存generator processを一度停止する。次のpreview hostname requestでshadow workspaceを含むproject-root overlayを使ってlazy startし、その後は同じsite runtimeを記事切替でも再利用してgenerator watcherが変更を拾う。
 
 ### 初回記事URL解決
 
@@ -230,7 +229,7 @@ POST /admin/api/preview/local
 POST /admin/api/preview/local/navigate
 ```
 
-記事選択時にCMSが`draft_id`と記事pathを`/admin/api/preview/local/navigate`へ送り、serverはactive sessionの所有者・記事pathを検証する。検証後、Hugoは`hugo list all`、Eleventyは稼働中wrapperの`/__hugo_cms_metadata`へ問い合わせて`article_url`を返す。Eleventyがbuild中ならmap更新まで待ち、初回起動も同じprocessのreadinessを待つ。この処理はproduction content、Git、editor revisionを変更しない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、409やその他の4xxは再試行しない。通常の本文編集はLiveReloadを利用し、URL関連front matter変更時は再解決する。解決失敗時はpreview rootへ黙ってフォールバックしない。
+記事選択時にCMSが`draft_id`と記事pathを`/admin/api/preview/local/navigate`へ送り、serverはactive sessionの所有者を検証する。検証後、Hugoは`hugo list all`、Eleventyは稼働中wrapperの`/__hugo_cms_metadata`へ問い合わせて要求pathの`article_url`を返す。Eleventyがbuild中ならmap更新まで待ち、初回起動も同じprocessのreadinessを待つ。この処理はproduction content、Git、editor revisionを変更しない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、409やその他の4xxは再試行しない。通常の本文編集はLiveReloadを利用し、URL関連front matter変更時は再解決する。解決失敗時はpreview rootへ黙ってフォールバックしない。
 
 ### release
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -160,7 +160,7 @@ static配下は元repositoryをHugoが直接参照するためshadow同期しま
 
 Local Preview ownership IDはbrowser document/tabのmemory上だけに保持します。複製tabが同じIDを引き継がないため、同一siteの別tab/sessionは`409 Conflict`になります。
 
-一方、tab reload、browser crash、network断ではrelease requestを確実に送れません。そのためactive workspaceにはlast-seen leaseを持たせます。
+一方、tab reload、browser crash、network断ではrelease requestを確実に送れません。そのためsite単位のruntimeに対するeditor ownershipにはlast-seen leaseを持たせます。ownershipの有効期限は、generator processやshadow workspaceの寿命とは別に管理します。
 
 - lease TTL: 2分
 - CMS editorは30秒ごとにheartbeat
@@ -169,7 +169,7 @@ Local Preview ownership IDはbrowser document/tabのmemory上だけに保持し�
 - stale workspaceは明示的なreclaim APIでCMS再起動なしに回収可能
 - liveなsessionはreclaimできない
 
-recovery時もgenerator processを先にstopします。release/reclaim中はsessionを論理的にdetachし、workspace rootを一意なcleanup領域へrenameしてから物理削除を非同期で実行します。その間のpreview ingressやsession更新は古いworkspaceを再利用せず、ingressのworkspace snapshot取得からprocess/portとproxy targetの準備完了までをsite単位のread gateで保護します。長寿命のHTTP/WebSocket配信中はgateを保持しないため、cleanupの遅延が記事切替の応答をブロックしません。
+recovery時もgenerator processを先にstopします。release/reclaim中はsessionを論理的にdetachし、workspace rootを一意なcleanup領域へrenameしてから物理削除を非同期で実行します。その間のpreview ingressやsession更新は古いworkspaceを再利用せず、ingressのworkspace snapshot取得からprocess/portとproxy targetの準備完了までをsite単位のread gateで保護します。長寿命のHTTP/WebSocket配信中はgateを保持しないため、cleanupの遅延が記事切替の応答をブロックしません。runtimeのidle timeoutは`HUGO_CMS_LOCAL_PREVIEW_IDLE_TIMEOUT`で設定でき、初期値は30分、`0`で無効化できます。停止時は明示的なreleaseと同じprocess/workspace cleanupを行います。
 
 ## UI
 
@@ -192,7 +192,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyは稼働中wrapperの`eleventy.after` metadata map（`inputPath`/`url`）を使います。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
-初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale、記事不一致）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
+初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。409（別session、stale）やその他の4xxは再試行せず、通常のsession recovery表示へ委譲します。URLを解決できない場合はpreview rootへフォールバックせず、エラー状態を表示します。
 
 iframeの読み込み中はloading表示を出し、`load`または対応するpreview bridgeのready通知を一定時間確認できない場合は、エラーと「新規タブで開く」fallbackを表示します。これはbest-effortの判定であり、CSPや`X-Frame-Options`などによるiframe拒否をブラウザAPIだけで確実に判定するものではありません。埋め込み表示はボタンから閉じられ、記事を切り替えるかstale sessionを回収すると再び自動表示されます。狭い画面では編集画面とpreviewを上下に配置します。
 
@@ -216,7 +216,9 @@ CMS側iframeにはsandboxを付け、top-level navigation等を許可しませ�
 
 ## article/site切替とcleanup
 
-article/site切替時はin-flight update完了を待ってsessionをreleaseします。
+article切替では、現在記事のproduction保存とin-flight Local Preview updateの完了を待ってから、同じsite workspaceへ新しい記事pathを反映します。generator process、project overlay、shadow workspaceは再利用し、watch rebuildとgenerator準拠のURL解決だけを行います。editor ownership/sessionは維持されるため、記事切替でstop/releaseは実行しません。
+
+site切替、UIの明示的な停止、stale sessionのreclaim、idle timeout、CMS shutdownでは、次の順でsite runtimeを終了します。
 
 ```text
 generator process stop
@@ -251,7 +253,7 @@ POST /admin/api/preview/local/navigate
 }
 ```
 
-このAPIはactive sessionの所有者と記事pathを検証し、shadow workspaceを使ってgeneratorの実ページURLを解決します。成功時は`article_url`、`revision`、`session_id`を返し、production content、Git working tree、editorのrevisionは変更しません。解決に失敗した場合はエラーを返し、preview rootへフォールバックしません。
+このAPIはactive sessionの所有者を検証し、site単位のshadow workspaceから要求された記事pathを使ってgeneratorの実ページURLを解決します。成功時は`article_url`、`revision`、`session_id`を返し、production content、Git working tree、editorのrevisionは変更しません。解決に失敗した場合はエラーを返し、preview rootへフォールバックしません。
 
 release:
 

--- a/main.go
+++ b/main.go
@@ -187,6 +187,13 @@ func main() {
 	}
 
 	srv := newHTTPServer(r)
+	previewManager := services.DefaultLocalPreviewManager()
+	idleReaperCtx, cancelIdleReaper := context.WithCancel(context.Background())
+	idleReaperDone := make(chan struct{})
+	go func() {
+		defer close(idleReaperDone)
+		services.RunLocalPreviewIdleReaper(idleReaperCtx, previewManager, workspaceManager)
+	}()
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -199,8 +206,9 @@ func main() {
 	<-quit
 	slog.Info("Shutting down server...")
 
-	previewManager := services.DefaultLocalPreviewManager()
 	previewManager.BeginShutdown()
+	cancelIdleReaper()
+	<-idleReaperDone
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	if err := srv.Shutdown(ctx); err != nil {

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -354,6 +354,9 @@ func DeleteArticle(c *gin.Context) {
 	// Re-scan or remove from cache
 	// Assuming UpdateCache handles re-scan or we'll fix it
 	services.UpdateCacheForRuntime(runtime, req.Path)
+	// Keep an active site-scoped Local Live Preview workspace in sync without
+	// releasing the generator runtime for the next article.
+	syncLocalPreviewContentResource(runtime, filepath.ToSlash(filepath.Join(runtime.ContentDir, req.Path)), true)
 	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
 }
 

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -77,11 +77,6 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 		ErrorConflict(c, services.ErrLocalPreviewSessionConflict.Error())
 		return
 	}
-	if workspace.ArticlePath != filepath.ToSlash(req.Path) {
-		ErrorConflict(c, services.ErrLocalPreviewSessionMismatch.Error())
-		return
-	}
-
 	if dependencies.resolveArticleURL == nil {
 		ErrorInternal(c, "Local preview URL resolver is unavailable")
 		return

--- a/pkg/handlers/local_preview_navigation_test.go
+++ b/pkg/handlers/local_preview_navigation_test.go
@@ -84,7 +84,7 @@ func TestNavigateLocalPreviewUsesShadowContentAndPreservesProductionContent(t *t
 	}
 }
 
-func TestNavigateLocalPreviewRejectsWrongOwnerAndPath(t *testing.T) {
+func TestNavigateLocalPreviewRejectsWrongOwnerAndAllowsAnotherArticle(t *testing.T) {
 	site, runtime := localPreviewNavigationTestSite(t)
 	configureLocalPreviewNavigationTestSite(t, site)
 	workspaceManager, err := services.NewLocalPreviewWorkspaceManager(t.TempDir())
@@ -109,11 +109,11 @@ func TestNavigateLocalPreviewRejectsWrongOwnerAndPath(t *testing.T) {
 		t.Fatalf("wrong owner status = %d, want 409", ownerResponse.Code)
 	}
 	pathResponse := executeLocalPreviewNavigationRequest(t, site.ID, dependencies, "draft-1", "other.md")
-	if pathResponse.Code != http.StatusConflict {
-		t.Fatalf("wrong path status = %d, want 409", pathResponse.Code)
+	if pathResponse.Code != http.StatusOK {
+		t.Fatalf("another article status = %d, want 200", pathResponse.Code)
 	}
-	if resolveCalls != 0 {
-		t.Fatalf("resolver calls = %d, want 0 for rejected requests", resolveCalls)
+	if resolveCalls != 1 {
+		t.Fatalf("resolver calls = %d, want 1 for the allowed article", resolveCalls)
 	}
 }
 

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -28,6 +28,7 @@ const (
 	localPreviewStderrLimit            = 64 << 10
 	localPreviewHugoEnvironment        = "development"
 	localPreviewStartupTimeoutEnv      = "HUGO_CMS_LOCAL_PREVIEW_STARTUP_TIMEOUT"
+	localPreviewIdleTimeoutEnv         = "HUGO_CMS_LOCAL_PREVIEW_IDLE_TIMEOUT"
 	eleventyLocalPreviewReadyPath      = "/__hugo_cms_ready"
 	eleventyLocalPreviewMetadataPath   = "/__hugo_cms_metadata"
 	eleventyLocalPreviewInvalidatePath = "/__hugo_cms_invalidate"
@@ -179,6 +180,7 @@ type LocalPreviewManager struct {
 	startupTimeout time.Duration
 	probeInterval  time.Duration
 	startAttempts  int
+	idleTimeout    time.Duration
 }
 
 func NewLocalPreviewManager(lifecycle *LocalPreviewLifecycle) *LocalPreviewManager {
@@ -193,6 +195,7 @@ func NewLocalPreviewManager(lifecycle *LocalPreviewLifecycle) *LocalPreviewManag
 		startupTimeout: configuredLocalPreviewStartupTimeout(),
 		probeInterval:  defaultLocalPreviewProbeInterval,
 		startAttempts:  defaultLocalPreviewStartAttempts,
+		idleTimeout:    configuredLocalPreviewIdleTimeout(),
 	}
 }
 
@@ -209,10 +212,89 @@ func configuredLocalPreviewStartupTimeout() time.Duration {
 	return defaultLocalPreviewStartupTimeout
 }
 
+func configuredLocalPreviewIdleTimeout() time.Duration {
+	value := strings.TrimSpace(os.Getenv(localPreviewIdleTimeoutEnv))
+	if value == "" {
+		return DefaultLocalPreviewIdleTimeout
+	}
+	timeout, err := time.ParseDuration(value)
+	if err == nil && timeout >= 0 {
+		return timeout
+	}
+	slog.Warn("Invalid local preview idle timeout; using default", "value", value, "default", DefaultLocalPreviewIdleTimeout)
+	return DefaultLocalPreviewIdleTimeout
+}
+
 var defaultLocalPreviewManager = NewLocalPreviewManager(nil)
 
 func DefaultLocalPreviewManager() *LocalPreviewManager {
 	return defaultLocalPreviewManager
+}
+
+// IdleTimeout returns the site runtime idle timeout. A zero duration
+// explicitly disables automatic idle cleanup.
+func (m *LocalPreviewManager) IdleTimeout() time.Duration {
+	return m.idleTimeout
+}
+
+// StopIdle releases workspaces that have exceeded the runtime idle timeout.
+// It uses the same claim -> process stop -> workspace detach sequence as an
+// explicit stop, so an article switch never enters this path.
+func (m *LocalPreviewManager) StopIdle(ctx context.Context, workspaceManager *LocalPreviewWorkspaceManager) error {
+	if workspaceManager == nil || m.idleTimeout <= 0 {
+		return nil
+	}
+	var errs []error
+	for _, workspace := range workspaceManager.IdleWorkspaces(m.idleTimeout) {
+		claim, claimed, err := workspaceManager.ClaimRelease(workspace.SiteID, workspace.DraftID)
+		if err != nil {
+			if errors.Is(err, ErrLocalPreviewSessionReleasing) || errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("claim idle local preview workspace for site %q: %w", workspace.SiteID, err))
+			continue
+		}
+		if !claimed {
+			continue
+		}
+		if err := m.Stop(ctx, workspace.SiteID); err != nil {
+			workspaceManager.CancelRelease(claim)
+			errs = append(errs, fmt.Errorf("stop idle local preview for site %q: %w", workspace.SiteID, err))
+			continue
+		}
+		if _, err := workspaceManager.FinishRelease(claim); err != nil {
+			workspaceManager.CancelRelease(claim)
+			errs = append(errs, fmt.Errorf("detach idle local preview workspace for site %q: %w", workspace.SiteID, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// RunLocalPreviewIdleReaper periodically applies the configured idle timeout
+// until ctx is cancelled. The server owns the context so shutdown can stop
+// the reaper before the workspace manager is closed.
+func RunLocalPreviewIdleReaper(ctx context.Context, manager *LocalPreviewManager, workspaceManager *LocalPreviewWorkspaceManager) {
+	if manager == nil || workspaceManager == nil || manager.idleTimeout <= 0 {
+		return
+	}
+	interval := time.Minute
+	if half := manager.idleTimeout / 2; half > 0 && half < interval {
+		interval = half
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			stopCtx, cancel := context.WithTimeout(ctx, DefaultLocalPreviewStopTimeout)
+			if err := manager.StopIdle(stopCtx, workspaceManager); err != nil {
+				slog.Warn("Failed to stop idle Local Live Preview runtime", "error", err)
+			}
+			cancel()
+		}
+	}
 }
 
 func (m *LocalPreviewManager) BeginShutdown() {
@@ -649,10 +731,6 @@ func (m *LocalPreviewManager) ResolveArticleURL(ctx context.Context, runtime con
 	if workspace.ContentDir == "" {
 		return "", fmt.Errorf("preview workspace content directory is required")
 	}
-	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
-		return "", fmt.Errorf("preview workspace article does not match request")
-	}
-
 	slot, err := m.ensureReadyRuntime(runtime)
 	if err != nil {
 		return "", fmt.Errorf("ensure Eleventy local preview ready: %w", err)

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -246,9 +246,11 @@ func (m *LocalPreviewManager) StopIdle(ctx context.Context, workspaceManager *Lo
 	}
 	var errs []error
 	for _, workspace := range workspaceManager.IdleWorkspaces(m.idleTimeout) {
-		claim, claimed, err := workspaceManager.ClaimRelease(workspace.SiteID, workspace.DraftID)
+		claim, claimed, err := workspaceManager.ClaimIdle(workspace.SiteID, workspace.DraftID, m.idleTimeout)
 		if err != nil {
-			if errors.Is(err, ErrLocalPreviewSessionReleasing) || errors.Is(err, ErrLocalPreviewSessionReclaiming) {
+			if errors.Is(err, ErrLocalPreviewSessionConflict) ||
+				errors.Is(err, ErrLocalPreviewSessionReleasing) ||
+				errors.Is(err, ErrLocalPreviewSessionReclaiming) {
 				continue
 			}
 			errs = append(errs, fmt.Errorf("claim idle local preview workspace for site %q: %w", workspace.SiteID, err))

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -169,6 +169,29 @@ func TestLocalPreviewManagerSupportsEleventy(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewManagerReusesSiteRuntimeForRepeatedPreparation(t *testing.T) {
+	for _, generator := range []string{"hugo", "eleventy"} {
+		t.Run(generator, func(t *testing.T) {
+			manager, site := newTestLocalPreviewManager(t)
+			site.Generator = generator
+			defer shutdownTestLocalPreviewManager(t, manager)
+
+			first, err := manager.EnsureReady(site)
+			if err != nil {
+				t.Fatalf("first EnsureReady() error = %v", err)
+			}
+			firstProcess := manager.process(site.ID)
+			second, err := manager.EnsureReady(site)
+			if err != nil {
+				t.Fatalf("second EnsureReady() error = %v", err)
+			}
+			if first.Port != second.Port || firstProcess == nil || manager.process(site.ID) != firstProcess {
+				t.Fatalf("site runtime was recreated: first=%#v second=%#v process_changed=%v", first, second, manager.process(site.ID) != firstProcess)
+			}
+		})
+	}
+}
+
 func TestLocalPreviewManagerResolvesEleventyURLFromRunningProcess(t *testing.T) {
 	manager, site := newTestLocalPreviewManager(t)
 	site.Generator = "eleventy"

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -427,6 +427,54 @@ func (m *LocalPreviewWorkspaceManager) IdleWorkspaces(timeout time.Duration) []L
 	return idle
 }
 
+// ClaimIdle atomically verifies that a workspace is still idle and marks it
+// as releasing. The site gate and manager lock cover the re-check so a
+// heartbeat/update that wins the race prevents idle cleanup rather than being
+// stopped immediately afterwards.
+func (m *LocalPreviewWorkspaceManager) ClaimIdle(siteID, draftID string, timeout time.Duration) (LocalPreviewRelease, bool, error) {
+	if err := validateDraftID(draftID); err != nil {
+		return LocalPreviewRelease{}, false, err
+	}
+	if timeout <= 0 {
+		return LocalPreviewRelease{}, false, nil
+	}
+	gate := m.siteGate(siteID)
+	gate.Lock()
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		gate.Unlock()
+		return LocalPreviewRelease{}, false, fmt.Errorf("local preview workspace manager is closed")
+	}
+	if err := m.transitionErrorLocked(siteID); err != nil {
+		m.mu.Unlock()
+		gate.Unlock()
+		return LocalPreviewRelease{}, false, err
+	}
+	workspace, ok := m.sessions[siteID]
+	if !ok {
+		m.mu.Unlock()
+		gate.Unlock()
+		return LocalPreviewRelease{}, false, nil
+	}
+	if workspace.DraftID != draftID {
+		m.mu.Unlock()
+		gate.Unlock()
+		return LocalPreviewRelease{}, false, ErrLocalPreviewSessionConflict
+	}
+	if workspace.LastSeenAt.IsZero() || m.currentTimeLocked().Sub(workspace.LastSeenAt) < timeout {
+		m.mu.Unlock()
+		gate.Unlock()
+		return LocalPreviewRelease{}, false, nil
+	}
+	m.nextReleaseToken++
+	state := localPreviewReleaseState{draftID: draftID, token: m.nextReleaseToken}
+	m.releasing[siteID] = state
+	m.mu.Unlock()
+	gate.Unlock()
+	return LocalPreviewRelease{siteID: siteID, draftID: draftID, token: state.token}, true, nil
+}
+
 // SyncContentResource mirrors a content-directory resource change made through
 // the normal CMS media API into an already-active shadow workspace. Static
 // resources do not need this because the generator overlay still references

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -14,7 +14,10 @@ import (
 	"time"
 )
 
-const DefaultLocalPreviewLeaseTTL = 2 * time.Minute
+const (
+	DefaultLocalPreviewLeaseTTL    = 2 * time.Minute
+	DefaultLocalPreviewIdleTimeout = 30 * time.Minute
+)
 
 var (
 	ErrLocalPreviewSessionConflict   = errors.New("another local preview session is already active for this site")
@@ -26,9 +29,9 @@ var (
 	ErrLocalPreviewSessionReleasing  = errors.New("local preview session is being released")
 )
 
-// LocalPreviewWorkspace is the active unsaved-content workspace for one site.
-// Each site is intentionally limited to one active browser-document session so
-// separate tabs cannot silently mix unsaved content.
+// LocalPreviewWorkspace is the site-scoped unsaved-content workspace and its
+// current editor owner/article metadata. The generator project belongs to the
+// site and is reused when the owner selects another article.
 type LocalPreviewWorkspace struct {
 	SiteID      string
 	DraftID     string
@@ -220,9 +223,11 @@ func (m *LocalPreviewWorkspaceManager) AcquireIngress(siteID string) (LocalPrevi
 }
 
 // Update creates the site's workspace on the first request and applies the
-// newest editor revision. Older in-flight HTTP requests become harmless no-ops
-// instead of overwriting newer editor state. Requests renew a lease only while
-// it is still valid; an expired session must be reclaimed before it can restart.
+// newest revision for the selected article. The same owner may switch article
+// paths without recreating the workspace or restarting the generator. Older
+// in-flight HTTP requests become harmless no-ops instead of overwriting newer
+// editor state. Requests renew a lease only while it is still valid; an
+// expired session must be reclaimed before it can restart.
 func (m *LocalPreviewWorkspaceManager) Update(runtime config.SiteRuntime, draftID, articlePath string, revision uint64, content []byte) (LocalPreviewWorkspace, bool, bool, error) {
 	return m.update(runtime, draftID, articlePath, revision, content, nil)
 }
@@ -277,16 +282,20 @@ func (m *LocalPreviewWorkspaceManager) update(runtime config.SiteRuntime, draftI
 		if workspace.DraftID != draftID {
 			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionConflict
 		}
-		if workspace.ArticlePath != filepath.ToSlash(articlePath) {
-			return LocalPreviewWorkspace{}, false, false, ErrLocalPreviewSessionMismatch
-		}
-		workspace.LastSeenAt = now
 		if revision <= workspace.Revision {
+			workspace.LastSeenAt = now
 			m.sessions[runtime.ID] = workspace
 			return workspace, false, false, nil
 		}
+		if workspace.ArticlePath != filepath.ToSlash(articlePath) {
+			// Keep the site workspace and advance the selected article only for a
+			// newer request. A late request for the previous article is therefore a
+			// harmless no-op instead of moving the active selection backwards.
+			workspace.ArticlePath = filepath.ToSlash(articlePath)
+		}
+		workspace.LastSeenAt = now
 	} else {
-		workspaceRoot := filepath.Join(m.root, runtime.ID, draftID)
+		workspaceRoot := filepath.Join(m.root, runtime.ID)
 		if err := os.RemoveAll(workspaceRoot); err != nil {
 			return LocalPreviewWorkspace{}, false, false, fmt.Errorf("reset local preview workspace: %w", err)
 		}
@@ -390,6 +399,32 @@ func (m *LocalPreviewWorkspaceManager) Status(siteID string) (LocalPreviewWorksp
 		return LocalPreviewWorkspace{}, false, false
 	}
 	return workspace, true, m.staleLocked(workspace, m.currentTimeLocked())
+}
+
+// IdleWorkspaces returns active site workspaces that have not received an
+// editor update or heartbeat within timeout. The caller must claim each
+// returned workspace before stopping its generator so a concurrent editor
+// request cannot revive it during cleanup.
+func (m *LocalPreviewWorkspaceManager) IdleWorkspaces(timeout time.Duration) []LocalPreviewWorkspace {
+	if timeout <= 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return nil
+	}
+	now := m.currentTimeLocked()
+	idle := make([]LocalPreviewWorkspace, 0)
+	for siteID, workspace := range m.sessions {
+		if m.transitionErrorLocked(siteID) != nil || workspace.LastSeenAt.IsZero() {
+			continue
+		}
+		if now.Sub(workspace.LastSeenAt) >= timeout {
+			idle = append(idle, workspace)
+		}
+	}
+	return idle
 }
 
 // SyncContentResource mirrors a content-directory resource change made through

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"hugo-cms/pkg/config"
 	"os"
@@ -55,6 +56,70 @@ func TestLocalPreviewWorkspaceMirrorsAndUpdatesContent(t *testing.T) {
 	}
 	if string(original) != "old" {
 		t.Fatalf("production content was modified: %q", original)
+	}
+}
+
+func TestLocalPreviewWorkspaceReusesSiteWorkspaceWhenArticleChanges(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+
+	first, created, applied, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("first draft"))
+	if err != nil {
+		t.Fatalf("first Update() error = %v", err)
+	}
+	if !created || !applied {
+		t.Fatalf("first update created=%v applied=%v, want true/true", created, applied)
+	}
+
+	second, created, applied, err := manager.Update(runtime, "draft-1", "two.md", 2, []byte("second draft"))
+	if err != nil {
+		t.Fatalf("second Update() error = %v", err)
+	}
+	if created || !applied {
+		t.Fatalf("article switch created=%v applied=%v, want false/true", created, applied)
+	}
+	if first.ContentDir != second.ContentDir || first.ProjectDir != second.ProjectDir {
+		t.Fatalf("article switch recreated workspace: first=%#v second=%#v", first, second)
+	}
+	if second.ArticlePath != "two.md" || second.Revision != 2 {
+		t.Fatalf("selected article metadata = path=%q revision=%d", second.ArticlePath, second.Revision)
+	}
+	assertFileContent(t, filepath.Join(second.ContentDir, "one.md"), "first draft")
+	assertFileContent(t, filepath.Join(second.ContentDir, "two.md"), "second draft")
+	late, created, applied, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("late old article"))
+	if err != nil {
+		t.Fatalf("late Update() error = %v", err)
+	}
+	if created || applied || late.ArticlePath != "two.md" || late.Revision != 2 {
+		t.Fatalf("late update created=%v applied=%v path=%q revision=%d", created, applied, late.ArticlePath, late.Revision)
+	}
+	assertFileContent(t, filepath.Join(second.ContentDir, "one.md"), "first draft")
+}
+
+func TestLocalPreviewIdleRuntimeDetachesIdleWorkspace(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	manager.now = func() time.Time { return base }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft")); err != nil {
+		t.Fatal(err)
+	}
+	manager.now = func() time.Time { return base.Add(DefaultLocalPreviewIdleTimeout + time.Second) }
+	previewManager := NewLocalPreviewManager(nil)
+	previewManager.idleTimeout = DefaultLocalPreviewIdleTimeout
+	if err := previewManager.StopIdle(context.Background(), manager); err != nil {
+		t.Fatalf("StopIdle() error = %v", err)
+	}
+	if _, active, _ := manager.Status(runtime.ID); active {
+		t.Fatal("idle workspace is still active")
 	}
 }
 

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -123,6 +123,41 @@ func TestLocalPreviewIdleRuntimeDetachesIdleWorkspace(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewClaimIdleRechecksHeartbeatBeforeRelease(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	now := base.Add(DefaultLocalPreviewIdleTimeout + time.Second)
+	manager.now = func() time.Time { return now }
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	if _, _, _, err := manager.Update(runtime, "draft-1", "one.md", 1, []byte("draft")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a heartbeat winning between IdleWorkspaces and ClaimIdle.
+	now = base.Add(DefaultLocalPreviewIdleTimeout - time.Second)
+	if _, err := manager.Heartbeat(runtime.ID, "draft-1"); err != nil {
+		t.Fatalf("Heartbeat() error = %v", err)
+	}
+	now = base.Add(DefaultLocalPreviewIdleTimeout + time.Second)
+	if _, claimed, err := manager.ClaimIdle(runtime.ID, "draft-1", DefaultLocalPreviewIdleTimeout); err != nil || claimed {
+		t.Fatalf("ClaimIdle() claimed=%v err=%v, want false/nil after heartbeat", claimed, err)
+	}
+
+	now = base.Add(2*DefaultLocalPreviewIdleTimeout + time.Second)
+	claim, claimed, err := manager.ClaimIdle(runtime.ID, "draft-1", DefaultLocalPreviewIdleTimeout)
+	if err != nil || !claimed {
+		t.Fatalf("ClaimIdle() claimed=%v err=%v, want true/nil", claimed, err)
+	}
+	if _, err := manager.Heartbeat(runtime.ID, "draft-1"); !errors.Is(err, ErrLocalPreviewSessionReleasing) {
+		t.Fatalf("Heartbeat() after claim error = %v, want releasing", err)
+	}
+	manager.CancelRelease(claim)
+}
+
 func TestEleventyLocalPreviewWorkspaceUsesProjectRootOverlay(t *testing.T) {
 	repo := t.TempDir()
 	for _, directory := range []string{

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -58,9 +58,6 @@ func (resolver *hugoPreviewURLResolver) ResolveArticleURL(ctx context.Context, r
 	if workspace.ContentDir == "" {
 		return "", fmt.Errorf("preview workspace content directory is required")
 	}
-	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
-		return "", fmt.Errorf("preview workspace article does not match request")
-	}
 	if strings.TrimSpace(runtime.ProductionContentDir) == "" {
 		runtime.ProductionContentDir = runtime.ContentDir
 	}
@@ -258,9 +255,6 @@ func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Contex
 	}
 	if workspace.ContentDir == "" {
 		return "", fmt.Errorf("preview workspace content directory is required")
-	}
-	if workspace.ArticlePath != filepath.ToSlash(articlePath) {
-		return "", fmt.Errorf("preview workspace article does not match request")
 	}
 	if strings.TrimSpace(runtime.ProductionContentDir) == "" {
 		runtime.ProductionContentDir = runtime.ContentDir

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -112,15 +112,18 @@ func TestParseHugoListAllMatchesRelativeAndAbsoluteContentPaths(t *testing.T) {
 	}
 }
 
-func TestHugoPreviewURLResolverRejectsMismatchedArticle(t *testing.T) {
+func TestHugoPreviewURLResolverAllowsAnotherArticleInSiteWorkspace(t *testing.T) {
 	resolver := &hugoPreviewURLResolver{run: func(context.Context, config.SiteRuntime, string) ([]byte, error) {
-		t.Fatal("Hugo should not run for a mismatched article")
-		return nil, nil
+		return []byte("path,url\ncontent/posts/two.md,/posts/two/\n"), nil
 	}}
 	runtime := config.SiteRuntime{ID: "tech", ContentDir: "/tmp/content", LocalPreview: config.LocalPreviewConfig{URL: "https://tech.preview.example.com/"}}
 	workspace := LocalPreviewWorkspace{ArticlePath: "posts/one.md", ContentDir: "/tmp/content"}
-	if _, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md"); err == nil {
-		t.Fatal("ResolveArticleURL() should reject a mismatched article")
+	got, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md")
+	if err != nil {
+		t.Fatalf("ResolveArticleURL() error = %v", err)
+	}
+	if got != "https://tech.preview.example.com/posts/two/" {
+		t.Fatalf("resolved URL = %q", got)
 	}
 }
 
@@ -268,15 +271,18 @@ func TestParseEleventyJSONMatchesRelativeInputAndDataPageURL(t *testing.T) {
 	}
 }
 
-func TestEleventyPreviewURLResolverRejectsMismatchedArticle(t *testing.T) {
+func TestEleventyPreviewURLResolverAllowsAnotherArticleInSiteWorkspace(t *testing.T) {
 	resolver := &eleventyPreviewURLResolver{run: func(context.Context, config.SiteRuntime) ([]byte, error) {
-		t.Fatal("Eleventy should not run for a mismatched article")
-		return nil, nil
+		return []byte(`[{"inputPath":"/tmp/content/posts/two.md","url":"/posts/two/"}]`), nil
 	}}
 	runtime := config.SiteRuntime{ID: "daily-blog", ContentDir: "/tmp/content", LocalPreview: config.LocalPreviewConfig{URL: "https://daily-blog.preview.example.com/"}}
 	workspace := LocalPreviewWorkspace{ArticlePath: "posts/one.md", ContentDir: "/tmp/content"}
-	if _, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md"); err == nil {
-		t.Fatal("ResolveArticleURL() should reject a mismatched article")
+	got, err := resolver.ResolveArticleURL(context.Background(), runtime, workspace, "posts/two.md")
+	if err != nil {
+		t.Fatalf("ResolveArticleURL() error = %v", err)
+	}
+	if got != "https://daily-blog.preview.example.com/posts/two/" {
+		t.Fatalf("resolved URL = %q", got)
 	}
 }
 

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -355,11 +355,13 @@ test("starts real Eleventy serve and broadcasts LiveReload", { skip: !hasRealEle
     assert.equal(metadata.statusCode, 200);
     assert.equal(JSON.parse(metadata.body).url, "/custom/one/");
     reloadSocket = await connectReloadSocket(port);
+    let reloadReceived = false;
     const reload = new Promise((resolve, reject) => {
       const deadline = setTimeout(() => reject(new Error("Timed out waiting for Eleventy LiveReload")), 15000);
       reloadSocket.on("data", (chunk) => {
         if (chunk.toString("utf8").includes('"type":"eleventy.reload"')) {
           clearTimeout(deadline);
+          reloadReceived = true;
           resolve();
         }
       });
@@ -369,12 +371,21 @@ test("starts real Eleventy serve and broadcasts LiveReload", { skip: !hasRealEle
     assert.equal(invalidated.statusCode, 202);
     const invalidatedMetadata = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
     assert.equal(invalidatedMetadata.statusCode, 503);
-    fs.writeFileSync(
-      fixture.article,
-      ["---", "title: Changed", "permalink: /custom/changed/", "---", "", "# {{ title }}", ""].join("\n"),
-    );
-    await reload;
-    const updatedMetadata = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
+    const updatedArticle = ["---", "title: Changed", "permalink: /custom/changed/", "---", "", "# {{ title }}", ""].join("\n");
+    fs.writeFileSync(fixture.article, updatedArticle);
+    // The first filesystem event can be coalesced with Eleventy's initial
+    // watch setup on a busy runner. Repeat the same write until the watcher
+    // acknowledges the rebuild so the test checks the LiveReload contract
+    // instead of depending on one platform-specific event delivery.
+    const retryWrite = setInterval(() => {
+      if (!reloadReceived) fs.writeFileSync(fixture.article, updatedArticle);
+    }, 1000);
+    try {
+      await reload;
+    } finally {
+      clearInterval(retryWrite);
+    }
+    const updatedMetadata = await waitForHTTPStatus(port, "/__hugo_cms_metadata?path=posts%2Fone.md", 200);
     assert.equal(updatedMetadata.statusCode, 200);
     assert.equal(JSON.parse(updatedMetadata.body).url, "/custom/changed/");
   } finally {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -230,7 +230,6 @@ async function loadFile(path) {
         return;
     }
 
-    localPreviewSessionID = "";
     resetLocalPreviewArticleURL();
     if (localPreviewEnabled) {
         localPreviewFrameController?.resetDismissed();

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -285,6 +285,13 @@ export async function refreshLocalLivePreview() {
     }
 }
 
+// Destructive article/site operations must wait for preview writes that have
+// already been sent. The site-scoped workspace stays alive across deletion,
+// so a late update must not recreate a removed article.
+export function waitForLocalPreviewUpdates(pending = localPreviewInflight) {
+    return Promise.allSettled(Array.from(pending));
+}
+
 export async function releaseLocalLivePreview() {
     cancelLocalPreviewTimer();
     const sessionID = localPreviewSessionID;
@@ -295,7 +302,7 @@ export async function releaseLocalLivePreview() {
 
     // Do not race release against an update that the server may still be
     // applying even when the UI has moved on to another article/site.
-    await Promise.allSettled(Array.from(localPreviewInflight));
+    await waitForLocalPreviewUpdates();
     try {
         const result = await API.releaseLocalPreviewContent(sessionID);
         resetLocalPreviewClientState();
@@ -385,7 +392,7 @@ export async function loadFile(path) {
         // Complete the previous article's preview update before changing the
         // selected path. The site workspace is reused, so an old request must
         // not arrive after the new article update and move the selection back.
-        await Promise.allSettled(Array.from(localPreviewInflight));
+        await waitForLocalPreviewUpdates();
     }
     await saveQueue.catch(() => {
         // Loading another file remains possible after a failed save.
@@ -460,6 +467,11 @@ export async function deleteFile(refreshListCb) {
         // Let a save that already reached the server finish, then prevent all
         // queued saves for this path from starting before DELETE.
         await saveQueue;
+        // The site-scoped workspace remains alive after article deletion. Wait
+        // for already-sent preview updates before removing the production and
+        // shadow files, otherwise a late update could recreate the deleted
+        // article in the resident workspace.
+        await waitForLocalPreviewUpdates();
         await API.deleteArticle(pathToDelete);
         // Production deletion is committed at this point. The server removes
         // the corresponding file from the site-scoped preview workspace while

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -292,6 +292,10 @@ export function waitForLocalPreviewUpdates(pending = localPreviewInflight) {
     return Promise.allSettled(Array.from(pending));
 }
 
+export function isLocalPreviewOwnershipConflict(error) {
+    return error?.status === 409;
+}
+
 // Article switching cancels the debounce timer, so explicitly send the
 // current editor payload after the previous preview writes have settled.
 // Keeping the pending set shared lets the final wait include this flush too.
@@ -394,10 +398,23 @@ export async function loadFile(path) {
     if (switchingArticle) {
         try {
             await queueCurrentSave("Saving before article switch...");
-            await flushLocalPreviewBeforeArticleSwitch();
         } catch (e) {
             UI.showToast("Failed to prepare article before switching: " + e.message, "error");
             return;
+        }
+        try {
+            await flushLocalPreviewBeforeArticleSwitch();
+        } catch (e) {
+            // A 409 means another document owns the site's preview workspace.
+            // Preview sync is unavailable for this tab, but normal article
+            // navigation must remain available. Production save errors above
+            // are still blocking.
+            if (isLocalPreviewOwnershipConflict(e)) {
+                // Continue with the article switch without a preview flush.
+            } else {
+                UI.showToast("Failed to prepare article before switching: " + e.message, "error");
+                return;
+            }
         }
     }
     await saveQueue.catch(() => {

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -256,9 +256,6 @@ export async function refreshLocalLivePreview() {
     const sessionID = localPreviewSessionID || createLocalPreviewSessionID();
     if (!sessionID) return null;
 
-    if (localPreviewSessionPath && localPreviewSessionPath !== requestPath) {
-        throw new Error("Local Live Preview session path changed without release");
-    }
     localPreviewSessionID = sessionID;
     localPreviewSessionPath = requestPath;
     const revision = ++localPreviewRevision;
@@ -377,21 +374,22 @@ export async function loadFile(path) {
     clearAutoSaveTimer();
     cancelMarkdownPreview();
     cancelLocalPreviewTimer();
+    const switchingArticle = Boolean(currentPath && currentPath !== path);
+    if (switchingArticle) {
+        try {
+            await queueCurrentSave("Saving before article switch...");
+        } catch (e) {
+            UI.showToast("Failed to save before switching article: " + e.message, "error");
+            return;
+        }
+        // Complete the previous article's preview update before changing the
+        // selected path. The site workspace is reused, so an old request must
+        // not arrive after the new article update and move the selection back.
+        await Promise.allSettled(Array.from(localPreviewInflight));
+    }
     await saveQueue.catch(() => {
         // Loading another file remains possible after a failed save.
     });
-
-    // A failed cleanup can leave preview ownership alive even after the
-    // production article was deleted and currentPath was cleared. Base the
-    // retry decision on Local Preview ownership rather than editor selection.
-    if (localPreviewSessionID && localPreviewSessionPath && localPreviewSessionPath !== path) {
-        try {
-            await releaseLocalLivePreview();
-        } catch (e) {
-            UI.showToast("Failed to release Local Live Preview: " + e.message, "error");
-            return;
-        }
-    }
 
     currentPath = path;
     const display = document.getElementById('filename-display');
@@ -463,24 +461,11 @@ export async function deleteFile(refreshListCb) {
         // queued saves for this path from starting before DELETE.
         await saveQueue;
         await API.deleteArticle(pathToDelete);
-        // Production deletion is committed at this point. Preview cleanup is a
-        // separate best-effort operation and must never re-enable autosave for
-        // the deleted article.
+        // Production deletion is committed at this point. The server removes
+        // the corresponding file from the site-scoped preview workspace while
+        // keeping the generator runtime alive for the next article.
         deleted = true;
-
-        let previewCleanupError = null;
-        try {
-            await releaseLocalLivePreview();
-        } catch (e) {
-            previewCleanupError = e;
-            console.error("[LocalPreview] Cleanup after article deletion failed:", e);
-        }
-
-        if (previewCleanupError) {
-            UI.showToast("Article deleted, but Local Live Preview cleanup failed: " + previewCleanupError.message, "warning");
-        } else {
-            UI.showToast("Article deleted", "success");
-        }
+        UI.showToast("Article deleted", "success");
 
         if (currentPath === pathToDelete) {
             cancelMarkdownPreview();

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -292,6 +292,15 @@ export function waitForLocalPreviewUpdates(pending = localPreviewInflight) {
     return Promise.allSettled(Array.from(pending));
 }
 
+// Article switching cancels the debounce timer, so explicitly send the
+// current editor payload after the previous preview writes have settled.
+// Keeping the pending set shared lets the final wait include this flush too.
+export async function flushLocalPreviewBeforeArticleSwitch(flush = refreshLocalLivePreview, pending = localPreviewInflight) {
+    await waitForLocalPreviewUpdates(pending);
+    await flush();
+    await waitForLocalPreviewUpdates(pending);
+}
+
 export async function releaseLocalLivePreview() {
     cancelLocalPreviewTimer();
     const sessionID = localPreviewSessionID;
@@ -385,14 +394,11 @@ export async function loadFile(path) {
     if (switchingArticle) {
         try {
             await queueCurrentSave("Saving before article switch...");
+            await flushLocalPreviewBeforeArticleSwitch();
         } catch (e) {
-            UI.showToast("Failed to save before switching article: " + e.message, "error");
+            UI.showToast("Failed to prepare article before switching: " + e.message, "error");
             return;
         }
-        // Complete the previous article's preview update before changing the
-        // selected path. The site workspace is reused, so an old request must
-        // not arrive after the new article update and move the selection back.
-        await waitForLocalPreviewUpdates();
     }
     await saveQueue.catch(() => {
         // Loading another file remains possible after a failed save.

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -38,6 +38,7 @@ const {
     createLocalPreviewSessionID,
     flushLocalPreviewBeforeArticleSwitch,
     getOrCreateDraftID,
+    isLocalPreviewOwnershipConflict,
     waitForLocalPreviewUpdates,
 } = await import("./editor.js");
 const API = await import("./api.js");
@@ -381,6 +382,12 @@ describe("Local Preview destructive operations", () => {
         resolveOldUpdate();
         await switching;
         assert.deepEqual(events, ["latest payload sent", "latest payload applied"]);
+    });
+
+    it("does not block article switching on a Local Preview ownership conflict", () => {
+        assert.equal(isLocalPreviewOwnershipConflict({ status: 409 }), true);
+        assert.equal(isLocalPreviewOwnershipConflict({ status: 500 }), false);
+        assert.equal(isLocalPreviewOwnershipConflict(new Error("network failure")), false);
     });
 });
 

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -33,7 +33,12 @@ const {
     shouldRetryLocalPreviewNavigation,
     shouldUseLocalPreviewSplitDefault,
 } = await import("./local_preview.js");
-const { createDraftUUID, createLocalPreviewSessionID, getOrCreateDraftID } = await import("./editor.js");
+const {
+    createDraftUUID,
+    createLocalPreviewSessionID,
+    getOrCreateDraftID,
+    waitForLocalPreviewUpdates,
+} = await import("./editor.js");
 const API = await import("./api.js");
 
 describe("safeExternalURL", () => {
@@ -329,6 +334,27 @@ describe("draft IDs", () => {
         assert.equal(createLocalPreviewSessionID(createUUID), "local-1");
         assert.equal(createLocalPreviewSessionID(createUUID), "local-2");
         assert.equal(sessionValues.size, 0);
+    });
+});
+
+describe("Local Preview destructive operations", () => {
+    it("waits for in-flight updates before deleting an article", async () => {
+        let updateApplied = false;
+        let resolveUpdate;
+        const update = new Promise(resolve => {
+            resolveUpdate = () => {
+                updateApplied = true;
+                resolve();
+            };
+        });
+
+        const waiting = waitForLocalPreviewUpdates(new Set([update]));
+        await Promise.resolve();
+        assert.equal(updateApplied, false);
+
+        resolveUpdate();
+        await waiting;
+        assert.equal(updateApplied, true);
     });
 });
 

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -36,6 +36,7 @@ const {
 const {
     createDraftUUID,
     createLocalPreviewSessionID,
+    flushLocalPreviewBeforeArticleSwitch,
     getOrCreateDraftID,
     waitForLocalPreviewUpdates,
 } = await import("./editor.js");
@@ -355,6 +356,31 @@ describe("Local Preview destructive operations", () => {
         resolveUpdate();
         await waiting;
         assert.equal(updateApplied, true);
+    });
+
+    it("flushes the latest preview payload before switching articles", async () => {
+        let oldUpdateApplied = false;
+        let resolveOldUpdate;
+        const oldUpdate = new Promise(resolve => {
+            resolveOldUpdate = () => {
+                oldUpdateApplied = true;
+                resolve();
+            };
+        });
+        const pending = new Set([oldUpdate]);
+        const events = [];
+        const switching = flushLocalPreviewBeforeArticleSwitch(async () => {
+            assert.equal(oldUpdateApplied, true);
+            events.push("latest payload sent");
+            const latestUpdate = Promise.resolve().then(() => events.push("latest payload applied"));
+            pending.add(latestUpdate);
+        }, pending);
+
+        await Promise.resolve();
+        assert.deepEqual(events, []);
+        resolveOldUpdate();
+        await switching;
+        assert.deepEqual(events, ["latest payload sent", "latest payload applied"]);
     });
 });
 


### PR DESCRIPTION
## 概要

Issue #56に対応し、Local Live Previewを記事単位のworkspace/runtimeからsite単位の常駐runtimeへ変更しました。

- site単位のshadow workspace/projectを記事切替で再利用
- 記事切替時のrelease/Stop/cleanup/restartを廃止
- 同一ownerのpath切替と遅延revisionを安全に処理
- generator準拠のURL解決を任意の記事pathに対応
- 記事削除前にin-flight preview updateを待機し、shadowへの再出現を防止
- 明示停止・stale reclaim・idle timeout・CMS shutdownでcleanup
- idle claim時にLastSeenAtを再確認
- Hugo/Eleventyのruntime再利用テストとdocsを更新

## 検証

- go test ./...
- 
ode --test static/js/*.test.mjs scripts/*.test.cjs

PR #55のマージ後にbaseをmainへ更新済みです。

Closes #56