### PR TITLE
fix: Eleventy Local Previewのupdateとmetadata復帰を安定化

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -168,6 +168,7 @@ browserはdocumentごとの単調増加`revision`を送る。
 - `revision == 0`は拒否
 - server側でsite単位のrevisionを採番し、client revisionをtab間のordering判定に使わない
 - 複数tabのupdateはlast-write-winsで受理する
+- shadow上の対象contentが受信contentと同一ならrevision、atomic replace、metadata invalidationを行わずactivityだけ更新する
 - 対象記事はtemporary fileからreplaceする
 
 ### content resource同期
@@ -181,6 +182,8 @@ static配下はHugoが元repositoryを直接参照するためshadow同期しな
 Local Previewは完全にsite-scopedであり、browser tab ownership、lease、heartbeat、stale reclaimを持たない。同じsiteへの複数tabのupdateは同じshadow workspaceへlast-write-winsで適用する。update、記事URL解決、preview ingress、content resource同期はsite runtimeの`lastActivity`を更新する。
 
 article切替ではbrowserがproduction saveとin-flight update完了を待ち、同じsite workspaceへ選択pathを反映する。generator process、Eleventy project overlay、shadow workspaceは再作成しない。serverは受理したupdateごとにserver側revisionと現在記事pathを更新し、watch rebuild後に要求pathのURLを解決する。明示的な停止またはidle timeoutではcleanup leaseがsiteのwrite gateを取得してgenerator processを停止し、workspace rootを一意なcleanup領域へrenameして論理的にdetachする。その間、ingress、update、resource同期、記事URL解決はread gateを保持し、cleanup開始時のgenerationを跨いでgate待ちした要求は503またはno-opとして古いworkspaceを再作成しない。その後のshadow directoryの物理削除は非同期で行い、準備後のHTTP/WebSocket streamingはgate外で実行する。
+
+Eleventyでは同一contentのupdateをno-opにしてwatch rebuildを発生させない。content変更時のmetadata invalidationには対象pathを渡し、wrapperは一定時間build開始を観測できなければ対象fileのmtimeを再通知する。metadata endpointはinvalidation/build generationと最終build完了時刻を返し、URL解決timeoutやarticle not foundのserver logでbuild停滞とpath不一致を切り分けられる。
 
 ### filesystem境界
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -256,6 +256,8 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 
 Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsite runtimeの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、project-root overlay、`--to=json` metadata URL解決を同じ導線へ追加し、Issue #48ではEleventy Programmatic APIの実際のUserConfig形に合わせたhook登録と実Eleventy統合テストを追加しています。Issue #50ではcleanなproduction outputからの実サイト相当fixtureで、config.dir・collection glob・passthrough・plugin生成物とproduction output不変を検証しています。Issue #58ではbrowser tab ownership、lease、heartbeat、stale reclaimを廃止し、Local Previewをsite-scoped runtimeへ統一しています。
 
+Issue #60ではEleventyの重複updateを抑制し、同一contentのserver no-op、watcher再通知、metadata診断を追加しています。
+
 Site Registryでサイトごとに設定します。
 
 ```yaml

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -206,7 +206,7 @@ CMS側iframeにはsandboxを付け、top-level navigation等を許可しませ�
 
 ## article/site切替とcleanup
 
-article切替では、現在記事のproduction保存とin-flight Local Preview updateの完了を待ってから、同じsite workspaceへ新しい記事pathを反映します。generator process、project overlay、shadow workspaceは再利用し、watch rebuildとgenerator準拠のURL解決だけを行います。browser tab ownershipを持たないため、記事切替でstop/releaseは実行しません。
+article切替では、現在記事のproduction保存とin-flight Local Preview updateの完了を待ってから、同じsite workspaceへ新しい記事pathを反映します。generator process、project overlay、shadow workspaceは再利用し、watch rebuildとgenerator準拠のURL解決だけを行います。browser tab ownershipを持たないため、記事切替でstop/releaseは実行しません。Previewの再表示では、現在のeditor payloadがshadowへ同期済みでruntimeもactiveなら既存workspaceをそのままURL解決し、不要なupdate/invalidationを発生させません。
 
 UIの明示的な停止では、clientがdebounce済みの更新をキャンセルし、送信済みの更新完了を待ってからsite runtimeを停止します。idle timeout、CMS shutdownを含め、site runtimeは次の順で終了します。
 

--- a/pkg/handlers/local_preview_content.go
+++ b/pkg/handlers/local_preview_content.go
@@ -57,7 +57,7 @@ func UpdateLocalPreviewContent(c *gin.Context) {
 		return
 	}
 	workspace, created, applied, err := workspaceManager.UpdateWithBeforeWrite(runtime, req.Path, req.Revision, finalContent, func() error {
-		return services.DefaultLocalPreviewManager().InvalidateArticleURL(runtime)
+		return services.DefaultLocalPreviewManager().InvalidateArticleURL(runtime, req.Path)
 	})
 	if err != nil {
 		if errors.Is(err, services.ErrLocalPreviewCleanupTransition) {

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -681,7 +681,9 @@ func (m *LocalPreviewManager) Proxy(w http.ResponseWriter, r *http.Request, site
 // InvalidateArticleURL marks the next Eleventy watch build as required before
 // shadow content is written. A running process is optional: a process started
 // after the write will always build the latest workspace content from scratch.
-func (m *LocalPreviewManager) InvalidateArticleURL(runtime config.SiteRuntime) error {
+// The optional article path lets the wrapper re-notify its watcher if the
+// first filesystem event is coalesced.
+func (m *LocalPreviewManager) InvalidateArticleURL(runtime config.SiteRuntime, articlePaths ...string) error {
 	if !isEleventyLocalPreviewGenerator(runtime.Generator) {
 		return nil
 	}
@@ -694,7 +696,16 @@ func (m *LocalPreviewManager) InvalidateArticleURL(runtime config.SiteRuntime) e
 		return nil
 	}
 	address := net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(slot.Port))
-	request, err := http.NewRequest(http.MethodPost, "http://"+address+eleventyLocalPreviewInvalidatePath, nil)
+	endpoint := url.URL{Scheme: "http", Host: address, Path: eleventyLocalPreviewInvalidatePath}
+	if len(articlePaths) > 0 {
+		articlePath := filepath.Clean(strings.TrimSpace(articlePaths[0]))
+		if articlePath != "." && !filepath.IsAbs(articlePath) {
+			query := endpoint.Query()
+			query.Set("path", filepath.ToSlash(articlePath))
+			endpoint.RawQuery = query.Encode()
+		}
+	}
+	request, err := http.NewRequest(http.MethodPost, endpoint.String(), nil)
 	if err != nil {
 		return fmt.Errorf("%w: create request: %v", ErrLocalPreviewMetadataInvalidation, err)
 	}
@@ -736,7 +747,12 @@ func (m *LocalPreviewManager) ResolveArticleURL(ctx context.Context, runtime con
 	if process == nil || process.exited() {
 		return "", fmt.Errorf("Eleventy local preview process is not running")
 	}
-	return resolveRunningEleventyArticleURL(ctx, runtime, slot.Port, articlePath)
+	articleURL, err := resolveRunningEleventyArticleURL(ctx, runtime, slot.Port, articlePath)
+	if err != nil {
+		slog.Warn("Eleventy local preview URL resolution failed", "site", runtime.ID, "article_path", articlePath, "process_state", slot.State, "error", err)
+		return "", err
+	}
+	return articleURL, nil
 }
 
 func (m *LocalPreviewManager) ProxyRuntime(w http.ResponseWriter, r *http.Request, runtime config.SiteRuntime) error {

--- a/pkg/services/local_preview_workspace.go
+++ b/pkg/services/local_preview_workspace.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"hugo-cms/pkg/config"
@@ -304,6 +305,17 @@ func (m *LocalPreviewWorkspaceManager) update(runtime config.SiteRuntime, articl
 			_ = os.RemoveAll(filepath.Dir(workspace.ContentDir))
 		}
 		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("invalid local preview workspace path")
+	}
+	if existing, err := os.ReadFile(target); err == nil && bytes.Equal(existing, content) {
+		workspace.LastActivityAt = now
+		m.workspaces[runtime.ID] = workspace
+		m.activities[runtime.ID] = now
+		return workspace, created, false, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		if created {
+			_ = os.RemoveAll(filepath.Dir(workspace.ContentDir))
+		}
+		return LocalPreviewWorkspace{}, false, false, fmt.Errorf("read local preview target: %w", err)
 	}
 	if beforeWrite != nil {
 		if err := beforeWrite(); err != nil {

--- a/pkg/services/local_preview_workspace_test.go
+++ b/pkg/services/local_preview_workspace_test.go
@@ -51,6 +51,30 @@ func TestLocalPreviewWorkspaceAllowsIndependentTabsAndUsesServerRevision(t *test
 	assertFileContent(t, filepath.Join(third.ContentDir, "one.md"), "tab C")
 }
 
+func TestLocalPreviewWorkspaceSkipsIdenticalContentUpdates(t *testing.T) {
+	repo := makeLocalPreviewWorkspaceRepo(t)
+	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{ID: "tech", RepoPath: repo, ContentDir: "content"}
+	first, created, applied, err := manager.Update(runtime, "one.md", 1, []byte("same"))
+	if err != nil || !created || !applied || first.Revision != 1 {
+		t.Fatalf("first update = %#v created=%v applied=%v err=%v", first, created, applied, err)
+	}
+	hookCalled := false
+	second, created, applied, err := manager.UpdateWithBeforeWrite(runtime, "one.md", 2, []byte("same"), func() error {
+		hookCalled = true
+		return nil
+	})
+	if err != nil || created || applied || hookCalled {
+		t.Fatalf("identical update = %#v created=%v applied=%v hook=%v err=%v", second, created, applied, hookCalled, err)
+	}
+	if second.Revision != first.Revision || second.ContentDir != first.ContentDir {
+		t.Fatalf("identical update changed workspace metadata: first=%#v second=%#v", first, second)
+	}
+}
+
 func TestLocalPreviewWorkspaceReusesWorkspaceWhenArticleChanges(t *testing.T) {
 	repo := makeLocalPreviewWorkspaceRepo(t)
 	manager, err := NewLocalPreviewWorkspaceManager(t.TempDir())

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hugo-cms/pkg/config"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -290,7 +291,10 @@ func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Contex
 }
 
 type eleventyRunningMetadata struct {
-	URL string `json:"url"`
+	URL                    string `json:"url"`
+	InvalidationGeneration uint64 `json:"invalidation_generation"`
+	ActiveBuildGeneration  uint64 `json:"active_build_generation"`
+	LastBuildCompletedAt   int64  `json:"last_build_completed_at"`
 }
 
 // resolveRunningEleventyArticleURL reads the URL map exposed by the running
@@ -328,12 +332,15 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 	client := &http.Client{Timeout: 500 * time.Millisecond}
 	ticker := time.NewTicker(defaultLocalPreviewProbeInterval)
 	defer ticker.Stop()
+	lastMetadataStatus := "not_observed"
+	var lastMetadata eleventyRunningMetadata
 
 	for {
 		request, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 		if requestErr == nil {
 			response, requestErr := client.Do(request)
 			if requestErr == nil {
+				lastMetadataStatus = response.Status
 				switch response.StatusCode {
 				case http.StatusOK:
 					var metadata eleventyRunningMetadata
@@ -347,10 +354,19 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 					}
 					return localPreviewArticleURL(previewURL, metadata.URL)
 				case http.StatusNotFound:
+					decodeErr := json.NewDecoder(response.Body).Decode(&lastMetadata)
 					_ = response.Body.Close()
+					if decodeErr != nil {
+						lastMetadata = eleventyRunningMetadata{}
+					}
+					slog.Warn("Eleventy metadata article not found", "site", runtime.ID, "article_path", articlePath, "metadata_status", lastMetadataStatus, "metadata_generation", lastMetadata.InvalidationGeneration, "active_build_generation", lastMetadata.ActiveBuildGeneration, "last_build_completed_at", lastMetadata.LastBuildCompletedAt)
 					return "", fmt.Errorf("eleventy did not resolve article %q", articlePath)
 				case http.StatusServiceUnavailable:
+					decodeErr := json.NewDecoder(response.Body).Decode(&lastMetadata)
 					_ = response.Body.Close()
+					if decodeErr != nil {
+						lastMetadata = eleventyRunningMetadata{}
+					}
 				default:
 					status := response.Status
 					_ = response.Body.Close()
@@ -362,6 +378,7 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 		select {
 		case <-ctx.Done():
 			if ctx.Err() == context.DeadlineExceeded {
+				slog.Warn("Eleventy metadata stuck building", "site", runtime.ID, "article_path", articlePath, "metadata_status", lastMetadataStatus, "metadata_generation", lastMetadata.InvalidationGeneration, "active_build_generation", lastMetadata.ActiveBuildGeneration, "last_build_completed_at", lastMetadata.LastBuildCompletedAt)
 				return "", fmt.Errorf("eleventy running preview URL resolution timed out after %s", timeout)
 			}
 			return "", ctx.Err()

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -13,6 +13,8 @@ const RELOAD_SOCKET_PATH = "/__hugo_cms_live_reload";
 const READY_PATH = "/__hugo_cms_ready";
 const METADATA_PATH = "/__hugo_cms_metadata";
 const INVALIDATE_PATH = "/__hugo_cms_invalidate";
+const WATCH_RECOVERY_DELAY_MS = 750;
+const WATCH_RECOVERY_INTERVAL_MS = 1000;
 const RELOAD_SCRIPT = `(() => {
   const protocol = location.protocol === "https:" ? "wss:" : "ws:";
   const socket = new WebSocket(protocol + "//" + location.host + "${RELOAD_SOCKET_PATH}");
@@ -66,6 +68,37 @@ function createBuildState(input) {
     entries: new Map(),
     invalidationGeneration: 0,
     activeBuildGeneration: 0,
+    invalidationAt: 0,
+    invalidationPath: "",
+    lastBuildCompletedAt: 0,
+    recoveryTimer: null,
+  };
+  const clearRecoveryTimer = () => {
+    if (state.recoveryTimer !== null) {
+      clearTimeout(state.recoveryTimer);
+      state.recoveryTimer = null;
+    }
+  };
+  const scheduleRecovery = () => {
+    if (state.recoveryTimer !== null) return;
+    const recover = () => {
+      state.recoveryTimer = null;
+      if (state.ready || state.activeBuildGeneration >= state.invalidationGeneration || !state.invalidationPath) return;
+      const articlePath = path.resolve(state.inputRoot, state.invalidationPath);
+      try {
+        const inputRoot = path.resolve(state.inputRoot);
+        const relativePath = path.relative(inputRoot, articlePath);
+        if (relativePath.startsWith(".." + path.sep) || path.isAbsolute(relativePath)) return;
+        fs.utimesSync(articlePath, new Date(), new Date());
+      } catch (_) {
+        // The update may still be writing the file. Keep retrying until a
+        // build observes the invalidation or the process is stopped.
+      }
+      state.recoveryTimer = setTimeout(recover, WATCH_RECOVERY_INTERVAL_MS);
+      state.recoveryTimer.unref?.();
+    };
+    state.recoveryTimer = setTimeout(recover, WATCH_RECOVERY_DELAY_MS);
+    state.recoveryTimer.unref?.();
   };
   state.begin = () => {
     state.activeBuildGeneration = state.invalidationGeneration;
@@ -94,13 +127,33 @@ function createBuildState(input) {
     state.entries = entries;
     state.ready = state.activeBuildGeneration >= state.invalidationGeneration;
     state.building = !state.ready;
+    state.lastBuildCompletedAt = Date.now();
+    if (state.ready) {
+      state.invalidationAt = 0;
+      state.invalidationPath = "";
+      clearRecoveryTimer();
+    }
   };
-  state.invalidate = () => {
+  state.invalidate = (articlePath = "") => {
     state.invalidationGeneration += 1;
     state.ready = false;
     state.building = true;
+    state.invalidationAt = Date.now();
+    const absoluteArticlePath = path.resolve(state.inputRoot, articlePath);
+    const relativeArticlePath = path.relative(state.inputRoot, absoluteArticlePath);
+    state.invalidationPath = articlePath && relativeArticlePath && !relativeArticlePath.startsWith(".." + path.sep) && !path.isAbsolute(relativeArticlePath)
+      ? normalizeMetadataPath(relativeArticlePath)
+      : "";
+    clearRecoveryTimer();
+    scheduleRecovery();
     return state.invalidationGeneration;
   };
+  state.diagnostics = () => ({
+    invalidation_generation: state.invalidationGeneration,
+    active_build_generation: state.activeBuildGeneration,
+    last_build_completed_at: state.lastBuildCompletedAt,
+    invalidation_at: state.invalidationAt,
+  });
   state.get = (articlePath) => {
     const absoluteArticlePath = path.resolve(state.inputRoot, articlePath);
     const relativeArticlePath = path.relative(state.inputRoot, absoluteArticlePath);
@@ -109,6 +162,7 @@ function createBuildState(input) {
     }
     return state.entries.get(normalizeMetadataPath(relativeArticlePath)) || null;
   };
+  state.stopRecovery = clearRecoveryTimer;
   return state;
 }
 
@@ -234,22 +288,22 @@ function createLoopbackServer(outputRoot, buildState = { ready: true, building: 
         sendJSON(response, 405, { status: "method_not_allowed" });
         return;
       }
-      const generation = buildState.invalidate?.() || 0;
-      sendJSON(response, 202, { status: "invalidated", generation });
+      const generation = buildState.invalidate?.(requestURL.searchParams.get("path") || "") || 0;
+      sendJSON(response, 202, { status: "invalidated", generation, ...buildState.diagnostics?.() });
       return;
     }
     if (requestURL.pathname === METADATA_PATH) {
       if (!buildState.ready) {
-        sendJSON(response, 503, { status: "building" });
+        sendJSON(response, 503, { status: "building", ...buildState.diagnostics?.() });
         return;
       }
       const articlePath = requestURL.searchParams.get("path");
       const metadata = articlePath ? buildState.get(articlePath) : null;
       if (!metadata) {
-        sendJSON(response, 404, { status: "not_found" });
+        sendJSON(response, 404, { status: "not_found", ...buildState.diagnostics?.() });
         return;
       }
-      sendJSON(response, 200, { status: "resolved", ...metadata });
+      sendJSON(response, 200, { status: "resolved", ...buildState.diagnostics?.(), ...metadata });
       return;
     }
     if (requestURL.pathname === RELOAD_SCRIPT_PATH) {
@@ -368,6 +422,7 @@ async function main(argv = process.argv.slice(2)) {
     await eleventy.init();
     await eleventy.watch();
   } catch (error) {
+    buildState?.stopRecovery?.();
     await closeServer(server);
     throw error;
   }
@@ -376,6 +431,7 @@ async function main(argv = process.argv.slice(2)) {
     if (stopping) return;
     stopping = true;
     await eleventy.stopWatch();
+    buildState?.stopRecovery?.();
     await closeServer(server);
     process.exit(0);
   };

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -10,6 +10,7 @@ const path = require("node:path");
 const test = require("node:test");
 
 const {
+  createBuildState,
   createLoopbackServer,
   configureProjectDirectories,
   findOutputFile,
@@ -259,6 +260,26 @@ test("uses the project-root overlay in JSON mode", () => {
   }
 });
 
+test("re-notifies a missed watcher event after invalidation", async () => {
+  const input = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-recovery-"));
+  const article = path.join(input, "posts", "one.md");
+  fs.mkdirSync(path.dirname(article), { recursive: true });
+  fs.writeFileSync(article, "# one\n");
+  const state = createBuildState(input);
+  try {
+    const before = fs.statSync(article).mtimeMs;
+    assert.equal(state.invalidate("posts/one.md"), 1);
+    assert.equal(state.diagnostics().invalidation_generation, 1);
+    await new Promise(resolve => setTimeout(resolve, 900));
+    assert.ok(fs.statSync(article).mtimeMs > before, "watcher recovery did not touch the article");
+  } finally {
+    state.activeBuildGeneration = state.invalidationGeneration;
+    state.update([]);
+    state.stopRecovery();
+    fs.rmSync(input, { recursive: true, force: true });
+  }
+});
+
 test("resolves a real Eleventy 3.x project in JSON mode", { skip: !hasRealEleventy() }, () => {
   const fixture = createEleventyFixture();
   try {
@@ -367,24 +388,13 @@ test("starts real Eleventy serve and broadcasts LiveReload", { skip: !hasRealEle
       });
       reloadSocket.once("error", reject);
     });
-    const invalidated = await requestHTTP(port, "/__hugo_cms_invalidate", "POST");
+    const invalidated = await requestHTTP(port, "/__hugo_cms_invalidate?path=posts%2Fone.md", "POST");
     assert.equal(invalidated.statusCode, 202);
     const invalidatedMetadata = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
     assert.equal(invalidatedMetadata.statusCode, 503);
     const updatedArticle = ["---", "title: Changed", "permalink: /custom/changed/", "---", "", "# {{ title }}", ""].join("\n");
     fs.writeFileSync(fixture.article, updatedArticle);
-    // The first filesystem event can be coalesced with Eleventy's initial
-    // watch setup on a busy runner. Repeat the same write until the watcher
-    // acknowledges the rebuild so the test checks the LiveReload contract
-    // instead of depending on one platform-specific event delivery.
-    const retryWrite = setInterval(() => {
-      if (!reloadReceived) fs.writeFileSync(fixture.article, updatedArticle);
-    }, 1000);
-    try {
-      await reload;
-    } finally {
-      clearInterval(retryWrite);
-    }
+    await reload;
     const updatedMetadata = await waitForHTTPStatus(port, "/__hugo_cms_metadata?path=posts%2Fone.md", 200);
     assert.equal(updatedMetadata.statusCode, 200);
     assert.equal(JSON.parse(updatedMetadata.body).url, "/custom/changed/");

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -218,7 +218,7 @@ async function loadFile(path) {
             narrowViewport: isNarrowViewport(),
         }) ? 'split' : 'edit');
         try {
-            await Editor.refreshLocalLivePreview();
+            if (localPreviewContentNeedsSync()) await Editor.refreshLocalLivePreview();
             const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (Editor.getCurrentPath() === path && !articleURL) {
                 throw new Error('generatorから記事URLを取得できませんでした');
@@ -258,6 +258,10 @@ function localPreviewURL() {
 
 function currentLocalPreviewURL() {
     return Editor.getCurrentPath() ? localPreviewArticleURL : localPreviewURL();
+}
+
+function localPreviewContentNeedsSync() {
+    return !Editor.isLocalLivePreviewCurrent() || localPreviewState?.workspace_active === false;
 }
 
 function isNarrowViewport() {
@@ -557,7 +561,7 @@ async function openLocalLivePreview() {
     }
     try {
         if (Editor.getCurrentPath()) {
-            await Editor.refreshLocalLivePreview();
+            if (localPreviewContentNeedsSync()) await Editor.refreshLocalLivePreview();
             const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }
@@ -585,7 +589,7 @@ async function toggleEmbeddedLocalPreview() {
     try {
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
-            await Editor.refreshLocalLivePreview();
+            if (localPreviewContentNeedsSync()) await Editor.refreshLocalLivePreview();
             const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -14,6 +14,7 @@ let previewController = null;
 let previewRevision = 0;
 let localPreviewTimer = null;
 let localPreviewRevision = 0;
+let localPreviewSyncedPayloadKey = "";
 const localPreviewInflight = new Set();
 
 const PREVIEW_DEBOUNCE_MS = 180;
@@ -224,6 +225,7 @@ function cancelLocalPreviewTimer() {
 
 function resetLocalPreviewClientState() {
     localPreviewRevision = 0;
+    localPreviewSyncedPayloadKey = "";
 }
 
 function scheduleLocalLivePreview() {
@@ -241,12 +243,16 @@ export async function refreshLocalLivePreview() {
 
     const revision = ++localPreviewRevision;
     const payload = getPayload();
+    const payloadKey = JSON.stringify(payload);
     const frontMatterKey = JSON.stringify(payload.frontmatter ?? null);
 
     const request = API.updateLocalPreviewContent(payload, revision);
     localPreviewInflight.add(request);
     try {
         const result = await request;
+        if (currentPath === payload.path && currentPath !== deletingPath) {
+            localPreviewSyncedPayloadKey = payloadKey;
+        }
         if (typeof window.refreshLocalPreviewArticleURL === 'function') {
             window.refreshLocalPreviewArticleURL(result, frontMatterKey).catch(() => undefined);
         }
@@ -257,6 +263,11 @@ export async function refreshLocalLivePreview() {
     } finally {
         localPreviewInflight.delete(request);
     }
+}
+
+export function isLocalLivePreviewCurrent() {
+    if (!localPreviewEnabled() || !currentPath || currentPath === deletingPath) return false;
+    return localPreviewSyncedPayloadKey === JSON.stringify(getPayload());
 }
 
 // Destructive article/site operations must wait for preview writes that have
@@ -365,6 +376,7 @@ export async function loadFile(path) {
     });
 
     currentPath = path;
+    resetLocalPreviewClientState();
     const display = document.getElementById('filename-display');
     if (display) display.textContent = path;
 
@@ -378,7 +390,6 @@ export async function loadFile(path) {
         lastSavedPayload = JSON.stringify(getPayload());
         lastQueuedPayload = "";
         await refreshMarkdownPreview();
-        refreshLocalLivePreview().catch(() => undefined);
 
     } catch (e) {
         UI.showEditorError(e);
@@ -449,6 +460,7 @@ export async function deleteFile(refreshListCb) {
             cancelMarkdownPreview();
             currentPath = "";
             currentData = null;
+            resetLocalPreviewClientState();
             lastSavedPayload = "";
             lastQueuedPayload = "";
             document.getElementById('filename-display').textContent = "Select a file...";
@@ -491,6 +503,7 @@ export async function createNewFile(refreshListCb) {
                 if (refreshListCb) await refreshListCb();
                 if (res.path) {
                     await loadFile(res.path);
+                    await refreshLocalLivePreview();
                     UI.showToast("File created successfully", "success");
                 }
             }
@@ -504,6 +517,7 @@ export async function resetChanges() {
     if (!currentPath) return;
     if (!confirm("Are you sure you want to discard all changes?")) return;
     await loadFile(currentPath);
+    await refreshLocalLivePreview();
     UI.showToast("Changes discarded", "info");
 }
 


### PR DESCRIPTION
## 概要

- 記事ロード時のLocal Preview update二重発行を解消
- Preview再表示時は同期済みpayloadとactive workspaceを再利用
- 同一contentのserver updateをrevision/invalidationなしのno-op化
- Eleventy invalidationに対象pathを渡し、watcher event取りこぼし時のmtime再通知を追加
- metadataのgeneration・build完了時刻を返し、URL解決失敗時の診断ログを強化
- 回帰テストと設計・利用ドキュメントを更新

## 検証

- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/ui.test.mjs scripts/eleventy-local-preview.test.cjs

Closes #60