### PR TITLE
Issue #70: Eleventy Local Previewのprocess tree停止

### DIFF
--- a/docs/architecture/local-live-preview-design.md
+++ b/docs/architecture/local-live-preview-design.md
@@ -79,6 +79,8 @@ stopped -> starting -> ready -> stopping -> stopped
 - child environmentはgenerator allowlistのみ
 - CMS shutdown開始後は新規lazy startを拒否
 - HTTP server drain後にchild processを停止
+- Unix/Linuxではgeneratorを独立process groupで起動し、wrapper配下も`SIGTERM`→grace period→`SIGKILL`の順で停止
+- process tree終了と`cmd.Wait()`を確認してからlifecycle slotをreleaseし、timeout時はPID/process groupを診断ログへ残す
 - 異常終了後は次requestで再起動可能
 
 Hugoは概ね次相当で起動する。
@@ -236,7 +238,7 @@ POST /admin/api/preview/local/navigate
 POST /admin/api/preview/local/stop
 ```
 
-Stop時はgenerator process停止後にworkspaceをdetachし、物理削除は非同期で行う。active shadow workspaceがなければ次のpreview requestは保存済みrepository contentを使う。Eleventyのtemporary outputも同時に削除する。
+Stop時はgenerator process groupの停止と`cmd.Wait()`完了後にworkspaceをdetachし、物理削除は非同期で行う。active shadow workspaceがなければ次のpreview requestは保存済みrepository contentを使う。Eleventyのtemporary outputも同時に削除する。`npm exec`や`mise`のwrapperがstdio pipeを保持しても待機が無期限にならないよう、process groupへのgraceful/forced signalと`WaitDelay`を共通の停止経路で管理する。
 
 ## Phase 4への契約
 

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -106,7 +106,7 @@ Eleventy siteでは、対象siteのlock fileから検出したpackage manager経
 
 CMSのNodeラッパーはtemporary project-root overlayをcwdにしてEleventyのprogrammatic `watch`を実行します。overlayでは`content_dir`をshadow workspaceへ、`public_dir`をtemporary outputへ置き換え、package.json、node_modules、config、includes/layouts/data、その他のproject-root相対パスはproduction repositoryを参照します。HTTP配信とLiveReload WebSocketはCMS側のloopback serverが担当し、Eleventyの初回build前にlistenerを`127.0.0.1`へbindします。`/__hugo_cms_ready`はbuild中に503、初回build完了後に200を返すため、重いsiteでも起動処理が固定秒数で同じbuildを繰り返しません。Eleventy標準Dev Serverの未指定hostや`HOST`環境変数には依存しません。
 
-process停止はgeneratorの`cmd.Wait()`完了を成功条件とし、temporary outputのfilesystem cleanup完了を待ちません。workspaceが所有するEleventyのproject/outputはsite runtimeのStopまたはidle cleanupで削除し、process cleanupとの二重削除や次世代workspaceとの競合を避けます。workspace外のEleventy previewは起動ごとに一意なtemporary project rootを割り当て、停止後に所有projectだけを非同期cleanupします。cleanupの遅延・失敗はserver logへ記録しますが、generator processの停止失敗とは区別します。
+process停止はgeneratorの`cmd.Wait()`完了を成功条件とし、temporary outputのfilesystem cleanup完了を待ちません。Unix/Linuxではgenerator commandを独立したprocess groupで起動し、Stop・idle cleanup・Git Sync reset・CMS shutdownの共通経路からgroup全体へ`SIGTERM`を送り、grace period後も残る場合は`SIGKILL`へ移行します。package managerや`mise`のwrapper配下にあるNode/Eleventyも同じgroupで終了させ、stdio pipeを保持した孤児化で`Wait()`が無期限に待たないよう待機上限も設定します。停止時のtimeoutには親PIDとprocess groupをserver logへ記録します。workspaceが所有するEleventyのproject/outputはsite runtimeのStopまたはidle cleanupで削除し、process cleanupとの二重削除や次世代workspaceとの競合を避けます。workspace外のEleventy previewは起動ごとに一意なtemporary project rootを割り当て、停止後に所有projectだけを非同期cleanupします。cleanupの遅延・失敗はserver logへ記録しますが、generator processの停止失敗とは区別します。
 
 Eleventy設定はoverlayのproject rootで通常どおり解決します。そのため`getFilteredByGlob("src/posts/**")`、`addPassthroughCopy("src/images")`、pluginの`outputDir: "./public/img/"`のようなproject-root相対指定も、CMS側で解析・推定せずpreview側のcontent/publicを参照します。通常の記事URL解決では、稼働中wrapperが`eleventy.after`の`inputPath`/`url`を保持する`/__hugo_cms_metadata?path=...`を利用します。workspace updateはshadow fileを書き換える直前にmetadataをinvalidateします。既知の記事はwatch build中も旧mapを`status: stale`、`fresh: false`として返し、未知の記事だけはbuild完了まで503で待機します。watch rebuildごとにmapを更新するため、resolver専用の追加full buildを発生させません。既存の直接resolver呼び出しにはJSONモードのfallbackを残します。
 repo外のabsolute pathや環境変数で指定された外部pathはこのfilesystem overlayの保証対象外です。
@@ -211,7 +211,10 @@ article切替では、現在記事のproduction保存とin-flight Local Preview 
 UIの明示的な停止では、clientがdebounce済みの更新をキャンセルし、送信済みの更新完了を待ってからsite runtimeを停止します。idle timeout、CMS shutdownを含め、site runtimeは次の順で終了します。
 
 ```text
-generator process stop
+SIGTERM -> generator process group
+  -> grace period
+  -> SIGKILL (if still running)
+  -> cmd.Wait() / process tree termination
   -> workspace root detach/rename
   -> shadow workspace delete (async)
 ```

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -592,12 +592,17 @@ func (m *LocalPreviewManager) handleProcessExit(siteID string, process *managedL
 	if m.process(siteID) != process {
 		return
 	}
-	m.removeProcessIfCurrent(siteID, process)
-
 	slot, ok := m.lifecycle.Get(siteID)
 	if !ok {
 		return
 	}
+	if slot.State == LocalPreviewStopping {
+		// Stop owns the process mapping and lifecycle release while a process
+		// tree termination is in flight. The parent may have exited while a
+		// wrapper child still holds the process group alive.
+		return
+	}
+	m.removeProcessIfCurrent(siteID, process)
 	switch slot.State {
 	case LocalPreviewReady:
 		_, _ = m.lifecycle.Transition(siteID, LocalPreviewFailed, process.processError())

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -471,6 +471,7 @@ func (m *LocalPreviewManager) startProcess(runtime config.SiteRuntime, port int,
 	// limit or leak CMS secrets through the browser response.
 	cmd.Stdout = stderr
 	cmd.Stderr = stderr
+	configureLocalPreviewCommand(cmd)
 	if err := cmd.Start(); err != nil {
 		cancel()
 		if cleanupErr := cleanup(); cleanupErr != nil {
@@ -556,17 +557,12 @@ func localPreviewHTTPReady(address string) (bool, error) {
 
 func (m *LocalPreviewManager) cleanupFailedSlotLocked(siteID string, process *managedLocalPreviewProcess, processErr error) {
 	if process != nil {
-		process.cancel()
-		select {
-		case <-process.done:
-		case <-time.After(time.Second):
-			if process.cmd.Process != nil {
-				_ = process.cmd.Process.Kill()
-			}
-			select {
-			case <-process.done:
-			case <-time.After(time.Second):
-			}
+		stopCtx, cancel := context.WithTimeout(context.Background(), DefaultLocalPreviewStopTimeout)
+		terminationErr := terminateManagedLocalPreviewProcess(stopCtx, siteID, process)
+		cancel()
+		if terminationErr != nil {
+			slog.Error("Local preview process tree did not terminate during startup cleanup", "site", siteID, "error", terminationErr)
+			return
 		}
 		m.removeProcessIfCurrent(siteID, process)
 	}
@@ -607,6 +603,7 @@ func (m *LocalPreviewManager) handleProcessExit(siteID string, process *managedL
 		_, _ = m.lifecycle.Transition(siteID, LocalPreviewFailed, process.processError())
 	case LocalPreviewStopping:
 		_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
+		_ = m.lifecycle.Release(siteID)
 	}
 }
 
@@ -633,15 +630,8 @@ func (m *LocalPreviewManager) Stop(ctx context.Context, siteID string) error {
 			return err
 		}
 	}
-	process.cancel()
-
-	select {
-	case <-process.done:
-	case <-ctx.Done():
-		if process.cmd.Process != nil {
-			_ = process.cmd.Process.Kill()
-		}
-		return fmt.Errorf("stopping local preview for site %q: %w", siteID, ctx.Err())
+	if err := terminateManagedLocalPreviewProcess(ctx, siteID, process); err != nil {
+		return err
 	}
 	m.removeProcessIfCurrent(siteID, process)
 

--- a/pkg/services/local_preview_manager.go
+++ b/pkg/services/local_preview_manager.go
@@ -601,9 +601,6 @@ func (m *LocalPreviewManager) handleProcessExit(siteID string, process *managedL
 	switch slot.State {
 	case LocalPreviewReady:
 		_, _ = m.lifecycle.Transition(siteID, LocalPreviewFailed, process.processError())
-	case LocalPreviewStopping:
-		_, _ = m.lifecycle.Transition(siteID, LocalPreviewStopped, nil)
-		_ = m.lifecycle.Release(siteID)
 	}
 }
 

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -360,6 +360,9 @@ func TestLocalPreviewManagerProcessExitDoesNotReleaseStoppingSlot(t *testing.T) 
 	if slot.State != LocalPreviewStopping {
 		t.Fatalf("slot.State = %q, want stopping", slot.State)
 	}
+	if manager.process(siteID) != process {
+		t.Fatal("process exit callback removed the process mapping while stopping")
+	}
 }
 
 func TestLocalPreviewManagerResetRuntimeStopsAndDetachesWorkspace(t *testing.T) {

--- a/pkg/services/local_preview_manager_test.go
+++ b/pkg/services/local_preview_manager_test.go
@@ -323,6 +323,45 @@ func TestLocalPreviewManagerStopReleasesSlot(t *testing.T) {
 	}
 }
 
+func TestLocalPreviewManagerProcessExitDoesNotReleaseStoppingSlot(t *testing.T) {
+	lifecycle, err := NewLocalPreviewLifecycle(14100, 14100)
+	if err != nil {
+		t.Fatalf("NewLocalPreviewLifecycle() error = %v", err)
+	}
+	manager := NewLocalPreviewManager(lifecycle)
+	const siteID = "tech"
+	if _, err := lifecycle.Reserve(siteID, nil); err != nil {
+		t.Fatalf("Reserve() error = %v", err)
+	}
+	if _, err := lifecycle.Transition(siteID, LocalPreviewStarting, nil); err != nil {
+		t.Fatalf("Transition(starting) error = %v", err)
+	}
+	if _, err := lifecycle.Transition(siteID, LocalPreviewReady, nil); err != nil {
+		t.Fatalf("Transition(ready) error = %v", err)
+	}
+	if _, err := lifecycle.Transition(siteID, LocalPreviewStopping, nil); err != nil {
+		t.Fatalf("Transition(stopping) error = %v", err)
+	}
+
+	terminated := make(chan struct{})
+	close(terminated)
+	process := &managedLocalPreviewProcess{
+		cmd:  &exec.Cmd{},
+		done: terminated,
+	}
+	manager.setProcess(siteID, process)
+
+	manager.handleProcessExit(siteID, process)
+
+	slot, ok := manager.Status(siteID)
+	if !ok {
+		t.Fatal("process exit callback released a stopping lifecycle slot")
+	}
+	if slot.State != LocalPreviewStopping {
+		t.Fatalf("slot.State = %q, want stopping", slot.State)
+	}
+}
+
 func TestLocalPreviewManagerResetRuntimeStopsAndDetachesWorkspace(t *testing.T) {
 	manager, site := newTestLocalPreviewManager(t)
 	defer shutdownTestLocalPreviewManager(t, manager)

--- a/pkg/services/local_preview_process.go
+++ b/pkg/services/local_preview_process.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+const (
+	localPreviewProcessGracePeriod = 2 * time.Second
+	localPreviewProcessKillWait    = 2 * time.Second
+	localPreviewProcessWaitDelay   = 500 * time.Millisecond
+)
+
+// terminateManagedLocalPreviewProcess stops the generator process tree before
+// callers release the lifecycle slot. The command context is cancelled only
+// after the tree has been signalled and Wait has observed termination; doing
+// it earlier would kill only the package-manager parent and strand children.
+func terminateManagedLocalPreviewProcess(ctx context.Context, siteID string, process *managedLocalPreviewProcess) error {
+	if process == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if process.exited() {
+		cancelProcessContext(process)
+		return nil
+	}
+
+	// Tests and startup races may provide a synthetic process without an OS
+	// process. Preserve the existing cancellation contract for that case.
+	if process.cmd == nil || process.cmd.Process == nil {
+		cancelProcessContext(process)
+		select {
+		case <-process.done:
+			return nil
+		case <-ctx.Done():
+			return fmt.Errorf("stopping local preview for site %q: %w", siteID, ctx.Err())
+		}
+	}
+
+	gracefulErr := signalLocalPreviewProcess(process.cmd, false)
+	if gracefulErr != nil && !process.exited() {
+		slog.Warn("Failed to send graceful Local Live Preview stop signal",
+			"site", siteID,
+			"process", localPreviewProcessDescription(process.cmd),
+			"error", gracefulErr,
+		)
+	}
+
+	gracefulTimer := time.NewTimer(localPreviewProcessGracePeriod)
+	defer gracefulTimer.Stop()
+	select {
+	case <-process.done:
+		cancelProcessContext(process)
+		return nil
+	case <-ctx.Done():
+		// The caller deadline is also a reason to escalate immediately. If the
+		// process tree is killed successfully, stopping still succeeded.
+	case <-gracefulTimer.C:
+	}
+
+	forceErr := signalLocalPreviewProcess(process.cmd, true)
+	if forceErr != nil && !process.exited() {
+		slog.Warn("Failed to send forced Local Live Preview stop signal",
+			"site", siteID,
+			"process", localPreviewProcessDescription(process.cmd),
+			"error", forceErr,
+		)
+	}
+
+	killTimer := time.NewTimer(localPreviewProcessKillWait)
+	defer killTimer.Stop()
+	select {
+	case <-process.done:
+		cancelProcessContext(process)
+		return nil
+	case <-killTimer.C:
+		cancelProcessContext(process)
+		description := localPreviewProcessDescription(process.cmd)
+		if forceErr != nil {
+			err := fmt.Errorf("local preview process tree did not terminate for site %q (%s): %w", siteID, description, forceErr)
+			slog.Error("Local preview process tree termination timed out", "site", siteID, "process", description, "error", err)
+			return err
+		}
+		err := fmt.Errorf("local preview process tree did not terminate for site %q (%s)", siteID, description)
+		slog.Error("Local preview process tree termination timed out", "site", siteID, "process", description, "error", err)
+		return err
+	}
+}
+
+func cancelProcessContext(process *managedLocalPreviewProcess) {
+	if process != nil && process.cancel != nil {
+		process.cancel()
+	}
+}

--- a/pkg/services/local_preview_process.go
+++ b/pkg/services/local_preview_process.go
@@ -24,7 +24,7 @@ func terminateManagedLocalPreviewProcess(ctx context.Context, siteID string, pro
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if process.exited() {
+	if process.exited() && !localPreviewProcessTreeAlive(process.cmd) {
 		cancelProcessContext(process)
 		return nil
 	}
@@ -50,16 +50,9 @@ func terminateManagedLocalPreviewProcess(ctx context.Context, siteID string, pro
 		)
 	}
 
-	gracefulTimer := time.NewTimer(localPreviewProcessGracePeriod)
-	defer gracefulTimer.Stop()
-	select {
-	case <-process.done:
+	if waitForLocalPreviewProcessTree(ctx, process, localPreviewProcessGracePeriod) {
 		cancelProcessContext(process)
 		return nil
-	case <-ctx.Done():
-		// The caller deadline is also a reason to escalate immediately. If the
-		// process tree is killed successfully, stopping still succeeded.
-	case <-gracefulTimer.C:
 	}
 
 	forceErr := signalLocalPreviewProcess(process.cmd, true)
@@ -71,23 +64,45 @@ func terminateManagedLocalPreviewProcess(ctx context.Context, siteID string, pro
 		)
 	}
 
-	killTimer := time.NewTimer(localPreviewProcessKillWait)
-	defer killTimer.Stop()
-	select {
-	case <-process.done:
+	if waitForLocalPreviewProcessTree(context.Background(), process, localPreviewProcessKillWait) {
 		cancelProcessContext(process)
 		return nil
-	case <-killTimer.C:
-		cancelProcessContext(process)
-		description := localPreviewProcessDescription(process.cmd)
-		if forceErr != nil {
-			err := fmt.Errorf("local preview process tree did not terminate for site %q (%s): %w", siteID, description, forceErr)
-			slog.Error("Local preview process tree termination timed out", "site", siteID, "process", description, "error", err)
-			return err
-		}
-		err := fmt.Errorf("local preview process tree did not terminate for site %q (%s)", siteID, description)
+	}
+
+	cancelProcessContext(process)
+	description := localPreviewProcessDescription(process.cmd)
+	if forceErr != nil {
+		err := fmt.Errorf("local preview process tree did not terminate for site %q (%s): %w", siteID, description, forceErr)
 		slog.Error("Local preview process tree termination timed out", "site", siteID, "process", description, "error", err)
 		return err
+	}
+	err := fmt.Errorf("local preview process tree did not terminate for site %q (%s)", siteID, description)
+	slog.Error("Local preview process tree termination timed out", "site", siteID, "process", description, "error", err)
+	return err
+}
+
+func waitForLocalPreviewProcessTree(ctx context.Context, process *managedLocalPreviewProcess, timeout time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if timeout <= 0 {
+		return process.exited() && !localPreviewProcessTreeAlive(process.cmd)
+	}
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		if process.exited() && !localPreviewProcessTreeAlive(process.cmd) {
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-deadline.C:
+			return process.exited() && !localPreviewProcessTreeAlive(process.cmd)
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/pkg/services/local_preview_process_test.go
+++ b/pkg/services/local_preview_process_test.go
@@ -1,0 +1,173 @@
+//go:build !windows
+
+package services
+
+import (
+	"context"
+	"fmt"
+	"hugo-cms/pkg/config"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestLocalPreviewManagerStopsPackageManagerWrapperProcessTree(t *testing.T) {
+	for _, mode := range []string{"graceful", "ignore"} {
+		t.Run(mode, func(t *testing.T) {
+			manager, site := newTestLocalPreviewManager(t)
+			site.Generator = "eleventy"
+			helpers := t.TempDir()
+			pidPath := filepath.Join(helpers, "child.pid")
+			signalPath := filepath.Join(helpers, "signal")
+			manager.commandFactory = func(ctx context.Context, runtime config.SiteRuntime, port int, _ string) (*exec.Cmd, error) {
+				cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestLocalPreviewProcessTreeHelper$")
+				cmd.Env = append(os.Environ(),
+					"HUGO_CMS_PROCESS_TREE_HELPER=wrapper",
+					"HUGO_CMS_PROCESS_TREE_MODE="+mode,
+					"HUGO_CMS_PROCESS_TREE_PORT="+strconv.Itoa(port),
+					"HUGO_CMS_PROCESS_TREE_PID_PATH="+pidPath,
+					"HUGO_CMS_PROCESS_TREE_SIGNAL_PATH="+signalPath,
+				)
+				return cmd, nil
+			}
+
+			slot, err := manager.EnsureReady(site)
+			if err != nil {
+				t.Fatalf("EnsureReady() error = %v", err)
+			}
+			waitForFile(t, pidPath)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+			defer cancel()
+			started := time.Now()
+			if err := manager.Stop(ctx, site.ID); err != nil {
+				t.Fatalf("Stop() error = %v", err)
+			}
+
+			if _, ok := manager.Status(site.ID); ok {
+				t.Fatal("Stop() should release the lifecycle slot after the process tree exits")
+			}
+			listener, err := net.Listen("tcp", net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(slot.Port)))
+			if err != nil {
+				t.Fatalf("preview port remains occupied after Stop(): %v", err)
+			}
+			_ = listener.Close()
+
+			if mode == "graceful" {
+				if elapsed := time.Since(started); elapsed >= localPreviewProcessGracePeriod {
+					t.Fatalf("graceful process-tree stop took %s; SIGTERM was not handled", elapsed)
+				}
+				if signal := strings.TrimSpace(readFile(t, signalPath)); signal != "terminated" {
+					t.Fatalf("child signal marker = %q, want terminated", signal)
+				}
+			}
+		})
+	}
+}
+
+func TestLocalPreviewProcessTreeHelper(t *testing.T) {
+	if os.Getenv("HUGO_CMS_PROCESS_TREE_HELPER") != "wrapper" {
+		return
+	}
+	port, err := strconv.Atoi(os.Getenv("HUGO_CMS_PROCESS_TREE_PORT"))
+	if err != nil {
+		os.Exit(2)
+	}
+	mode := os.Getenv("HUGO_CMS_PROCESS_TREE_MODE")
+	pidPath := os.Getenv("HUGO_CMS_PROCESS_TREE_PID_PATH")
+	signalPath := os.Getenv("HUGO_CMS_PROCESS_TREE_SIGNAL_PATH")
+
+	child := exec.Command(os.Args[0], "-test.run=^TestLocalPreviewProcessTreeChild$")
+	child.Env = append(os.Environ(),
+		"HUGO_CMS_PROCESS_TREE_HELPER=child",
+		"HUGO_CMS_PROCESS_TREE_MODE="+mode,
+		"HUGO_CMS_PROCESS_TREE_PORT="+strconv.Itoa(port),
+		"HUGO_CMS_PROCESS_TREE_SIGNAL_PATH="+signalPath,
+	)
+	child.Stdout = os.Stdout
+	child.Stderr = os.Stderr
+	if err := child.Start(); err != nil {
+		os.Exit(3)
+	}
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(child.Process.Pid)), 0600); err != nil {
+		_ = child.Process.Kill()
+		os.Exit(4)
+	}
+	select {}
+}
+
+func TestLocalPreviewProcessTreeChild(t *testing.T) {
+	if os.Getenv("HUGO_CMS_PROCESS_TREE_HELPER") != "child" {
+		return
+	}
+	port, err := strconv.Atoi(os.Getenv("HUGO_CMS_PROCESS_TREE_PORT"))
+	if err != nil {
+		os.Exit(5)
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort(LocalPreviewBindAddress, strconv.Itoa(port)))
+	if err != nil {
+		os.Exit(6)
+	}
+	defer listener.Close()
+
+	server := &httpServerForProcessTree{listener: listener}
+	go server.serve()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(signals)
+	for {
+		sig := <-signals
+		if os.Getenv("HUGO_CMS_PROCESS_TREE_MODE") == "ignore" {
+			continue
+		}
+		if err := os.WriteFile(os.Getenv("HUGO_CMS_PROCESS_TREE_SIGNAL_PATH"), []byte("terminated"), 0600); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+		}
+		_ = sig
+		return
+	}
+}
+
+type httpServerForProcessTree struct {
+	listener net.Listener
+}
+
+func (s *httpServerForProcessTree) serve() {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok\r\n"))
+		_ = conn.Close()
+	}
+}
+
+func waitForFile(t *testing.T, filename string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(filename); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", filename)
+}
+
+func readFile(t *testing.T, filename string) string {
+	t.Helper()
+	contents, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	return string(contents)
+}

--- a/pkg/services/local_preview_process_unix.go
+++ b/pkg/services/local_preview_process_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package services
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+func configureLocalPreviewCommand(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.WaitDelay = localPreviewProcessWaitDelay
+}
+
+func signalLocalPreviewProcess(cmd *exec.Cmd, force bool) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	signal := syscall.SIGTERM
+	if force {
+		signal = syscall.SIGKILL
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, signal); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}
+
+func localPreviewProcessDescription(cmd *exec.Cmd) string {
+	if cmd == nil || cmd.Process == nil {
+		return "pid=unknown process_group=unknown"
+	}
+	return fmt.Sprintf("pid=%d process_group=%d", cmd.Process.Pid, cmd.Process.Pid)
+}

--- a/pkg/services/local_preview_process_unix.go
+++ b/pkg/services/local_preview_process_unix.go
@@ -30,6 +30,14 @@ func signalLocalPreviewProcess(cmd *exec.Cmd, force bool) error {
 	return nil
 }
 
+func localPreviewProcessTreeAlive(cmd *exec.Cmd) bool {
+	if cmd == nil || cmd.Process == nil {
+		return false
+	}
+	err := syscall.Kill(-cmd.Process.Pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
 func localPreviewProcessDescription(cmd *exec.Cmd) string {
 	if cmd == nil || cmd.Process == nil {
 		return "pid=unknown process_group=unknown"

--- a/pkg/services/local_preview_process_windows.go
+++ b/pkg/services/local_preview_process_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package services
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func configureLocalPreviewCommand(cmd *exec.Cmd) {
+	cmd.WaitDelay = localPreviewProcessWaitDelay
+}
+
+// Windows does not provide the Unix process-group semantics used by the
+// package-manager wrappers. Keep the same lifecycle contract with the best
+// available direct-process termination; Unix/Linux uses the full tree path.
+func signalLocalPreviewProcess(cmd *exec.Cmd, _ bool) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func localPreviewProcessDescription(cmd *exec.Cmd) string {
+	if cmd == nil || cmd.Process == nil {
+		return "pid=unknown process_group=unsupported"
+	}
+	return fmt.Sprintf("pid=%d process_group=unsupported", cmd.Process.Pid)
+}

--- a/pkg/services/local_preview_process_windows.go
+++ b/pkg/services/local_preview_process_windows.go
@@ -21,6 +21,13 @@ func signalLocalPreviewProcess(cmd *exec.Cmd, _ bool) error {
 	return cmd.Process.Kill()
 }
 
+func localPreviewProcessTreeAlive(cmd *exec.Cmd) bool {
+	if cmd == nil || cmd.Process == nil {
+		return false
+	}
+	return cmd.ProcessState == nil || !cmd.ProcessState.Exited()
+}
+
 func localPreviewProcessDescription(cmd *exec.Cmd) string {
 	if cmd == nil || cmd.Process == nil {
 		return "pid=unknown process_group=unsupported"


### PR DESCRIPTION

## 概要

Issue #70に対応し、Eleventy Local Preview停止時にpackage managerやmise配下のNode/Eleventy processが残る問題を修正しました。

## 変更内容

- Unix/LinuxではLocal Previewを独立process groupとして起動
- Stop、idle cleanup、Git Sync reset、CMS shutdownで同じ停止経路を利用
- process group全体へSIGTERMを送り、grace period後にSIGKILLへ移行
- cmd.Waitのstdio pipe待ちにWaitDelayを設定
- process tree終了確認後にlifecycle slotをrelease
- timeout時にPID、process group、siteを診断ログへ記録
- wrapper配下の子processを対象にgraceful stopとforced killの回帰テストを追加
- Local Live Previewの設計・ガイドを更新

Closes #70

## 検証

- go test ./pkg/services -count=1
- go vet ./...
- go build -buildvcs=false ./...
- node --test static/js/*.test.mjs
- node --test scripts/eleventy-local-preview.test.cjs
- GOOS=linux GOARCH=amd64 go test -c ./pkg/services
