### PR TITLE
fix: guard concurrent site switches

### DIFF
--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -225,6 +225,8 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 - 記事キャッシュは`repo_path + content_dir`でkey分割する。
 - preview adapter mapのlockはmapアクセス中だけ保持し、preview process操作中には保持しない。
 
+Frontendのsite selectorもsite IDを明示したconfig・記事一覧・Local Preview status・デプロイPreviewの取得を行う。site切替ごとにgenerationとAbortControllerを更新し、古いresponseのstate commit、selector表示、rollbackを許可しない。切替中はselectorをdisableし、保存失敗時だけ切替前siteへ戻す。
+
 今後の最終形は、process-wide runtime値を読むdefault site向け起動・readiness経路も必要に応じて`SiteRuntime`生成へ寄せ、テストを含めてグローバル設定への依存をさらに減らすことである。
 
 ## ジェネレーターごとの差異

--- a/docs/architecture/multi-site-generator-design.md
+++ b/docs/architecture/multi-site-generator-design.md
@@ -225,7 +225,7 @@ preview proxyはCMSの認証済みadmin route配下に置く。直接`127.0.0.1:
 - 記事キャッシュは`repo_path + content_dir`でkey分割する。
 - preview adapter mapのlockはmapアクセス中だけ保持し、preview process操作中には保持しない。
 
-Frontendのsite selectorもsite IDを明示したconfig・記事一覧・Local Preview status・デプロイPreviewの取得を行う。site切替ごとにgenerationとAbortControllerを更新し、古いresponseのstate commit、selector表示、rollbackを許可しない。切替中はselectorをdisableし、保存失敗時だけ切替前siteへ戻す。
+Frontendのsite selectorもsite IDを明示したconfig・記事一覧・Local Preview status・デプロイPreviewの取得を行う。site切替ごとにgenerationとAbortControllerを更新し、古いresponseのstate commit、selector表示、rollbackを許可しない。Local Previewのstop/open/toggleとデプロイPreviewのcreate/retry/discard/publishも開始時のsite ID、generation、path、draft IDを保持し、await後に現在siteを検証する。切替中はselectorをdisableし、保存失敗時だけ切替前siteへ戻す。
 
 今後の最終形は、process-wide runtime値を読むdefault site向け起動・readiness経路も必要に応じて`SiteRuntime`生成へ寄せ、テストを含めてグローバル設定への依存をさらに減らすことである。
 

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -212,12 +212,12 @@ export async function runSync() {
     return await res.json();
 }
 
-export async function runPublish(path, draftID) {
-    const res = await fetchWithCSRF(withSite('/admin/api/publish'), {
+export async function runPublish(path, draftID, siteID = currentSite) {
+    const res = await fetchWithCSRF(withSite('/admin/api/publish', siteID), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            ...siteHeaders()
+            ...siteHeaders(siteID)
         },
         body: JSON.stringify({ path, draft_id: draftID })
     });
@@ -281,24 +281,24 @@ export async function fetchLocalPreviewStatus(signal, siteID = currentSite) {
     return await res.json();
 }
 
-export async function stopLocalPreviewContent() {
-    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/stop'), {
+export async function stopLocalPreviewContent(siteID = currentSite) {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/local/stop', siteID), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            ...siteHeaders()
+            ...siteHeaders(siteID)
         },
     });
     if (!res.ok) throw await responseError(res, "Local Live Preview stop failed");
     return await res.json();
 }
 
-export async function triggerPreviewDeployment(path, draftID) {
-    const res = await fetchWithCSRF(withSite('/admin/api/preview/deployments'), {
+export async function triggerPreviewDeployment(path, draftID, siteID = currentSite) {
+    const res = await fetchWithCSRF(withSite('/admin/api/preview/deployments', siteID), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            ...siteHeaders()
+            ...siteHeaders(siteID)
         },
         body: JSON.stringify({ path, draft_id: draftID })
     });
@@ -317,24 +317,24 @@ export async function fetchPreviewDeployment(draftID, signal, siteID = currentSi
     return await res.json();
 }
 
-async function postPreviewDeploymentAction(draftID, action) {
+async function postPreviewDeploymentAction(draftID, action, siteID = currentSite) {
     const id = encodeURIComponent(draftID);
-    const res = await fetchWithCSRF(withSite(`/admin/api/preview/deployments/${id}/${action}`), {
+    const res = await fetchWithCSRF(withSite(`/admin/api/preview/deployments/${id}/${action}`, siteID), {
         method: 'POST',
         headers: {
-            ...siteHeaders()
+            ...siteHeaders(siteID)
         }
     });
     if (!res.ok) throw new Error(`Failed to ${action} deployment preview`);
     return await res.json();
 }
 
-export function retryPreviewDeployment(draftID) {
-    return postPreviewDeploymentAction(draftID, 'retry');
+export function retryPreviewDeployment(draftID, siteID = currentSite) {
+    return postPreviewDeploymentAction(draftID, 'retry', siteID);
 }
 
-export function discardPreviewDeployment(draftID) {
-    return postPreviewDeploymentAction(draftID, 'discard');
+export function discardPreviewDeployment(draftID, siteID = currentSite) {
+    return postPreviewDeploymentAction(draftID, 'discard', siteID);
 }
 
 export async function fetchMedia(mode, path) {

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -29,15 +29,15 @@ export function initializeCurrentSite(registry) {
     }
 }
 
-function withSite(url) {
-    if (!currentSite) return url;
+function withSite(url, siteID = currentSite) {
+    if (!siteID) return url;
     const parsed = new URL(url, window.location.origin);
-    parsed.searchParams.set('site', currentSite);
+    parsed.searchParams.set('site', siteID);
     return parsed.pathname + parsed.search;
 }
 
-function siteHeaders() {
-    return currentSite ? { 'X-CMS-Site': currentSite } : {};
+function siteHeaders(siteID = currentSite) {
+    return siteID ? { 'X-CMS-Site': siteID } : {};
 }
 
 async function ensureCSRFToken(forceRefresh = false) {
@@ -85,8 +85,8 @@ async function responseError(res, fallback) {
     return error;
 }
 
-export async function fetchConfig() {
-    const res = await fetch(withSite('/admin/api/config'), { headers: siteHeaders() });
+export async function fetchConfig(siteID = currentSite, signal) {
+    const res = await fetch(withSite('/admin/api/config', siteID), { headers: siteHeaders(siteID), signal });
     if (!res.ok) throw new Error("Config fetch failed");
     return await res.json();
 }
@@ -97,8 +97,8 @@ export async function fetchSites() {
     return await res.json();
 }
 
-export async function fetchArticles() {
-    const res = await fetch(withSite('/admin/api/articles'), { headers: siteHeaders() });
+export async function fetchArticles(siteID = currentSite, signal) {
+    const res = await fetch(withSite('/admin/api/articles', siteID), { headers: siteHeaders(siteID), signal });
     if (res.status === 401) {
         window.location.href = "/admin/login";
         return null;
@@ -253,12 +253,12 @@ export async function updateLocalPreviewContent(payload, revision, signal) {
     return await res.json();
 }
 
-export async function resolveLocalPreviewArticleURL(path, signal) {
+export async function resolveLocalPreviewArticleURL(path, signal, siteID = currentSite) {
     const res = await fetchWithCSRF(withSite('/admin/api/preview/local/navigate'), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            ...siteHeaders()
+            ...siteHeaders(siteID)
         },
         body: JSON.stringify({ path }),
         signal
@@ -271,10 +271,10 @@ export async function resolveLocalPreviewArticleURL(path, signal) {
 // helper. The endpoint now resolves and returns the article URL directly.
 export const navigateLocalPreviewContent = resolveLocalPreviewArticleURL;
 
-export async function fetchLocalPreviewStatus(signal) {
+export async function fetchLocalPreviewStatus(signal, siteID = currentSite) {
     const url = '/admin/api/preview/local/status';
-    const res = await fetch(withSite(url), {
-        headers: siteHeaders(),
+    const res = await fetch(withSite(url, siteID), {
+        headers: siteHeaders(siteID),
         signal
     });
     if (!res.ok) throw await responseError(res, "Local Live Preview status failed");
@@ -306,10 +306,10 @@ export async function triggerPreviewDeployment(path, draftID) {
     return await res.json();
 }
 
-export async function fetchPreviewDeployment(draftID, signal) {
+export async function fetchPreviewDeployment(draftID, signal, siteID = currentSite) {
     const id = encodeURIComponent(draftID);
-    const res = await fetch(withSite(`/admin/api/preview/deployments/${id}`), {
-        headers: siteHeaders(),
+    const res = await fetch(withSite(`/admin/api/preview/deployments/${id}`, siteID), {
+        headers: siteHeaders(siteID),
         signal
     });
     if (res.status === 404) return null;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -32,22 +32,63 @@ let localPreviewURLResolutionGeneration = 0;
 let localPreviewFrontMatterKey = "";
 let localPreviewArticleURLKey = "";
 let localPreviewURLResolution = null;
+let siteSwitchGeneration = 0;
+let siteSwitchController = null;
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_FRESH_NAVIGATION_MAX_ATTEMPTS = 120;
+
+function beginSiteRequest(siteID) {
+    siteSwitchController?.abort();
+    const request = {
+        generation: ++siteSwitchGeneration,
+        siteID,
+        controller: new AbortController(),
+    };
+    siteSwitchController = request;
+    return request;
+}
+
+function isCurrentSiteRequest(request) {
+    return Boolean(
+        request &&
+        request.generation === siteSwitchGeneration &&
+        siteSwitchController === request
+    );
+}
+
+function isCurrentSiteContext(siteID, generation = siteSwitchGeneration) {
+    return API.getCurrentSite() === siteID && siteSwitchGeneration === generation;
+}
+
+function finishSiteRequest(request) {
+    if (siteSwitchController === request) siteSwitchController = null;
+}
+
+function setSiteSelectorDisabled(disabled) {
+    const selector = document.getElementById('site-selector');
+    if (selector) selector.disabled = disabled;
+}
 
 init();
 
 async function init() {
     initializeLocalPreviewFrame();
+    let initialRequest = null;
     try {
         siteRegistry = await API.fetchSites();
         API.initializeCurrentSite(siteRegistry);
-        UI.renderSiteSelector(siteRegistry, API.getCurrentSite(), switchSite);
-        await loadSiteData();
+        const initialSiteID = API.getCurrentSite();
+        initialRequest = beginSiteRequest(initialSiteID);
+        UI.renderSiteSelector(siteRegistry, initialSiteID, switchSite);
+        await loadSiteData(initialSiteID, initialRequest);
     } catch (e) {
-        console.error("Initial load failed", e);
-        UI.showToast("Failed to load site configuration", "error");
+        if (!initialRequest || isCurrentSiteRequest(initialRequest)) {
+            console.error("Initial load failed", e);
+            UI.showToast("Failed to load site configuration", "error");
+        }
+    } finally {
+        if (initialRequest) finishSiteRequest(initialRequest);
     }
 
     Editor.initAutoSave();
@@ -142,13 +183,23 @@ function resetLocalPreviewArticleURL() {
     localPreviewFrontMatterKey = "";
 }
 
-async function loadSiteData() {
+async function loadSiteData(siteID = API.getCurrentSite(), request = null) {
+    const generation = request?.generation ?? siteSwitchGeneration;
+    const isCurrent = () => (
+        (!request || isCurrentSiteRequest(request)) &&
+        isCurrentSiteContext(siteID, generation)
+    );
+    if (!isCurrent()) return false;
+
     stopLocalPreviewMonitoring();
     resetLocalPreviewArticleURL();
     localPreviewState = null;
 
-    cmsConfig = await API.fetchConfig();
-    const site = siteRegistry?.sites?.find(s => s.id === API.getCurrentSite());
+    const config = await API.fetchConfig(siteID, request?.controller.signal);
+    if (!isCurrent()) return false;
+
+    cmsConfig = config;
+    const site = siteRegistry?.sites?.find(s => s.id === siteID);
     if (!cmsConfig._cms) cmsConfig._cms = {};
     cmsConfig._cms.local_preview = site?.preview?.local_preview || { enabled: false, url: '' };
     Editor.setConfig(cmsConfig);
@@ -158,25 +209,34 @@ async function loadSiteData() {
     configureLocalPreviewPanel();
     UI.switchView('edit');
     if (localPreviewEnabled) {
-        await refreshLocalPreviewStatus();
-        scheduleLocalPreviewMonitoring();
+        await refreshLocalPreviewStatus(siteID, request, generation);
+        if (!isCurrent()) return false;
+        scheduleLocalPreviewMonitoring(siteID, generation);
     }
 
     deploymentEnabled = UI.configureDeploymentPreview(cmsConfig);
     deploymentState = null;
     UI.renderDeploymentState(null);
-    await refreshFileList();
+    await refreshFileList(siteID, request, generation);
+    return isCurrent();
 }
 
 async function switchSite(siteID) {
     const previousSiteID = API.getCurrentSite();
     if (!siteID || siteID === previousSiteID) return;
+    const request = beginSiteRequest(siteID);
+    let switchedSite = false;
+    setSiteSelectorDisabled(true);
 
     try {
         await Editor.flushPendingSave();
+        if (!isCurrentSiteRequest(request)) return;
     } catch (e) {
+        if (!isCurrentSiteRequest(request)) return;
         UI.showToast("Site switch cancelled: save failed", "error");
-        UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite);
+        UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite, true);
+        finishSiteRequest(request);
+        setSiteSelectorDisabled(false);
         return;
     }
 
@@ -184,31 +244,45 @@ async function switchSite(siteID) {
     stopDeploymentPolling();
     closeEmbeddedLocalPreview();
     API.setCurrentSite(siteID);
+    switchedSite = true;
     Editor.clearEditor();
     try {
-        await loadSiteData();
-        UI.renderSiteSelector(siteRegistry, siteID, switchSite);
+        const loaded = await loadSiteData(siteID, request);
+        if (!isCurrentSiteRequest(request) || !loaded) return;
+        UI.renderSiteSelector(siteRegistry, siteID, switchSite, false);
         const site = siteRegistry?.sites?.find(s => s.id === siteID);
         UI.showToast(`Switched to ${site?.name || siteID}`, "success");
     } catch (e) {
+        if (!isCurrentSiteRequest(request)) return;
+        if (!switchedSite) return;
         API.setCurrentSite(previousSiteID);
-        UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite);
+        Editor.clearEditor();
         try {
-            await loadSiteData();
+            await loadSiteData(previousSiteID, request);
         } catch (reloadErr) {
             console.error("Failed to reload previous site", reloadErr);
         }
+        if (!isCurrentSiteRequest(request)) return;
+        UI.renderSiteSelector(siteRegistry, previousSiteID, switchSite, false);
         UI.showToast("Failed to switch site: " + e.message, "error");
+    } finally {
+        if (isCurrentSiteRequest(request)) {
+            finishSiteRequest(request);
+            setSiteSelectorDisabled(false);
+        }
     }
 }
 
 async function loadFile(path) {
+    const siteID = API.getCurrentSite();
+    const generation = siteSwitchGeneration;
     stopDeploymentPolling();
     deploymentState = null;
     UI.renderDeploymentState(null);
     await Editor.loadFile(path);
+    if (!isCurrentSiteContext(siteID, generation)) return;
     if (Editor.getCurrentPath() !== path) {
-        await refreshLocalPreviewStatus();
+        await refreshLocalPreviewStatus(siteID, null, generation);
         return;
     }
 
@@ -222,27 +296,32 @@ async function loadFile(path) {
         }) ? 'split' : 'edit');
         try {
             await Editor.refreshLocalLivePreview();
+            if (!isCurrentSiteContext(siteID, generation)) return;
             const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
+            if (!isCurrentSiteContext(siteID, generation)) return;
             if (Editor.getCurrentPath() === path && !articleURL) {
                 throw new Error('generatorから記事URLを取得できませんでした');
             }
             if (Editor.getCurrentPath() === path) showEmbeddedLocalPreview();
         } catch (error) {
+            if (!isCurrentSiteContext(siteID, generation)) return;
             showLocalPreviewResolutionError(error);
         }
-        await refreshLocalPreviewStatus();
+        await refreshLocalPreviewStatus(siteID, null, generation);
     }
-    if (deploymentEnabled) await refreshDeploymentState();
+    if (deploymentEnabled) await refreshDeploymentState(siteID, generation);
 }
 
-async function refreshFileList() {
+async function refreshFileList(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteSwitchGeneration) {
+    if (!isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
     try {
-        const files = await API.fetchArticles();
-        if (files) {
+        const files = await API.fetchArticles(siteID, request?.controller.signal);
+        if (files && isCurrentSiteContext(siteID, generation) && (!request || isCurrentSiteRequest(request))) {
             UI.renderFileList(files, cmsConfig);
             return files;
         }
     } catch (e) {
+        if (e?.name === 'AbortError' || !isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
         UI.showToast("Failed to fetch file list", "error");
     }
     return null;
@@ -598,28 +677,32 @@ function stopLocalPreviewMonitoring() {
     localPreviewController = null;
 }
 
-function scheduleLocalPreviewMonitoring() {
-    if (!localPreviewEnabled) return;
+function scheduleLocalPreviewMonitoring(siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
+    if (!localPreviewEnabled || !isCurrentSiteContext(siteID, generation)) return;
     if (!localPreviewPollTimer) {
         localPreviewPollTimer = setTimeout(async () => {
             localPreviewPollTimer = null;
-            await refreshLocalPreviewStatus();
-            scheduleLocalPreviewMonitoring();
+            if (!isCurrentSiteContext(siteID, generation)) return;
+            await refreshLocalPreviewStatus(siteID, null, generation);
+            scheduleLocalPreviewMonitoring(siteID, generation);
         }, LOCAL_PREVIEW_POLL_MS);
     }
 }
 
-async function refreshLocalPreviewStatus() {
-    if (!localPreviewEnabled) return null;
+async function refreshLocalPreviewStatus(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteSwitchGeneration) {
+    if (!localPreviewEnabled || !isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
     if (localPreviewController) localPreviewController.abort();
     const controller = new AbortController();
     localPreviewController = controller;
     try {
-        const state = await API.fetchLocalPreviewStatus(controller.signal);
+        const state = await API.fetchLocalPreviewStatus(controller.signal, siteID);
+        if (!isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
         renderLocalPreviewState(state);
         return localPreviewState;
     } catch (e) {
-        if (e?.name !== 'AbortError') console.error('[LocalPreview] status failed', e);
+        if (e?.name !== 'AbortError' && isCurrentSiteContext(siteID, generation) && (!request || isCurrentSiteRequest(request))) {
+            console.error('[LocalPreview] status failed', e);
+        }
         return null;
     } finally {
         if (localPreviewController === controller) localPreviewController = null;
@@ -840,11 +923,11 @@ function stopDeploymentPolling() {
     }
 }
 
-function applyDeploymentState(state) {
+function applyDeploymentState(state, siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
     deploymentState = UI.normalizeDeploymentState(state);
     UI.renderDeploymentState(deploymentState);
     if (deploymentState?.status === 'queued' || deploymentState?.status === 'building') {
-        deploymentPollTimer = setTimeout(() => refreshDeploymentState(), 3000);
+        deploymentPollTimer = setTimeout(() => refreshDeploymentState(siteID, generation), 3000);
     }
 }
 
@@ -859,7 +942,8 @@ function markDeploymentPreviewStale() {
     });
 }
 
-async function refreshDeploymentState() {
+async function refreshDeploymentState(siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
+    if (!isCurrentSiteContext(siteID, generation)) return;
     stopDeploymentPolling();
     if (!deploymentEnabled || !Editor.getCurrentPath()) {
         applyDeploymentState(null);
@@ -870,14 +954,18 @@ async function refreshDeploymentState() {
     const controller = new AbortController();
     deploymentController = controller;
     try {
-        const state = await API.fetchPreviewDeployment(draftID, controller.signal);
-        if (path !== Editor.getCurrentPath() || draftID !== Editor.getDraftID()) return;
-        applyDeploymentState(state);
+        const state = await API.fetchPreviewDeployment(draftID, controller.signal, siteID);
+        if (
+            !isCurrentSiteContext(siteID, generation) ||
+            path !== Editor.getCurrentPath() ||
+            draftID !== Editor.getDraftID()
+        ) return;
+        applyDeploymentState(state, siteID, generation);
     } catch (e) {
-        if (e?.name !== 'AbortError') {
+        if (e?.name !== 'AbortError' && isCurrentSiteContext(siteID, generation)) {
             UI.showToast(e.message, 'error');
             if (deploymentState?.status === 'queued' || deploymentState?.status === 'building') {
-                deploymentPollTimer = setTimeout(() => refreshDeploymentState(), 5000);
+                deploymentPollTimer = setTimeout(() => refreshDeploymentState(siteID, generation), 5000);
             }
         }
     } finally {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,7 @@
 import * as API from './api.js';
 import * as UI from './ui.js';
 import * as Editor from './editor.js';
+import { createSiteRequestTracker } from './site_request.js';
 import {
     createLocalPreviewFrameController,
     LOCAL_PREVIEW_INITIAL_NAVIGATION_MAX_ATTEMPTS,
@@ -33,37 +34,25 @@ let localPreviewURLResolutionGeneration = 0;
 let localPreviewFrontMatterKey = "";
 let localPreviewArticleURLKey = "";
 let localPreviewURLResolution = null;
-let siteSwitchGeneration = 0;
-let siteSwitchController = null;
+const siteRequestTracker = createSiteRequestTracker();
 
 const LOCAL_PREVIEW_POLL_MS = 3000;
 const LOCAL_PREVIEW_FRESH_NAVIGATION_MAX_ATTEMPTS = 120;
 
 function beginSiteRequest(siteID) {
-    siteSwitchController?.abort();
-    const request = {
-        generation: ++siteSwitchGeneration,
-        siteID,
-        controller: new AbortController(),
-    };
-    siteSwitchController = request;
-    return request;
+    return siteRequestTracker.begin(siteID);
 }
 
 function isCurrentSiteRequest(request) {
-    return Boolean(
-        request &&
-        request.generation === siteSwitchGeneration &&
-        siteSwitchController === request
-    );
+    return siteRequestTracker.isCurrent(request);
 }
 
-function isCurrentSiteContext(siteID, generation = siteSwitchGeneration) {
-    return API.getCurrentSite() === siteID && siteSwitchGeneration === generation;
+function isCurrentSiteContext(siteID, generation = siteRequestTracker.generation) {
+    return API.getCurrentSite() === siteID && siteRequestTracker.generation === generation;
 }
 
 function finishSiteRequest(request) {
-    if (siteSwitchController === request) siteSwitchController = null;
+    siteRequestTracker.finish(request);
 }
 
 function setSiteSelectorDisabled(disabled) {
@@ -185,7 +174,7 @@ function resetLocalPreviewArticleURL() {
 }
 
 async function loadSiteData(siteID = API.getCurrentSite(), request = null) {
-    const generation = request?.generation ?? siteSwitchGeneration;
+    const generation = request?.generation ?? siteRequestTracker.generation;
     const isCurrent = () => (
         (!request || isCurrentSiteRequest(request)) &&
         isCurrentSiteContext(siteID, generation)
@@ -276,7 +265,7 @@ async function switchSite(siteID) {
 
 async function loadFile(path) {
     const siteID = API.getCurrentSite();
-    const generation = siteSwitchGeneration;
+    const generation = siteRequestTracker.generation;
     stopDeploymentPolling();
     deploymentState = null;
     UI.renderDeploymentState(null);
@@ -313,7 +302,7 @@ async function loadFile(path) {
     if (deploymentEnabled) await refreshDeploymentState(siteID, generation);
 }
 
-async function refreshFileList(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteSwitchGeneration) {
+async function refreshFileList(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteRequestTracker.generation) {
     if (!isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
     try {
         const files = await API.fetchArticles(siteID, request?.controller.signal);
@@ -474,7 +463,7 @@ function waitForLocalPreviewRetry(delay, signal) {
 
 function resolveLocalPreviewArticleURLState(
     frontMatterKey = localPreviewFrontMatterKey,
-    { requireFresh = false, siteID = API.getCurrentSite(), siteGeneration = siteSwitchGeneration } = {},
+    { requireFresh = false, siteID = API.getCurrentSite(), siteGeneration = siteRequestTracker.generation } = {},
 ) {
     if (!localPreviewEnabled || !Editor.getCurrentPath() || !isCurrentSiteContext(siteID, siteGeneration)) return Promise.resolve(null);
     const requestPath = Editor.getCurrentPath();
@@ -547,7 +536,7 @@ function resolveLocalPreviewArticleURLState(
     return resolution.promise;
 }
 
-function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL, { siteID = API.getCurrentSite(), siteGeneration = siteSwitchGeneration } = {}) {
+function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL, { siteID = API.getCurrentSite(), siteGeneration = siteRequestTracker.generation } = {}) {
     const requestPath = Editor.getCurrentPath();
     if (!requestPath || !cachedURL || !isCurrentSiteContext(siteID, siteGeneration)) return;
     void resolveLocalPreviewArticleURLState(frontMatterKey, { requireFresh: true, siteID, siteGeneration }).then((resolution) => {
@@ -576,7 +565,7 @@ async function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontM
 
 async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const requestPath = Editor.getCurrentPath();
     const context = { siteID, siteGeneration };
     const requestKey = localPreviewURLResolutionKey(frontMatterKey, siteID, requestPath);
@@ -697,7 +686,7 @@ function stopLocalPreviewMonitoring() {
     localPreviewController = null;
 }
 
-function scheduleLocalPreviewMonitoring(siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
+function scheduleLocalPreviewMonitoring(siteID = API.getCurrentSite(), generation = siteRequestTracker.generation) {
     if (!localPreviewEnabled || !isCurrentSiteContext(siteID, generation)) return;
     if (!localPreviewPollTimer) {
         localPreviewPollTimer = setTimeout(async () => {
@@ -709,7 +698,7 @@ function scheduleLocalPreviewMonitoring(siteID = API.getCurrentSite(), generatio
     }
 }
 
-async function refreshLocalPreviewStatus(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteSwitchGeneration) {
+async function refreshLocalPreviewStatus(siteID = API.getCurrentSite(), request = null, generation = request?.generation ?? siteRequestTracker.generation) {
     if (!localPreviewEnabled || !isCurrentSiteContext(siteID, generation) || (request && !isCurrentSiteRequest(request))) return null;
     if (localPreviewController) localPreviewController.abort();
     const controller = new AbortController();
@@ -731,7 +720,7 @@ async function refreshLocalPreviewStatus(siteID = API.getCurrentSite(), request 
 
 async function openLocalLivePreview() {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const isCurrent = () => isCurrentSiteContext(siteID, siteGeneration);
     if (!isCurrent()) return;
     if (!localPreviewEnabled || !localPreviewURL()) {
@@ -762,7 +751,7 @@ async function openLocalLivePreview() {
 
 async function toggleEmbeddedLocalPreview() {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const isCurrent = () => isCurrentSiteContext(siteID, siteGeneration);
     if (!isCurrent()) return;
     const wrapper = document.getElementById('local-preview-embed');
@@ -801,7 +790,7 @@ let localPreviewOperation = null;
 async function stopLocalLivePreview() {
     if (!localPreviewEnabled || localPreviewOperationInProgress) return;
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const operation = { siteID, siteGeneration };
     localPreviewOperation = operation;
     localPreviewOperationInProgress = true;
@@ -917,7 +906,7 @@ async function runSync() {
 
 async function runPublish(path, draftID) {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const isCurrent = () => (
         isCurrentSiteContext(siteID, siteGeneration) &&
         path === Editor.getCurrentPath() &&
@@ -987,7 +976,7 @@ function stopDeploymentPolling() {
     }
 }
 
-function applyDeploymentState(state, siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
+function applyDeploymentState(state, siteID = API.getCurrentSite(), generation = siteRequestTracker.generation) {
     deploymentState = UI.normalizeDeploymentState(state);
     UI.renderDeploymentState(deploymentState);
     if (deploymentState?.status === 'queued' || deploymentState?.status === 'building') {
@@ -1006,7 +995,7 @@ function markDeploymentPreviewStale() {
     });
 }
 
-async function refreshDeploymentState(siteID = API.getCurrentSite(), generation = siteSwitchGeneration) {
+async function refreshDeploymentState(siteID = API.getCurrentSite(), generation = siteRequestTracker.generation) {
     if (!isCurrentSiteContext(siteID, generation)) return;
     stopDeploymentPolling();
     if (!deploymentEnabled || !Editor.getCurrentPath()) {
@@ -1039,7 +1028,7 @@ async function refreshDeploymentState(siteID = API.getCurrentSite(), generation 
 
 async function updateDeploymentPreview() {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const path = Editor.getCurrentPath();
     const draftID = path ? Editor.getDraftID() : "";
     const isCurrent = () => (
@@ -1079,7 +1068,7 @@ async function updateDeploymentPreview() {
 
 async function retryDeploymentPreview() {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const path = Editor.getCurrentPath();
     const draftID = path ? Editor.getDraftID() : "";
     const isCurrent = () => (
@@ -1112,7 +1101,7 @@ async function retryDeploymentPreview() {
 
 async function discardDeploymentPreview() {
     const siteID = API.getCurrentSite();
-    const siteGeneration = siteSwitchGeneration;
+    const siteGeneration = siteRequestTracker.generation;
     const path = Editor.getCurrentPath();
     const draftID = path ? Editor.getDraftID() : "";
     const isCurrent = () => (

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -20,6 +20,7 @@ let deploymentState = null;
 let deploymentPollTimer = null;
 let deploymentController = null;
 let deploymentOperationInProgress = false;
+let deploymentOperation = null;
 let localPreviewEnabled = false;
 let localPreviewState = null;
 let localPreviewPollTimer = null;
@@ -297,7 +298,7 @@ async function loadFile(path) {
         try {
             await Editor.refreshLocalLivePreview();
             if (!isCurrentSiteContext(siteID, generation)) return;
-            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey(), { siteID, siteGeneration: generation });
             if (!isCurrentSiteContext(siteID, generation)) return;
             if (Editor.getCurrentPath() === path && !articleURL) {
                 throw new Error('generatorから記事URLを取得できませんでした');
@@ -441,8 +442,8 @@ function isLocalPreviewArticleURL(value) {
     }
 }
 
-function localPreviewURLResolutionKey(frontMatterKey) {
-    return [API.getCurrentSite(), Editor.getCurrentPath(), frontMatterKey || ""].join("\u0000");
+function localPreviewURLResolutionKey(frontMatterKey, siteID = API.getCurrentSite(), path = Editor.getCurrentPath()) {
+    return [siteID, path, frontMatterKey || ""].join("\u0000");
 }
 
 function localPreviewResolutionAbortError() {
@@ -471,10 +472,13 @@ function waitForLocalPreviewRetry(delay, signal) {
     });
 }
 
-function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMatterKey, { requireFresh = false } = {}) {
-    if (!localPreviewEnabled || !Editor.getCurrentPath()) return Promise.resolve(null);
+function resolveLocalPreviewArticleURLState(
+    frontMatterKey = localPreviewFrontMatterKey,
+    { requireFresh = false, siteID = API.getCurrentSite(), siteGeneration = siteSwitchGeneration } = {},
+) {
+    if (!localPreviewEnabled || !Editor.getCurrentPath() || !isCurrentSiteContext(siteID, siteGeneration)) return Promise.resolve(null);
     const requestPath = Editor.getCurrentPath();
-    const requestKey = localPreviewURLResolutionKey(frontMatterKey);
+    const requestKey = localPreviewURLResolutionKey(frontMatterKey, siteID, requestPath);
     if (!requireFresh && localPreviewArticleURL && localPreviewArticleURLKey === requestKey) {
         return Promise.resolve({
             url: localPreviewArticleURL,
@@ -504,10 +508,11 @@ function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMa
             if (controller.signal.aborted) throw localPreviewResolutionAbortError();
             if (
                 Editor.getCurrentPath() !== requestPath ||
-                localPreviewURLResolutionGeneration !== requestGeneration
+                localPreviewURLResolutionGeneration !== requestGeneration ||
+                !isCurrentSiteContext(siteID, siteGeneration)
             ) return null;
             try {
-                const result = await API.resolveLocalPreviewArticleURL(requestPath, controller.signal);
+                const result = await API.resolveLocalPreviewArticleURL(requestPath, controller.signal, siteID);
                 const articleURL = UI.safeExternalURL(result?.article_url || "");
                 if (!isLocalPreviewArticleURL(articleURL)) throw new Error('generator returned an invalid local preview URL');
                 const fresh = result?.fresh !== false && result?.metadata_status !== 'stale' && result?.status !== 'stale';
@@ -517,7 +522,8 @@ function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMa
                 }
                 if (
                     Editor.getCurrentPath() !== requestPath ||
-                    localPreviewURLResolutionGeneration !== requestGeneration
+                    localPreviewURLResolutionGeneration !== requestGeneration ||
+                    !isCurrentSiteContext(siteID, siteGeneration)
                 ) return null;
                 localPreviewArticleURL = articleURL;
                 localPreviewArticleURLFresh = fresh;
@@ -525,6 +531,7 @@ function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMa
                 return { url: articleURL, fresh, result, generation: requestGeneration };
             } catch (error) {
                 if (error?.name === 'AbortError') throw error;
+                if (!isCurrentSiteContext(siteID, siteGeneration)) return null;
                 const transient = error?.status === undefined || error?.status === 408 || error?.status === 425 || error?.status === 429 || error?.status >= 500;
                 if (!(requireFresh && attempt < maxAttempts && transient) && !shouldRetryLocalPreviewNavigation({ error, attempt })) throw error;
                 await waitForLocalPreviewRetry(localPreviewNavigationRetryDelay(attempt), controller.signal);
@@ -540,11 +547,16 @@ function resolveLocalPreviewArticleURLState(frontMatterKey = localPreviewFrontMa
     return resolution.promise;
 }
 
-function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL) {
+function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL, { siteID = API.getCurrentSite(), siteGeneration = siteSwitchGeneration } = {}) {
     const requestPath = Editor.getCurrentPath();
-    if (!requestPath || !cachedURL) return;
-    void resolveLocalPreviewArticleURLState(frontMatterKey, { requireFresh: true }).then((resolution) => {
-        if (!resolution || Editor.getCurrentPath() !== requestPath || resolution.generation !== localPreviewURLResolutionGeneration) return;
+    if (!requestPath || !cachedURL || !isCurrentSiteContext(siteID, siteGeneration)) return;
+    void resolveLocalPreviewArticleURLState(frontMatterKey, { requireFresh: true, siteID, siteGeneration }).then((resolution) => {
+        if (
+            !resolution ||
+            Editor.getCurrentPath() !== requestPath ||
+            resolution.generation !== localPreviewURLResolutionGeneration ||
+            !isCurrentSiteContext(siteID, siteGeneration)
+        ) return;
         if (resolution.url !== cachedURL && !localPreviewFrameController?.isDismissed()) {
             showEmbeddedLocalPreview({ reload: true });
         }
@@ -553,22 +565,28 @@ function reconcileFreshLocalPreviewArticleURL(frontMatterKey, cachedURL) {
     });
 }
 
-async function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterKey) {
-    const resolution = await resolveLocalPreviewArticleURLState(frontMatterKey);
+async function resolveLocalPreviewArticleURL(frontMatterKey = localPreviewFrontMatterKey, context = {}) {
+    const resolution = await resolveLocalPreviewArticleURLState(frontMatterKey, context);
+    if (context.siteID && !isCurrentSiteContext(context.siteID, context.siteGeneration)) return null;
     if (resolution?.url && !resolution.fresh) {
-        reconcileFreshLocalPreviewArticleURL(frontMatterKey, resolution.url);
+        reconcileFreshLocalPreviewArticleURL(frontMatterKey, resolution.url, context);
     }
     return resolution?.url || null;
 }
 
 async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") {
-    const requestKey = localPreviewURLResolutionKey(frontMatterKey);
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const requestPath = Editor.getCurrentPath();
+    const context = { siteID, siteGeneration };
+    const requestKey = localPreviewURLResolutionKey(frontMatterKey, siteID, requestPath);
+    if (!isCurrentSiteContext(siteID, siteGeneration)) return null;
     if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey && localPreviewArticleURLFresh) {
         return localPreviewArticleURL;
     }
     localPreviewFrontMatterKey = frontMatterKey;
     if (localPreviewArticleURL && localPreviewArticleURLKey === requestKey && !localPreviewArticleURLFresh) {
-        reconcileFreshLocalPreviewArticleURL(frontMatterKey, localPreviewArticleURL);
+        reconcileFreshLocalPreviewArticleURL(frontMatterKey, localPreviewArticleURL, context);
         return localPreviewArticleURL;
     }
     localPreviewArticleURL = "";
@@ -576,12 +594,14 @@ async function refreshLocalPreviewArticleURL(updateResult, frontMatterKey = "") 
     localPreviewArticleURLKey = "";
     if (!localPreviewEnabled || !Editor.getCurrentPath()) return null;
     try {
-        const articleURL = await resolveLocalPreviewArticleURL(frontMatterKey);
+        const articleURL = await resolveLocalPreviewArticleURL(frontMatterKey, context);
+        if (!isCurrentSiteContext(siteID, siteGeneration)) return null;
         if (articleURL && Editor.getCurrentPath() && !localPreviewFrameController?.isDismissed()) {
             showEmbeddedLocalPreview();
         }
         return articleURL;
     } catch (error) {
+        if (!isCurrentSiteContext(siteID, siteGeneration)) return null;
         showLocalPreviewResolutionError(error);
         return null;
     }
@@ -710,6 +730,10 @@ async function refreshLocalPreviewStatus(siteID = API.getCurrentSite(), request 
 }
 
 async function openLocalLivePreview() {
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const isCurrent = () => isCurrentSiteContext(siteID, siteGeneration);
+    if (!isCurrent()) return;
     if (!localPreviewEnabled || !localPreviewURL()) {
         UI.showToast('Local Live Preview is not configured', 'warning');
         return;
@@ -717,20 +741,30 @@ async function openLocalLivePreview() {
     try {
         if (Editor.getCurrentPath()) {
             await Editor.refreshLocalLivePreview();
-            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
+            if (!isCurrent()) return;
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey(), { siteID, siteGeneration });
+            if (!isCurrent()) return;
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }
+        if (!isCurrent()) return;
         const url = currentLocalPreviewURL();
         if (!url) throw new Error('記事URLを解決できませんでした');
         window.open(url, '_blank', 'noopener');
-        setTimeout(() => refreshLocalPreviewStatus(), 500);
+        setTimeout(() => {
+            if (isCurrent()) refreshLocalPreviewStatus(siteID, null, siteGeneration);
+        }, 500);
     } catch (e) {
+        if (!isCurrent()) return;
         showLocalPreviewResolutionError(e);
         UI.showToast('Local Live Previewを開けません: ' + e.message, 'error');
     }
 }
 
 async function toggleEmbeddedLocalPreview() {
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const isCurrent = () => isCurrentSiteContext(siteID, siteGeneration);
+    if (!isCurrent()) return;
     const wrapper = document.getElementById('local-preview-embed');
     const frame = document.getElementById('local-preview-frame');
     const btn = document.getElementById('local-preview-embed-btn');
@@ -745,31 +779,51 @@ async function toggleEmbeddedLocalPreview() {
         localPreviewFrameController?.resetDismissed();
         if (Editor.getCurrentPath()) {
             await Editor.refreshLocalLivePreview();
-            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey());
+            if (!isCurrent()) return;
+            const articleURL = await resolveLocalPreviewArticleURL(Editor.getCurrentLocalPreviewFrontMatterKey(), { siteID, siteGeneration });
+            if (!isCurrent()) return;
             if (!articleURL) throw new Error('generatorから記事URLを取得できませんでした');
         }
+        if (!isCurrent()) return;
         showEmbeddedLocalPreview({ reload: true });
-        setTimeout(() => refreshLocalPreviewStatus(), 500);
+        setTimeout(() => {
+            if (isCurrent()) refreshLocalPreviewStatus(siteID, null, siteGeneration);
+        }, 500);
     } catch (e) {
+        if (!isCurrent()) return;
         showLocalPreviewResolutionError(e);
         UI.showToast('埋め込みpreviewを開始できません: ' + e.message, 'error');
     }
 }
 
+let localPreviewOperation = null;
+
 async function stopLocalLivePreview() {
     if (!localPreviewEnabled || localPreviewOperationInProgress) return;
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const operation = { siteID, siteGeneration };
+    localPreviewOperation = operation;
     localPreviewOperationInProgress = true;
     try {
         await Editor.prepareLocalLivePreviewStop();
-        await API.stopLocalPreviewContent();
+        if (!isCurrentSiteContext(siteID, siteGeneration)) return;
+        await API.stopLocalPreviewContent(siteID);
+        if (!isCurrentSiteContext(siteID, siteGeneration)) return;
         resetLocalPreviewArticleURL();
         closeEmbeddedLocalPreview();
         UI.showToast('Local Live Previewを停止しました', 'success');
     } catch (e) {
+        if (!isCurrentSiteContext(siteID, siteGeneration)) return;
         UI.showToast('Local Live Previewを停止できません: ' + e.message, 'error');
     } finally {
-        localPreviewOperationInProgress = false;
-        await refreshLocalPreviewStatus();
+        if (localPreviewOperation === operation) {
+            localPreviewOperation = null;
+            localPreviewOperationInProgress = false;
+            if (isCurrentSiteContext(siteID, siteGeneration)) {
+                await refreshLocalPreviewStatus(siteID, null, siteGeneration);
+            }
+        }
     }
 }
 
@@ -862,6 +916,13 @@ async function runSync() {
 }
 
 async function runPublish(path, draftID) {
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const isCurrent = () => (
+        isCurrentSiteContext(siteID, siteGeneration) &&
+        path === Editor.getCurrentPath() &&
+        draftID === Editor.getDraftID()
+    );
     if (publishInProgress) {
         UI.showToast("Publish is already running", "warning");
         return;
@@ -883,16 +944,19 @@ async function runPublish(path, draftID) {
 
     try {
         await Editor.flushPendingSave();
-        const data = await Editor.runGitMutation(() => API.runPublish(path, draftID));
+        if (!isCurrent()) return;
+        const data = await Editor.runGitMutation(() => API.runPublish(path, draftID, siteID));
+        if (!isCurrent()) return;
         if (data.status === 'ok') {
             UI.showToast("PRを作成しました", "success");
             const url = UI.safeExternalURL(data.url);
             if (url) window.open(url, '_blank', 'noopener');
-            await refreshFileList();
+            await refreshFileList(siteID, null, siteGeneration);
         } else {
             UI.showToast("Publish Error: " + data.log, "error");
         }
     } catch (e) {
+        if (!isCurrent()) return;
         UI.showToast("Publish cancelled: " + e.message, "error");
     } finally {
         publishInProgress = false;
@@ -974,7 +1038,15 @@ async function refreshDeploymentState(siteID = API.getCurrentSite(), generation 
 }
 
 async function updateDeploymentPreview() {
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
     const path = Editor.getCurrentPath();
+    const draftID = path ? Editor.getDraftID() : "";
+    const isCurrent = () => (
+        isCurrentSiteContext(siteID, siteGeneration) &&
+        path === Editor.getCurrentPath() &&
+        draftID === Editor.getDraftID()
+    );
     if (!deploymentEnabled || !path) {
         UI.showToast("デプロイ対象の記事を選択してください", "warning");
         return;
@@ -983,52 +1055,92 @@ async function updateDeploymentPreview() {
         UI.showToast("デプロイ操作を実行中です", "warning");
         return;
     }
+    const operation = { siteID, siteGeneration, path, draftID };
+    deploymentOperation = operation;
     deploymentOperationInProgress = true;
     try {
         stopDeploymentPolling();
         await Editor.flushPendingSave();
+        if (!isCurrent()) return;
         applyDeploymentState({ status: 'queued', message: 'デプロイを開始しています…' });
-        const state = await Editor.runGitMutation(() => API.triggerPreviewDeployment(path, Editor.getDraftID()));
-        if (path === Editor.getCurrentPath()) applyDeploymentState(state);
+        const state = await Editor.runGitMutation(() => API.triggerPreviewDeployment(path, draftID, siteID));
+        if (isCurrent()) applyDeploymentState(state, siteID, siteGeneration);
     } catch (e) {
+        if (!isCurrent()) return;
         applyDeploymentState({ status: 'failed', message: e.message, retryable: false });
         UI.showToast(e.message, 'error');
     } finally {
-        deploymentOperationInProgress = false;
+        if (deploymentOperation === operation) {
+            deploymentOperation = null;
+            deploymentOperationInProgress = false;
+        }
     }
 }
 
 async function retryDeploymentPreview() {
-    if (!deploymentEnabled || !Editor.getCurrentPath()) return;
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const path = Editor.getCurrentPath();
+    const draftID = path ? Editor.getDraftID() : "";
+    const isCurrent = () => (
+        isCurrentSiteContext(siteID, siteGeneration) &&
+        path === Editor.getCurrentPath() &&
+        draftID === Editor.getDraftID()
+    );
+    if (!deploymentEnabled || !path) return;
     if (deploymentOperationInProgress) return;
+    const operation = { siteID, siteGeneration, path, draftID };
+    deploymentOperation = operation;
     deploymentOperationInProgress = true;
     try {
         stopDeploymentPolling();
-        applyDeploymentState({ ...deploymentState, status: 'queued', message: '再試行しています…' });
-        const state = await Editor.runGitMutation(() => API.retryPreviewDeployment(Editor.getDraftID()));
-        applyDeploymentState(state);
+        if (!isCurrent()) return;
+        applyDeploymentState({ ...deploymentState, status: 'queued', message: '再試行しています…' }, siteID, siteGeneration);
+        const state = await Editor.runGitMutation(() => API.retryPreviewDeployment(draftID, siteID));
+        if (isCurrent()) applyDeploymentState(state, siteID, siteGeneration);
     } catch (e) {
+        if (!isCurrent()) return;
         applyDeploymentState({ ...deploymentState, status: 'failed', message: e.message });
         UI.showToast(e.message, "error");
     } finally {
-        deploymentOperationInProgress = false;
+        if (deploymentOperation === operation) {
+            deploymentOperation = null;
+            deploymentOperationInProgress = false;
+        }
     }
 }
 
 async function discardDeploymentPreview() {
-    if (!deploymentEnabled || !Editor.getCurrentPath()) return;
+    const siteID = API.getCurrentSite();
+    const siteGeneration = siteSwitchGeneration;
+    const path = Editor.getCurrentPath();
+    const draftID = path ? Editor.getDraftID() : "";
+    const isCurrent = () => (
+        isCurrentSiteContext(siteID, siteGeneration) &&
+        path === Editor.getCurrentPath() &&
+        draftID === Editor.getDraftID()
+    );
+    if (!deploymentEnabled || !path) return;
     if (deploymentOperationInProgress) return;
     if (!confirm("このデプロイプレビューと下書きbranchを破棄しますか？")) return;
+    const operation = { siteID, siteGeneration, path, draftID };
+    deploymentOperation = operation;
     deploymentOperationInProgress = true;
     try {
         stopDeploymentPolling();
-        await Editor.runGitMutation(() => API.discardPreviewDeployment(Editor.getDraftID()));
+        if (!isCurrent()) return;
+        await Editor.runGitMutation(() => API.discardPreviewDeployment(draftID, siteID));
+        if (!isCurrent()) return;
         Editor.resetDraftID();
-        applyDeploymentState(null);
+        applyDeploymentState(null, siteID, siteGeneration);
         UI.showToast("デプロイプレビューを破棄しました", "success");
     } catch (e) {
+        if (!isCurrent()) return;
         UI.showToast(e.message, "error");
     } finally {
-        deploymentOperationInProgress = false;
+        if (deploymentOperation === operation) {
+            deploymentOperation = null;
+            deploymentOperationInProgress = false;
+        }
     }
 }

--- a/static/js/site_request.js
+++ b/static/js/site_request.js
@@ -1,0 +1,33 @@
+export function createSiteRequestTracker(controllerFactory = () => new AbortController()) {
+    let generation = 0;
+    let activeRequest = null;
+
+    return {
+        begin(siteID) {
+            activeRequest?.controller.abort();
+            const request = {
+                generation: ++generation,
+                siteID,
+                controller: controllerFactory(),
+            };
+            activeRequest = request;
+            return request;
+        },
+
+        isCurrent(request) {
+            return Boolean(
+                request &&
+                request.generation === generation &&
+                activeRequest === request
+            );
+        },
+
+        finish(request) {
+            if (activeRequest === request) activeRequest = null;
+        },
+
+        get generation() {
+            return generation;
+        },
+    };
+}

--- a/static/js/site_request.test.mjs
+++ b/static/js/site_request.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createSiteRequestTracker } from "./site_request.js";
+
+describe("site request tracker", () => {
+    it("aborts the initial site load when another site is selected", () => {
+        const tracker = createSiteRequestTracker();
+        const initialRequest = tracker.begin("site-a");
+        const switchRequest = tracker.begin("site-b");
+        const committedSites = [];
+        const commitIfCurrent = request => {
+            if (tracker.isCurrent(request)) committedSites.push(request.siteID);
+        };
+
+        assert.equal(initialRequest.controller.signal.aborted, true);
+        assert.equal(tracker.isCurrent(initialRequest), false);
+        assert.equal(tracker.isCurrent(switchRequest), true);
+        commitIfCurrent(initialRequest);
+        commitIfCurrent(switchRequest);
+        assert.deepEqual(committedSites, ["site-b"]);
+    });
+
+    it("aborts an existing site request and keeps only the latest request current", () => {
+        const tracker = createSiteRequestTracker();
+        const firstRequest = tracker.begin("site-a");
+        const secondRequest = tracker.begin("site-b");
+        const latestRequest = tracker.begin("site-c");
+        const committedSites = [];
+        const commitIfCurrent = request => {
+            if (tracker.isCurrent(request)) committedSites.push(request.siteID);
+        };
+
+        assert.equal(firstRequest.controller.signal.aborted, true);
+        assert.equal(secondRequest.controller.signal.aborted, true);
+        assert.equal(latestRequest.controller.signal.aborted, false);
+        assert.equal(tracker.isCurrent(firstRequest), false);
+        assert.equal(tracker.isCurrent(secondRequest), false);
+        assert.equal(tracker.isCurrent(latestRequest), true);
+        commitIfCurrent(firstRequest);
+        commitIfCurrent(secondRequest);
+        commitIfCurrent(latestRequest);
+        assert.deepEqual(committedSites, ["site-c"]);
+
+        tracker.finish(secondRequest);
+        assert.equal(tracker.isCurrent(latestRequest), true);
+    });
+});

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -86,7 +86,7 @@ export function toggleSidebar() {
     }
 }
 
-export function renderSiteSelector(registry, selectedSiteID, onChange) {
+export function renderSiteSelector(registry, selectedSiteID, onChange, disabled = false) {
     const container = document.getElementById('site-selector-container');
     if (!container) return;
 
@@ -104,6 +104,7 @@ export function renderSiteSelector(registry, selectedSiteID, onChange) {
 
     const select = document.createElement('select');
     select.id = 'site-selector';
+    select.disabled = disabled;
     sites.forEach(site => {
         const option = document.createElement('option');
         option.value = site.id;

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -900,6 +900,34 @@ describe("preview API contracts", () => {
         calls.forEach(call => assert.equal(call.options.headers["X-CMS-Site"], "site-b"));
     });
 
+    it("pins site-scoped destructive preview requests to their explicit site id", async () => {
+        const calls = [];
+        globalThis.fetch = async (url, options = {}) => {
+            calls.push({ url, options });
+            if (url === "/admin/api/csrf-token") {
+                return { ok: true, status: 200, json: async () => ({ csrf_token: "csrf" }) };
+            }
+            return { ok: true, status: 200, json: async () => ({ status: "ok" }) };
+        };
+
+        API.setCurrentSite("site-a");
+        await API.stopLocalPreviewContent("site-b");
+        await API.triggerPreviewDeployment("posts/one.md", "draft/id", "site-b");
+        await API.retryPreviewDeployment("draft/id", "site-b");
+        await API.discardPreviewDeployment("draft/id", "site-b");
+        await API.runPublish("posts/one.md", "draft/id", "site-b");
+
+        const requestCalls = calls.filter(call => call.url !== "/admin/api/csrf-token");
+        assert.deepEqual(requestCalls.map(call => call.url), [
+            "/admin/api/preview/local/stop?site=site-b",
+            "/admin/api/preview/deployments?site=site-b",
+            "/admin/api/preview/deployments/draft%2Fid/retry?site=site-b",
+            "/admin/api/preview/deployments/draft%2Fid/discard?site=site-b",
+            "/admin/api/publish?site=site-b",
+        ]);
+        requestCalls.forEach(call => assert.equal(call.options.headers["X-CMS-Site"], "site-b"));
+    });
+
     it("scopes Markdown, local lifecycle, and deployment operations to the selected site", async () => {
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -878,6 +878,28 @@ describe("Git Sync editor gate", () => {
 });
 
 describe("preview API contracts", () => {
+    it("pins site-scoped read requests to their explicit site id", async () => {
+        const calls = [];
+        globalThis.fetch = async (url, options = {}) => {
+            calls.push({ url, options });
+            return { ok: true, status: 200, json: async () => ({ status: "ready" }) };
+        };
+
+        API.setCurrentSite("site-a");
+        await API.fetchConfig("site-b");
+        await API.fetchArticles("site-b");
+        await API.fetchLocalPreviewStatus(undefined, "site-b");
+        await API.fetchPreviewDeployment("draft/id", undefined, "site-b");
+
+        assert.deepEqual(calls.map(call => call.url), [
+            "/admin/api/config?site=site-b",
+            "/admin/api/articles?site=site-b",
+            "/admin/api/preview/local/status?site=site-b",
+            "/admin/api/preview/deployments/draft%2Fid?site=site-b",
+        ]);
+        calls.forEach(call => assert.equal(call.options.headers["X-CMS-Site"], "site-b"));
+    });
+
     it("scopes Markdown, local lifecycle, and deployment operations to the selected site", async () => {
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {


### PR DESCRIPTION
## 概要
Issue #80対応。高速なsite切替で古いconfig・editor・file list・Local Preview・deployment stateが新siteへ混入しないよう、site generationとAbortControllerによる最新request優先制御を追加しました。config・記事一覧・Preview status・deployment取得には対象site IDを明示し、切替中はsite selectorをdisableします。
## テスト
- Node.js test: 45 passed, 3 skipped
- go test ./...
- go vet ./...
`nRefs #80