### PR TITLE
feat: Eleventy記事切替をbuild完了待ちせず高速化

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -9,6 +9,7 @@ Issue #32のLocal Live Previewは段階的に実装する。
 - Phase 3 (#35): shadow content workspace + editor debounce + content resource同期
 - Phase 4: UI/運用導線、generator別URL解決
 - Issue #46: Eleventy `--serve`、project-root overlay、generator metadata URL解決
+- Issue #68: Eleventyのlast-known metadataを使ったcached URL先行navigationとfresh URL収束
 - Issue #37: 実blog・wildcard ingressでのHugo/Eleventy受け入れ確認は実環境で継続する
 
 Local Live PreviewはMarkdown本文プレビューとDeployment Previewを置き換えず、両者の中間を担う。
@@ -113,7 +114,7 @@ Eleventyは対象siteのpackage managerを再利用し、production repository�
 
 CMSのNodeラッパーはEleventyのprogrammatic `watch`で再ビルドし、Eleventyの初回build前にCMS側のHTTP/LiveReload WebSocket serverを`127.0.0.1`へbindする。`/__hugo_cms_ready`は初回build中に503、build完了後に200を返す。Eleventy標準Dev Serverのhost省略時のbind挙動や`HOST`環境変数には依存しない。出力ディレクトリはproductionの`public`/`_site`を上書きせず、停止時にtemporary outputを削除する。
 
-記事選択時の初回起動では、shadow workspaceを含むtemporary project-root overlayをgeneratorの入力として使う。CMSはgeneratorに依存しないURL解決契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装は稼働中wrapperが`eleventy.after`の結果から作る`inputPath -> url` mapを`/__hugo_cms_metadata`で公開し、CMSは同じprocessへ問い合わせる。workspace updateはshadow fileの書き換え直前にmetadataをinvalidateし、次のwatch build generationが完了するまでreadinessとmetadataを未完了として扱う。watch rebuild完了ごとにmapを置き換えるため、通常経路でresolver専用のJSON full buildやpreview outputの共有・resetは行わない。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
+記事選択時の初回起動では、shadow workspaceを含むtemporary project-root overlayをgeneratorの入力として使う。CMSはgeneratorに依存しないURL解決契約を介して解決する。Hugo実装はserverと同じ`--environment development`を指定し、`HUGO_CONTENTDIR`と`HUGO_BASEURL`のenvironment variableでshadow contentとLocal Preview URLをoverrideし、`--noBuildLock`を渡す。Eleventy実装は稼働中wrapperが`eleventy.after`の結果から作る`inputPath -> url` mapを`/__hugo_cms_metadata`で公開し、CMSは同じprocessへ問い合わせる。workspace updateはshadow fileの書き換え直前にmetadataをinvalidateする。既知の記事はwatch build generation中もlast-known mapを`stale`として返し、未知の記事や初回build前の記事だけはfresh mapまで待つ。記事切替はcached URLを先に表示し、build後にfresh URLが変わった場合だけ再遷移する。watch rebuild完了ごとにmapを置き換えるため、通常経路でresolver専用のJSON full buildやpreview outputの共有・resetは行わない。取得したURLはpath、query、fragmentを保持してLocal Preview originへ変換し、CMSはpermalink、slug、Data Cascade、paginationを再実装しない。以降の同一記事の編集はgeneratorのwatch/live reloadを利用する。
 
 ## Reverse proxy / LiveReload
 
@@ -227,7 +228,7 @@ POST /admin/api/preview/local
 POST /admin/api/preview/local/navigate
 ```
 
-記事選択時にCMSが記事pathを`/admin/api/preview/local/navigate`へ送り、Hugoは`hugo list all`、Eleventyは稼働中wrapperの`/__hugo_cms_metadata`へ問い合わせて要求pathの`article_url`を返す。Eleventyがbuild中ならmap更新まで待ち、初回起動も同じprocessのreadinessを待つ。この処理はproduction content、Git、browser revisionを変更しない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、その他の4xxは再試行しない。通常の本文編集はLiveReloadを利用し、URL関連front matter変更時は再解決する。解決失敗時はpreview rootへ黙ってフォールバックしない。
+記事選択時にCMSが記事pathを`/admin/api/preview/local/navigate`へ送り、Hugoは`hugo list all`、Eleventyは稼働中wrapperの`/__hugo_cms_metadata`へ問い合わせて要求pathの`article_url`を返す。レスポンスには`fresh`、`metadata_status`、build generationを含める。Eleventyが既知の記事をbuild中に解決した場合はcached URLを即時返し、clientはfresh mapをバックグラウンドで待ってURL変更時だけ再遷移する。未知の記事や初回起動は同じprocessのfresh metadata/readinessを待つ。この処理はproduction content、Git、browser revisionを変更しない。network error、408/425/429、5xxに限ってclientが250ms・750msのbackoffで最大3回まで再試行し、その他の4xxは再試行しない。通常の本文編集はLiveReloadを利用し、URL関連front matter変更時は再解決する。解決失敗時はpreview rootへ黙ってフォールバックしない。
 
 ### stop
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -256,7 +256,7 @@ CMSは設定読み込み時に、collection名・folder・path変数・`preview.
 
 Issue #32ではPhase 1/2でLocal Live Previewの設定・hostname routing・Hugo process/proxy/LiveReload基盤まで実装済みです。Phase 3 (#35)では未保存editor入力をephemeral shadow content workspaceへ約250msで反映し、generator watcherへつなぎます。Local Preview update自体はproduction working tree/Git index/refを書き換えず、content配下のmedia upload/deleteもactive workspaceへ同期します。Phase 4ではsite runtimeの状態表示と操作を追加し、Issue #38でCMS内の埋め込みpreviewを主導線、新規タブをfallbackとするUIへ整理しています。Issue #40ではLocal Preview有効siteの`Edit` / `Preview` / `Split`をLocal Live Preview中心に統合しています。Issue #42では記事選択直後の初回表示を追加し、Issue #44では`PreviewURLResolver`を通じてHugo自身のURL解決結果をiframeと新規タブへ直接表示するようにしています。Issue #46ではEleventyの`--serve`、project-root overlay、`--to=json` metadata URL解決を同じ導線へ追加し、Issue #48ではEleventy Programmatic APIの実際のUserConfig形に合わせたhook登録と実Eleventy統合テストを追加しています。Issue #50ではcleanなproduction outputからの実サイト相当fixtureで、config.dir・collection glob・passthrough・plugin生成物とproduction output不変を検証しています。Issue #58ではbrowser tab ownership、lease、heartbeat、stale reclaimを廃止し、Local Previewをsite-scoped runtimeへ統一しています。
 
-Issue #60ではEleventyの重複updateを抑制し、同一contentのserver no-op、watcher再通知、metadata診断を追加しています。Issue #64では記事削除とmedia/resource同期にもmetadata invalidationと削除時のparent directory recoveryを適用しています。
+Issue #60ではEleventyの重複updateを抑制し、同一contentのserver no-op、watcher再通知、metadata診断を追加しています。Issue #64では記事削除とmedia/resource同期にもmetadata invalidationと削除時のparent directory recoveryを適用しています。Issue #68では既知記事のlast-known metadataをbuild中もstaleとして返し、Eleventy記事切替をcached URLへ先に遷移してからfresh URLへ収束する方式にしています。
 
 Site Registryでサイトごとに設定します。
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -108,7 +108,7 @@ CMSのNodeラッパーはtemporary project-root overlayをcwdにしてEleventy�
 
 process停止はgeneratorの`cmd.Wait()`完了を成功条件とし、temporary outputのfilesystem cleanup完了を待ちません。workspaceが所有するEleventyのproject/outputはsite runtimeのStopまたはidle cleanupで削除し、process cleanupとの二重削除や次世代workspaceとの競合を避けます。workspace外のEleventy previewは起動ごとに一意なtemporary project rootを割り当て、停止後に所有projectだけを非同期cleanupします。cleanupの遅延・失敗はserver logへ記録しますが、generator processの停止失敗とは区別します。
 
-Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。通常の記事URL解決では、稼働中wrapperが`eleventy.after`の`inputPath`/`url`を保持する`/__hugo_cms_metadata?path=...`を利用します。workspace updateはshadow fileを書き換える直前にmetadataをinvalidateし、次のwatch buildが完了するまで旧mapを503で隠します。watch rebuildごとにmapを更新するため、resolver専用の追加full buildを発生させません。既存の直接resolver呼び出しにはJSONモードのfallbackを残します。
+Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。通常の記事URL解決では、稼働中wrapperが`eleventy.after`の`inputPath`/`url`を保持する`/__hugo_cms_metadata?path=...`を利用します。workspace updateはshadow fileを書き換える直前にmetadataをinvalidateします。既知の記事はwatch build中も旧mapを`status: stale`、`fresh: false`として返し、未知の記事だけはbuild完了まで503で待機します。watch rebuildごとにmapを更新するため、resolver専用の追加full buildを発生させません。既存の直接resolver呼び出しにはJSONモードのfallbackを残します。
 repo外のabsolute pathや環境変数で指定された外部pathはこのfilesystem overlayの保証対象外です。
 
 初回buildとwatch rebuild後のmetadata URL解決の待機上限はデフォルト2分です。必要に応じて`HUGO_CMS_LOCAL_PREVIEW_STARTUP_TIMEOUT`へGoのduration（例: `5m`）を設定できます。Eleventyの初回build失敗時は同じ重いbuildを自動で繰り返さず、stderrの末尾を含む診断を返します。
@@ -180,7 +180,7 @@ Local Live Previewが有効なsiteではheaderのview切替を次のように扱
 
 記事選択時はdesktopでは`Split`を初期viewにし、generatorが解決した記事ページを表示します。CMSは`slug`、`url`、permalink、page bundleの規則を推測せず、generatorのURL resolverへ解決を委譲します。Local Live Previewが無効なsiteでは、従来どおり`Preview`と`Split`の右側に簡易Markdown Previewを表示します。
 
-記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyは稼働中wrapperの`eleventy.after` metadata map（`inputPath`/`url`）を使います。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
+記事選択直後の初回表示では、現在の記事をshadow workspaceへ反映した後、generator自身のURL解決結果を取得します。Hugoは`hugo list all`の`permalink`、Eleventyは稼働中wrapperの`eleventy.after` metadata map（`inputPath`/`url`）を使います。Eleventyがready済みで対象記事のlast-known URLがある場合は、`fresh: false`のcached URLをbuild完了前にiframeへ設定し、fresh metadataの取得をバックグラウンドで続けます。build後のURLがcached URLと異なる場合だけiframeを再遷移し、同じ場合は再navigationしません。初回build前・新規記事などcached URLがない場合は従来どおりfresh metadataを待ちます。取得したURLはpath、query、fragmentを保持したままLocal Preview originへ変換し、iframeと新規タブへ直接設定します。CMSはslug、`url`、permalink、page bundle、Data Cascade、paginationなどの規則を再実装しません。通常の本文編集ではiframeの現在URLを維持してgeneratorのwatch/live reloadを利用し、URLに影響するfront matter変更時だけ再解決します。
 
 初回URL解決のnetwork error、408/425/429、5xxは250ms・750msのbackoffで最大3試行します。その他の4xxは再試行せず、エラー状態を表示します。URLを解決できない場合はpreview rootへフォールバックしません。
 

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -100,6 +100,7 @@ func GetArticle(c *gin.Context) {
 
 	c.JSON(http.StatusOK, models.Article{
 		Path:        targetPath,
+		RawContent:  string(content),
 		FrontMatter: fm,
 		Body:        body,
 		Format:      format,

--- a/pkg/handlers/local_preview_navigation.go
+++ b/pkg/handlers/local_preview_navigation.go
@@ -21,15 +21,16 @@ type localPreviewNavigationWorkspaceManager interface {
 }
 
 type localPreviewNavigationDependencies struct {
-	workspaceManager  localPreviewNavigationWorkspaceManager
-	resolveArticleURL func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error)
+	workspaceManager              localPreviewNavigationWorkspaceManager
+	resolveArticleURL             func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (string, error)
+	resolveArticleURLWithMetadata func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (services.PreviewArticleURLResolution, error)
 }
 
 // NavigateLocalPreview resolves the selected shadow article through the
 // configured generator and returns the URL to open in the local preview.
 func NavigateLocalPreview(c *gin.Context) {
 	navigateLocalPreview(c, localPreviewNavigationDependencies{
-		resolveArticleURL: services.DefaultLocalPreviewManager().ResolveArticleURL,
+		resolveArticleURLWithMetadata: services.DefaultLocalPreviewManager().ResolveArticleURLWithMetadata,
 	})
 }
 
@@ -72,7 +73,7 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 		ErrorConflict(c, "Local Live Preview workspace is not active")
 		return
 	}
-	if dependencies.resolveArticleURL == nil {
+	if dependencies.resolveArticleURL == nil && dependencies.resolveArticleURLWithMetadata == nil {
 		ErrorInternal(c, "Local preview URL resolver is unavailable")
 		return
 	}
@@ -83,7 +84,14 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 		resolverRuntime.RepoPath = workspace.ProjectDir
 		resolverRuntime.LocalPreviewProjectDir = workspace.ProjectDir
 	}
-	articleURL, err := dependencies.resolveArticleURL(c.Request.Context(), resolverRuntime, workspace, req.Path)
+	var resolution services.PreviewArticleURLResolution
+	if dependencies.resolveArticleURLWithMetadata != nil {
+		resolution, err = dependencies.resolveArticleURLWithMetadata(c.Request.Context(), resolverRuntime, workspace, req.Path)
+	} else {
+		var articleURL string
+		articleURL, err = dependencies.resolveArticleURL(c.Request.Context(), resolverRuntime, workspace, req.Path)
+		resolution = services.PreviewArticleURLResolution{URL: articleURL, Fresh: true, Status: "resolved"}
+	}
 	if err != nil {
 		slog.Error("Failed to resolve Local Live Preview article URL", "site", runtime.ID, "article_path", req.Path, "error", err)
 		ErrorInternal(c, "Failed to resolve Local Live Preview article URL")
@@ -91,10 +99,14 @@ func navigateLocalPreview(c *gin.Context, dependencies localPreviewNavigationDep
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status":       "resolved",
-		"article_url":  articleURL,
-		"revision":     workspace.Revision,
-		"preview_url":  runtime.LocalPreview.URL,
-		"article_path": workspace.ArticlePath,
+		"status":                  "resolved",
+		"article_url":             resolution.URL,
+		"fresh":                   resolution.Fresh,
+		"metadata_status":         resolution.Status,
+		"invalidation_generation": resolution.InvalidationGeneration,
+		"active_build_generation": resolution.ActiveBuildGeneration,
+		"revision":                workspace.Revision,
+		"preview_url":             runtime.LocalPreview.URL,
+		"article_path":            workspace.ArticlePath,
 	})
 }

--- a/pkg/handlers/local_preview_navigation_test.go
+++ b/pkg/handlers/local_preview_navigation_test.go
@@ -100,6 +100,40 @@ func TestNavigateLocalPreviewAcceptsAnyTabAndArticle(t *testing.T) {
 	}
 }
 
+func TestNavigateLocalPreviewReturnsMetadataFreshness(t *testing.T) {
+	site, _ := localPreviewNavigationTestSite(t)
+	configureLocalPreviewNavigationTestSite(t, site)
+	workspaceManager := &fakeLocalPreviewNavigationWorkspaceManager{
+		workspace: services.LocalPreviewWorkspace{SiteID: site.ID, ArticlePath: "one.md", ContentDir: filepath.Join(site.RepoPath, "shadow", "content"), Revision: 4},
+		active:    true,
+	}
+	response := executeLocalPreviewNavigationRequest(t, site.ID, localPreviewNavigationDependencies{
+		workspaceManager: workspaceManager,
+		resolveArticleURLWithMetadata: func(context.Context, config.SiteRuntime, services.LocalPreviewWorkspace, string) (services.PreviewArticleURLResolution, error) {
+			return services.PreviewArticleURLResolution{
+				URL:                    "https://tech.preview.example.com/old/",
+				Fresh:                  false,
+				Status:                 "stale",
+				InvalidationGeneration: 12,
+				ActiveBuildGeneration:  11,
+			}, nil
+		},
+	}, "one.md")
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", response.Code, response.Body.String())
+	}
+	var payload map[string]interface{}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["fresh"] != false || payload["metadata_status"] != "stale" || payload["article_url"] != "https://tech.preview.example.com/old/" {
+		t.Fatalf("response = %#v", payload)
+	}
+	if int(payload["invalidation_generation"].(float64)) != 12 || int(payload["active_build_generation"].(float64)) != 11 {
+		t.Fatalf("response generations = %#v", payload)
+	}
+}
+
 func TestNavigateLocalPreviewRequiresActiveWorkspace(t *testing.T) {
 	site, _ := localPreviewNavigationTestSite(t)
 	configureLocalPreviewNavigationTestSite(t, site)

--- a/pkg/models/article.go
+++ b/pkg/models/article.go
@@ -4,7 +4,8 @@ package models
 type Article struct {
 	Path        string                 `json:"path"`
 	Title       string                 `json:"title"`
-	Content     string                 `json:"content,omitempty"` // Raw content (backward compatibility)
+	Content     string                 `json:"content,omitempty"`     // Raw content (backward compatibility)
+	RawContent  string                 `json:"raw_content,omitempty"` // Original bytes for no-op preview synchronization
 	FrontMatter map[string]interface{} `json:"frontmatter,omitempty"`
 	Body        string                 `json:"body,omitempty"`
 	Format      string                 `json:"format,omitempty"` // yaml, toml, json

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -785,31 +785,47 @@ func (m *LocalPreviewManager) InvalidateArticleURL(runtime config.SiteRuntime, a
 // by the already-running preview process. Hugo keeps its existing resolver
 // because its list command is inexpensive and already reflects its watch state.
 func (m *LocalPreviewManager) ResolveArticleURL(ctx context.Context, runtime config.SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (string, error) {
+	resolution, err := m.ResolveArticleURLWithMetadata(ctx, runtime, workspace, articlePath)
+	if err != nil {
+		return "", err
+	}
+	return resolution.URL, nil
+}
+
+// ResolveArticleURLWithMetadata is the navigation-aware variant of
+// ResolveArticleURL. Eleventy can answer from its last completed metadata map
+// while a watch build is active, so the caller can use the cached URL now and
+// reconcile it after the build returns a fresh map.
+func (m *LocalPreviewManager) ResolveArticleURLWithMetadata(ctx context.Context, runtime config.SiteRuntime, workspace LocalPreviewWorkspace, articlePath string) (PreviewArticleURLResolution, error) {
 	if !isEleventyLocalPreviewGenerator(runtime.Generator) {
-		return ResolvePreviewArticleURL(ctx, runtime, workspace, articlePath)
+		articleURL, err := ResolvePreviewArticleURL(ctx, runtime, workspace, articlePath)
+		if err != nil {
+			return PreviewArticleURLResolution{}, err
+		}
+		return PreviewArticleURLResolution{URL: articleURL, Fresh: true, Status: "resolved"}, nil
 	}
 
 	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
 	if articlePath == "." || filepath.IsAbs(articlePath) {
-		return "", fmt.Errorf("invalid preview article path")
+		return PreviewArticleURLResolution{}, fmt.Errorf("invalid preview article path")
 	}
 	if workspace.ContentDir == "" {
-		return "", fmt.Errorf("preview workspace content directory is required")
+		return PreviewArticleURLResolution{}, fmt.Errorf("preview workspace content directory is required")
 	}
 	slot, err := m.ensureReadyRuntime(runtime)
 	if err != nil {
-		return "", fmt.Errorf("ensure Eleventy local preview ready: %w", err)
+		return PreviewArticleURLResolution{}, fmt.Errorf("ensure Eleventy local preview ready: %w", err)
 	}
 	process := m.process(runtime.ID)
 	if process == nil || process.exited() {
-		return "", fmt.Errorf("Eleventy local preview process is not running")
+		return PreviewArticleURLResolution{}, fmt.Errorf("Eleventy local preview process is not running")
 	}
-	articleURL, err := resolveRunningEleventyArticleURL(ctx, runtime, slot.Port, articlePath)
+	resolution, err := resolveRunningEleventyArticleURLResolution(ctx, runtime, slot.Port, articlePath)
 	if err != nil {
 		slog.Warn("Eleventy local preview URL resolution failed", "site", runtime.ID, "article_path", articlePath, "process_state", slot.State, "error", err)
-		return "", err
+		return PreviewArticleURLResolution{}, err
 	}
-	return articleURL, nil
+	return resolution, nil
 }
 
 func (m *LocalPreviewManager) ProxyRuntime(w http.ResponseWriter, r *http.Request, runtime config.SiteRuntime) error {

--- a/pkg/services/preview_url_resolver.go
+++ b/pkg/services/preview_url_resolver.go
@@ -28,6 +28,19 @@ type PreviewURLResolver interface {
 	ResolveArticleURL(context.Context, config.SiteRuntime, LocalPreviewWorkspace, string) (string, error)
 }
 
+// PreviewArticleURLResolution describes both the URL currently known by the
+// generator and whether it came from the completed build generation. Eleventy
+// can return a last-known URL while a watch build is running; callers may use
+// Fresh to navigate immediately and reconcile with the authoritative URL once
+// the build completes.
+type PreviewArticleURLResolution struct {
+	URL                    string
+	Fresh                  bool
+	Status                 string
+	InvalidationGeneration uint64
+	ActiveBuildGeneration  uint64
+}
+
 func NewPreviewURLResolver(generator string) (PreviewURLResolver, error) {
 	switch strings.ToLower(strings.TrimSpace(generator)) {
 	case "", "hugo":
@@ -292,26 +305,36 @@ func (resolver *eleventyPreviewURLResolver) ResolveArticleURL(ctx context.Contex
 
 type eleventyRunningMetadata struct {
 	URL                    string `json:"url"`
+	Status                 string `json:"status"`
+	Fresh                  *bool  `json:"fresh"`
 	InvalidationGeneration uint64 `json:"invalidation_generation"`
 	ActiveBuildGeneration  uint64 `json:"active_build_generation"`
 	LastBuildCompletedAt   int64  `json:"last_build_completed_at"`
 }
 
 // resolveRunningEleventyArticleURL reads the URL map exposed by the running
-// Eleventy helper. A 503 means the watcher is still building (or rebuilding),
-// so the request waits for the next completed build instead of starting a
-// second Eleventy process.
+// Eleventy helper. A known article may return a stale last-known URL while the
+// watcher is rebuilding; a 503 means no URL is known yet, so the request waits
+// for the next completed build instead of starting a second Eleventy process.
 func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRuntime, port int, articlePath string) (string, error) {
-	previewURL, err := localPreviewResolverURL(runtime)
+	resolution, err := resolveRunningEleventyArticleURLResolution(ctx, runtime, port, articlePath)
 	if err != nil {
 		return "", err
 	}
+	return resolution.URL, nil
+}
+
+func resolveRunningEleventyArticleURLResolution(ctx context.Context, runtime config.SiteRuntime, port int, articlePath string) (PreviewArticleURLResolution, error) {
+	previewURL, err := localPreviewResolverURL(runtime)
+	if err != nil {
+		return PreviewArticleURLResolution{}, err
+	}
 	articlePath = filepath.Clean(strings.TrimSpace(articlePath))
 	if articlePath == "." || filepath.IsAbs(articlePath) {
-		return "", fmt.Errorf("invalid preview article path")
+		return PreviewArticleURLResolution{}, fmt.Errorf("invalid preview article path")
 	}
 	if port < 1 || port > 65535 {
-		return "", fmt.Errorf("invalid local preview port %d", port)
+		return PreviewArticleURLResolution{}, fmt.Errorf("invalid local preview port %d", port)
 	}
 
 	if ctx == nil {
@@ -347,12 +370,34 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 					decodeErr := json.NewDecoder(response.Body).Decode(&metadata)
 					_ = response.Body.Close()
 					if decodeErr != nil {
-						return "", fmt.Errorf("decode Eleventy metadata: %w", decodeErr)
+						return PreviewArticleURLResolution{}, fmt.Errorf("decode Eleventy metadata: %w", decodeErr)
 					}
 					if strings.TrimSpace(metadata.URL) == "" {
-						return "", fmt.Errorf("Eleventy metadata did not provide a URL for article %q", articlePath)
+						return PreviewArticleURLResolution{}, fmt.Errorf("Eleventy metadata did not provide a URL for article %q", articlePath)
 					}
-					return localPreviewArticleURL(previewURL, metadata.URL)
+					fresh := metadata.Status != "stale"
+					if metadata.Fresh != nil {
+						fresh = *metadata.Fresh
+					}
+					status := strings.TrimSpace(metadata.Status)
+					if status == "" {
+						if fresh {
+							status = "resolved"
+						} else {
+							status = "stale"
+						}
+					}
+					resolvedURL, urlErr := localPreviewArticleURL(previewURL, metadata.URL)
+					if urlErr != nil {
+						return PreviewArticleURLResolution{}, urlErr
+					}
+					return PreviewArticleURLResolution{
+						URL:                    resolvedURL,
+						Fresh:                  fresh,
+						Status:                 status,
+						InvalidationGeneration: metadata.InvalidationGeneration,
+						ActiveBuildGeneration:  metadata.ActiveBuildGeneration,
+					}, nil
 				case http.StatusNotFound:
 					decodeErr := json.NewDecoder(response.Body).Decode(&lastMetadata)
 					_ = response.Body.Close()
@@ -360,7 +405,7 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 						lastMetadata = eleventyRunningMetadata{}
 					}
 					slog.Warn("Eleventy metadata article not found", "site", runtime.ID, "article_path", articlePath, "metadata_status", lastMetadataStatus, "metadata_generation", lastMetadata.InvalidationGeneration, "active_build_generation", lastMetadata.ActiveBuildGeneration, "last_build_completed_at", lastMetadata.LastBuildCompletedAt)
-					return "", fmt.Errorf("eleventy did not resolve article %q", articlePath)
+					return PreviewArticleURLResolution{}, fmt.Errorf("eleventy did not resolve article %q", articlePath)
 				case http.StatusServiceUnavailable:
 					decodeErr := json.NewDecoder(response.Body).Decode(&lastMetadata)
 					_ = response.Body.Close()
@@ -370,7 +415,7 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 				default:
 					status := response.Status
 					_ = response.Body.Close()
-					return "", fmt.Errorf("Eleventy metadata endpoint returned %s", status)
+					return PreviewArticleURLResolution{}, fmt.Errorf("Eleventy metadata endpoint returned %s", status)
 				}
 			}
 		}
@@ -379,9 +424,9 @@ func resolveRunningEleventyArticleURL(ctx context.Context, runtime config.SiteRu
 		case <-ctx.Done():
 			if ctx.Err() == context.DeadlineExceeded {
 				slog.Warn("Eleventy metadata stuck building", "site", runtime.ID, "article_path", articlePath, "metadata_status", lastMetadataStatus, "metadata_generation", lastMetadata.InvalidationGeneration, "active_build_generation", lastMetadata.ActiveBuildGeneration, "last_build_completed_at", lastMetadata.LastBuildCompletedAt)
-				return "", fmt.Errorf("eleventy running preview URL resolution timed out after %s", timeout)
+				return PreviewArticleURLResolution{}, fmt.Errorf("eleventy running preview URL resolution timed out after %s", timeout)
 			}
-			return "", ctx.Err()
+			return PreviewArticleURLResolution{}, ctx.Err()
 		case <-ticker.C:
 		}
 	}

--- a/pkg/services/preview_url_resolver_test.go
+++ b/pkg/services/preview_url_resolver_test.go
@@ -201,6 +201,44 @@ func TestResolveRunningEleventyArticleURLWaitsForMetadataAndRewritesOrigin(t *te
 	}
 }
 
+func TestResolveRunningEleventyArticleURLReturnsLastKnownURLWhileBuilding(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"stale","fresh":false,"invalidation_generation":12,"active_build_generation":11,"url":"/old/one/"}`))
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := config.SiteRuntime{
+		ID:           "daily-blog",
+		Generator:    "eleventy",
+		LocalPreview: config.LocalPreviewConfig{URL: "https://daily.preview.example.com/"},
+	}
+
+	resolution, err := resolveRunningEleventyArticleURLResolution(context.Background(), runtime, port, "posts/one.md")
+	if err != nil {
+		t.Fatalf("resolveRunningEleventyArticleURLResolution() error = %v", err)
+	}
+	if resolution.URL != "https://daily.preview.example.com/old/one/" || resolution.Fresh || resolution.Status != "stale" {
+		t.Fatalf("resolution = %#v, want stale last-known URL", resolution)
+	}
+	if resolution.InvalidationGeneration != 12 || resolution.ActiveBuildGeneration != 11 {
+		t.Fatalf("resolution generations = %#v", resolution)
+	}
+	if attempts != 1 {
+		t.Fatalf("metadata requests = %d, want one immediate response", attempts)
+	}
+}
+
 func TestEleventyResolverUsesDedicatedProjectAndOutput(t *testing.T) {
 	production := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(production, "src", "posts"), 0755); err != nil {

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -107,7 +107,6 @@ function createBuildState(input) {
     state.recoveryTimer.unref?.();
   };
   state.begin = () => {
-    state.activeBuildGeneration = state.invalidationGeneration;
     state.ready = false;
     state.building = true;
   };
@@ -131,6 +130,7 @@ function createBuildState(input) {
       });
     }
     state.entries = entries;
+    state.activeBuildGeneration = state.invalidationGeneration;
     state.ready = state.activeBuildGeneration >= state.invalidationGeneration;
     state.building = !state.ready;
     state.lastBuildCompletedAt = Date.now();
@@ -299,17 +299,26 @@ function createLoopbackServer(outputRoot, buildState = { ready: true, building: 
       return;
     }
     if (requestURL.pathname === METADATA_PATH) {
+      const articlePath = requestURL.searchParams.get("path");
+      const metadata = articlePath ? buildState.get(articlePath) : null;
       if (!buildState.ready) {
+        if (metadata) {
+          sendJSON(response, 200, {
+            status: "stale",
+            fresh: false,
+            ...buildState.diagnostics?.(),
+            ...metadata,
+          });
+          return;
+        }
         sendJSON(response, 503, { status: "building", ...buildState.diagnostics?.() });
         return;
       }
-      const articlePath = requestURL.searchParams.get("path");
-      const metadata = articlePath ? buildState.get(articlePath) : null;
       if (!metadata) {
         sendJSON(response, 404, { status: "not_found", ...buildState.diagnostics?.() });
         return;
       }
-      sendJSON(response, 200, { status: "resolved", ...buildState.diagnostics?.(), ...metadata });
+      sendJSON(response, 200, { status: "resolved", fresh: true, ...buildState.diagnostics?.(), ...metadata });
       return;
     }
     if (requestURL.pathname === RELOAD_SCRIPT_PATH) {

--- a/scripts/eleventy-local-preview.cjs
+++ b/scripts/eleventy-local-preview.cjs
@@ -107,6 +107,7 @@ function createBuildState(input) {
     state.recoveryTimer.unref?.();
   };
   state.begin = () => {
+    state.activeBuildGeneration = state.invalidationGeneration;
     state.ready = false;
     state.building = true;
   };
@@ -130,7 +131,6 @@ function createBuildState(input) {
       });
     }
     state.entries = entries;
-    state.activeBuildGeneration = state.invalidationGeneration;
     state.ready = state.activeBuildGeneration >= state.invalidationGeneration;
     state.building = !state.ready;
     state.lastBuildCompletedAt = Date.now();

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -358,6 +358,56 @@ test("serves stale metadata immediately after a resource invalidation", async ()
   }
 });
 
+test("does not mark an older build fresh after a second invalidation", async () => {
+  const input = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-generation-race-"));
+  const output = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-generation-output-"));
+  const state = createBuildState(input);
+  const result = {
+    inputPath: path.join(input, "posts", "one.md"),
+    outputPath: path.join(output, "posts", "one", "index.html"),
+    url: "/posts/one/",
+  };
+  state.ready = true;
+  state.building = false;
+  state.invalidationGeneration = 10;
+  state.activeBuildGeneration = 10;
+  state.entries.set("posts/one.md", result);
+  const server = createLoopbackServer(output, state);
+  try {
+    await listen(server, 0, "127.0.0.1");
+    const port = server.address().port;
+
+    assert.equal(state.invalidate("posts/one.md"), 11);
+    state.begin();
+    assert.equal(state.diagnostics().active_build_generation, 11);
+    assert.equal(state.invalidate("posts/one.md"), 12);
+    state.update([result]);
+
+    assert.equal(state.ready, false);
+    assert.equal(state.diagnostics().active_build_generation, 11);
+    assert.equal(state.diagnostics().invalidation_generation, 12);
+    const stale = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
+    assert.equal(stale.statusCode, 200);
+    assert.equal(JSON.parse(stale.body).status, "stale");
+    assert.equal(JSON.parse(stale.body).fresh, false);
+
+    state.begin();
+    state.update([result]);
+    assert.equal(state.ready, true);
+    assert.equal(state.diagnostics().active_build_generation, 12);
+    const fresh = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
+    assert.equal(fresh.statusCode, 200);
+    assert.equal(JSON.parse(fresh.body).status, "resolved");
+    assert.equal(JSON.parse(fresh.body).fresh, true);
+  } finally {
+    state.stopRecovery();
+    server.closeAll();
+    await new Promise(resolve => server.close(resolve));
+    fs.rmSync(input, { recursive: true, force: true });
+    fs.rmSync(output, { recursive: true, force: true });
+  }
+});
+
 test("resolves a real Eleventy 3.x project in JSON mode", { skip: !hasRealEleventy() }, () => {
   const fixture = createEleventyFixture();
   try {

--- a/scripts/eleventy-local-preview.test.cjs
+++ b/scripts/eleventy-local-preview.test.cjs
@@ -317,7 +317,7 @@ test("re-notifies the input root when invalidation has no specific path", async 
   }
 });
 
-test("hides stale metadata immediately after a resource invalidation", async () => {
+test("serves stale metadata immediately after a resource invalidation", async () => {
   const input = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-resource-barrier-"));
   const output = fs.mkdtempSync(path.join(os.tmpdir(), "homecms-eleventy-resource-output-"));
   const state = createBuildState(input);
@@ -338,7 +338,17 @@ test("hides stale metadata immediately after a resource invalidation", async () 
     const invalidated = await requestHTTP(port, "/__hugo_cms_invalidate", "POST");
     assert.equal(invalidated.statusCode, 202);
     const duringMutation = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
-    assert.equal(duringMutation.statusCode, 503);
+    assert.equal(duringMutation.statusCode, 200);
+    const stale = JSON.parse(duringMutation.body);
+    assert.equal(stale.status, "stale");
+    assert.equal(stale.fresh, false);
+    assert.equal(stale.invalidation_generation, 1);
+    assert.equal(stale.active_build_generation, 0);
+    assert.equal(stale.last_build_completed_at, 0);
+    assert.equal(typeof stale.invalidation_at, "number");
+    assert.equal(stale.inputPath, path.join(input, "posts", "one.md"));
+    assert.equal(stale.outputPath, path.join(output, "posts", "one", "index.html"));
+    assert.equal(stale.url, "/posts/one/");
   } finally {
     state.stopRecovery();
     server.closeAll();
@@ -459,7 +469,9 @@ test("starts real Eleventy serve and broadcasts LiveReload", { skip: !hasRealEle
     const invalidated = await requestHTTP(port, "/__hugo_cms_invalidate?path=posts%2Fone.md", "POST");
     assert.equal(invalidated.statusCode, 202);
     const invalidatedMetadata = await requestHTTP(port, "/__hugo_cms_metadata?path=posts%2Fone.md");
-    assert.equal(invalidatedMetadata.statusCode, 503);
+    assert.equal(invalidatedMetadata.statusCode, 200);
+    assert.equal(JSON.parse(invalidatedMetadata.body).status, "stale");
+    assert.equal(JSON.parse(invalidatedMetadata.body).fresh, false);
     const updatedArticle = ["---", "title: Changed", "permalink: /custom/changed/", "---", "", "# {{ title }}", ""].join("\n");
     fs.writeFileSync(fixture.article, updatedArticle);
     await reload;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -27,12 +27,14 @@ let localPreviewController = null;
 let localPreviewOperationInProgress = false;
 let localPreviewFrameController = null;
 let localPreviewArticleURL = "";
+let localPreviewArticleURLFresh = false;
 let localPreviewURLResolutionGeneration = 0;
 let localPreviewFrontMatterKey = "";
 let localPreviewArticleURLKey = "";
 let localPreviewURLResolution = null;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
+const LOCAL_PREVIEW_FRESH_NAVIGATION_MAX_ATTEMPTS = 120;
 
 init();
 
@@ -135,6 +137,7 @@ function resetLocalPreviewArticleURL() {
     cancelLocalPreviewURLResolution();
     localPreviewURLResolutionGeneration += 1;
     localPreviewArticleURL = "";
+    localPreviewArticleURLFresh = false;
     localPreviewArticleURLKey = "";
     localPreviewFrontMatterKey = "";
 }
@@ -223,7 +226,7 @@ async function loadFile(path) {
             if (Editor.getCurrentPath() === path && !articleURL) {
                 throw new Error('generatorから記事URLを取得できませんでした');
             }
-            if (Editor.getCurrentPath() === path) showEmbeddedLocalPreview({ reload: true });
+            if (Editor.getCurrentPath() === path) showEmbeddedLocalPreview();
         } catch (error) {
             showLocalPreviewResolutionError(error);
         }
@@ -389,24 +392,36 @@ function waitForLocalPreviewRetry(delay, signal) {
     });
 }
 
-function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterKey) {
-    if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
+function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMatterKey, { requireFresh = false } = {}) {
+    if (!localPreviewEnabled || !Editor.getCurrentPath()) return Promise.resolve(null);
     const requestPath = Editor.getCurrentPath();
     const requestKey = localPreviewURLResolutionKey(frontMatterKey);
-    if (localPreviewURLResolution?.key === requestKey) return localPreviewURLResolution.promise;
+    if (!requireFresh && localPreviewArticleURL && localPreviewArticleURLKey === requestKey) {
+        return Promise.resolve({
+            url: localPreviewArticleURL,
+            fresh: localPreviewArticleURLFresh,
+            result: null,
+            generation: localPreviewURLResolutionGeneration,
+        });
+    }
+    const resolutionKey = `${requestKey}\u0000${requireFresh ? 'fresh' : 'cached'}`;
+    if (localPreviewURLResolution?.key === resolutionKey) return localPreviewURLResolution.promise;
 
     cancelLocalPreviewURLResolution();
     localPreviewURLResolutionGeneration += 1;
     const requestGeneration = localPreviewURLResolutionGeneration;
     const controller = new AbortController();
+    const maxAttempts = requireFresh
+        ? LOCAL_PREVIEW_FRESH_NAVIGATION_MAX_ATTEMPTS
+        : LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS;
 
     const resolution = {
         controller,
-        key: requestKey,
+        key: resolutionKey,
         promise: null,
     };
     resolution.promise = (async () => {
-        for (let attempt = 1; attempt <= LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS; attempt++) {
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
             if (controller.signal.aborted) throw localPreviewResolutionAbortError();
             if (
                 Editor.getCurrentPath() !== requestPath ||
@@ -416,16 +431,23 @@ function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterK
                 const result = await API.resolveLocalPreviewArticleURL(requestPath, controller.signal);
                 const articleURL = UI.safeExternalURL(result?.article_url || "");
                 if (!isLocalPreviewArticleURL(articleURL)) throw new Error('generator returned an invalid local preview URL');
+                const fresh = result?.fresh !== false && result?.metadata_status !== 'stale' && result?.status !== 'stale';
+                if (requireFresh && !fresh) {
+                    await waitForLocalPreviewRetry(localPreviewNavigationRetryDelay(attempt), controller.signal);
+                    continue;
+                }
                 if (
                     Editor.getCurrentPath() !== requestPath ||
                     localPreviewURLResolutionGeneration !== requestGeneration
                 ) return null;
                 localPreviewArticleURL = articleURL;
+                localPreviewArticleURLFresh = fresh;
                 localPreviewArticleURLKey = requestKey;
-                return articleURL;
+                return { url: articleURL, fresh, result, generation: requestGeneration };
             } catch (error) {
                 if (error?.name === 'AbortError') throw error;
-                if (!shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
+                const transient = error?.status === undefined || error?.status === 408 || error?.status === 425 || error?.status === 429 || error?.status >= 500;
+                if (!(requireFresh && attempt < maxAttempts && transient) && !shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
                 await waitForLocalPreviewRetry(localPreviewNavigationRetryDelay(attempt), controller.signal);
             }
         }
@@ -439,13 +461,39 @@ function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterK
     return resolution.promise;
 }
 
+function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL) {
+    const requestPath = Editor.getCurrentPath();
+    if (!requestPath || !cachedURL) return;
+    void resolveLocalPreviewArticleURLState(frontMatterKey, { requireFresh: true }).then((resolution) => {
+        if (!resolution || Editor.getCurrentPath() !== requestPath || resolution.generation !== localPreviewURLResolutionGeneration) return;
+        if (resolution.url !== cachedURL && !localPreviewFrameController?.isDismissed()) {
+            showEmbeddedLocalPreview({ reload: true });
+        }
+    }).catch((error) => {
+        if (error?.name !== 'AbortError') console.warn('[LocalPreview] fresh URL reconciliation failed', error);
+    });
+}
+
+async function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterKey) {
+    const resolution = await resolveLocalPreviewArticleURLState(frontMatterKey);
+    if (resolution?.url && !resolution.fresh) {
+        reconcileFreshLocalPreviewArticleURL(frontMatterKey, resolution.url);
+    }
+    return resolution?.url || null;
+}
+
 async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") {
     const requestKey = localPreviewURLResolutionKey(frontMatterKey);
-    if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey) {
+    if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey && localPreviewArticleURLFresh) {
         return localPreviewArticleURL;
     }
     localPreviewFrontMatterKey = frontMatterKey;
+    if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey && !localPreviewArticleURLFresh) {
+        reconcileFreshLocalPreviewArticleURL(frontMatterKey, localPreviewArticleURL);
+        return localPreviewArticleURL;
+    }
     localPreviewArticleURL = "";
+    localPreviewArticleURLFresh = false;
     localPreviewArticleURLKey = "";
     if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
     try {

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -160,6 +160,9 @@ export function initAutoSave() {
 
 function handleEditorChange() {
     if (gitSyncInProgress) return;
+    if (currentData && typeof currentData.raw_content === 'string') {
+        currentData.raw_content = '';
+    }
     triggerAutoSave();
     scheduleMarkdownPreview();
     scheduleLocalLivePreview();
@@ -463,6 +466,9 @@ export async function loadFile(path, { allowDuringGitSync = false } = {}) {
 }
 
 function getPayload() {
+    if (currentData?.path === currentPath && typeof currentData.raw_content === 'string' && currentData.raw_content !== '') {
+        return { path: currentPath, content: currentData.raw_content };
+    }
     const payload = { path: currentPath };
     const fm = UI.collectFrontMatter();
     if (fm) {


### PR DESCRIPTION

## 概要

Issue #68 に対応し、Eleventy Local Previewの記事切替をlast-known metadataで先行表示できるようにしました。

## 変更内容

- build中も既知記事のmetadataを stale / fresh: false で返却
- cached URLを先にiframeへ表示し、fresh URLをバックグラウンドで確認
- permalink変更時などURLが変わった場合のみiframeを再遷移
- 未編集記事は元ファイルbytesをshadowへ同期して不要な再シリアライズ・rebuildを抑制
- 初回build前・未知記事は従来どおりfresh metadataを待機
- A→B→Cの切替で古い非同期結果が戻らないようgenerationで制御
- ビルド中に追加の無効化が発生した場合も、次のビルド完了までstaleを維持
- 回帰テストとdocsを更新

Closes #68

## 検証

- go test ./...
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs
- node --test scripts/eleventy-local-preview.test.cjs
