### PR TITLE
記事のstale overwriteをrevision競合検出で防止

### DIFF
--- a/docs/architecture/current-architecture.md
+++ b/docs/architecture/current-architecture.md
@@ -249,14 +249,16 @@ type Collection struct {
 ### 記事の保存
 
 ```
-1. クライアント: PUT /admin/api/article
+1. クライアント: POST /admin/api/article
 2. CSRFトークン検証
 3. SaveArticle() →
    a. パス検証 (SafeJoin)
    b. Front Matter正規化
-   c. ファイル書き込み
-   d. キャッシュ更新
-4. 成功応答
+   c. repository lock内で現在のcontent revisionを検証
+   d. revisionが一致しなければ409 Conflict
+   e. ファイル書き込み
+   f. 新revisionを返してキャッシュ更新
+4. 成功応答（新revision）
 ```
 
 ### 記事の公開

--- a/docs/guides/local-live-preview.md
+++ b/docs/guides/local-live-preview.md
@@ -153,6 +153,8 @@ generatorの作業ディレクトリは、Hugoでは元repository、Eleventyで�
 
 既存の3秒autosaveは保存機能として残りますが、Local Previewの250ms update経路はproduction working tree/Git index/refへ書き込みません。
 
+production記事のautosaveは記事内容のSHA-256 revisionを使った楽観的排他で保護します。記事GET時のrevisionを`base_revision`として保存へ送信し、Git Sync、別tab、別browser/deviceなどでproduction内容が変わっていればserverはHTTP 409を返して上書きを拒否します。frontendは409後にAutoSaveを停止し、記事の再読み込みまたはDiffで確認するよう通知します。Local Preview shadowの更新はこのproduction競合判定とは独立して動作します。
+
 ### revision / 複数tab
 
 各updateにはbrowser documentごとの`revision`を付けます。serverはこの値をtab間のordering判定には使わず、受信したrequestをsite workspaceへ適用してserver側のrevisionを採番します。同じsiteを複数tabから編集しても`409`にはならず、preview shadowはlast-write-winsです。production contentとGitの整合性は通常のsave側で管理します。

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -142,7 +142,8 @@ CSRFトークンを取得します。
         "tags": ["blog", "hello"]
     },
     "body": "# Hello\n\nThis is my first post.",
-    "format": "yaml"
+    "format": "yaml",
+    "revision": "sha256:..."
 }
 ```
 
@@ -168,15 +169,28 @@ CSRFトークンを取得します。
         "date": "2026-01-10T12:00:00Z",
         "draft": false
     },
-    "body": "# Updated Content\n\nNew content here."
+    "body": "# Updated Content\n\nNew content here.",
+    "base_revision": "sha256:..."
 }
 ```
 
 **レスポンス**:
 ```json
 {
-    "status": "ok",
-    "log": "Saved"
+    "status": "saved",
+    "revision": "sha256:..."
+}
+```
+
+`base_revision`はGETで取得した記事のrevisionです。サーバー上の内容が変更されている場合は、記事を上書きせずHTTP 409を返します。
+
+```json
+{
+    "status": "error",
+    "code": "CONFLICT",
+    "message": "Article was changed externally; reload before saving",
+    "path": "posts/2026-01-10-hello/index.md",
+    "current_revision": "sha256:..."
 }
 ```
 
@@ -198,10 +212,9 @@ CSRFトークンを取得します。
 **レスポンス**:
 ```json
 {
-    "status": "ok",
-    "data": {
-        "path": "posts/20260110-new-article/index.md"
-    }
+    "status": "created",
+    "path": "posts/20260110-new-article/index.md",
+    "revision": "sha256:..."
 }
 ```
 
@@ -218,8 +231,15 @@ CSRFトークンを取得します。
 
 記事を削除します。
 
-**クエリパラメータ**:
-- `path` (必須): 記事のパス
+**リクエストボディ**:
+```json
+{
+    "path": "posts/2026-01-10-hello/index.md",
+    "base_revision": "sha256:..."
+}
+```
+
+`base_revision`が現在のrevisionと一致しない場合、記事は削除せずHTTP 409を返します。
 
 **レスポンス**:
 ```json

--- a/pkg/handlers/api.go
+++ b/pkg/handlers/api.go
@@ -91,10 +91,16 @@ func GetArticle(c *gin.Context) {
 		ErrorNotFound(c, "File not found")
 		return
 	}
+	revision := services.ArticleRevision(content)
 
 	fm, body, format, err := services.ParseFrontMatter(content)
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{"content": string(content)})
+		c.JSON(http.StatusOK, models.Article{
+			Path:       targetPath,
+			Content:    string(content),
+			RawContent: string(content),
+			Revision:   revision,
+		})
 		return
 	}
 
@@ -104,6 +110,7 @@ func GetArticle(c *gin.Context) {
 		FrontMatter: fm,
 		Body:        body,
 		Format:      format,
+		Revision:    revision,
 	})
 }
 
@@ -145,13 +152,26 @@ func SaveArticle(c *gin.Context) {
 		finalContent = []byte(art.Content)
 	}
 
+	currentRevision, err := services.ArticleRevisionForPath(fullPath)
+	if err != nil {
+		ErrorInternal(c, "Failed to check article revision")
+		return
+	}
+	if currentRevision != art.BaseRevision {
+		respondArticleRevisionConflict(c, art.Path, currentRevision)
+		return
+	}
+
 	if err := os.WriteFile(fullPath, finalContent, 0644); err != nil {
 		ErrorInternal(c, "Save failed")
 		return
 	}
 
 	services.UpdateCacheForRuntime(runtime, art.Path)
-	c.JSON(http.StatusOK, gin.H{"status": "saved"})
+	c.JSON(http.StatusOK, gin.H{
+		"status":   "saved",
+		"revision": services.ArticleRevision(finalContent),
+	})
 }
 
 func CreateArticle(c *gin.Context) {
@@ -241,12 +261,21 @@ func CreateArticle(c *gin.Context) {
 		contentRelPath = filepath.ToSlash(contentRelPath)
 
 		services.UpdateCacheForRuntime(runtime, contentRelPath)
-		c.JSON(http.StatusOK, gin.H{"status": "created", "path": contentRelPath})
+		c.JSON(http.StatusOK, gin.H{
+			"status":   "created",
+			"path":     contentRelPath,
+			"revision": services.ArticleRevision(content),
+		})
 		return
 	}
 
 	// Legacy/Direct path logic
 	if req.Path == "" || strings.Contains(req.Path, "..") {
+		ErrorBadRequest(c, "Invalid path")
+		return
+	}
+	fullPath := services.SafeJoin(runtime.RepoPath, runtime.ContentDir, req.Path)
+	if fullPath == "" {
 		ErrorBadRequest(c, "Invalid path")
 		return
 	}
@@ -262,7 +291,16 @@ func CreateArticle(c *gin.Context) {
 	}
 
 	services.UpdateCacheForRuntime(runtime, req.Path)
-	c.JSON(http.StatusOK, gin.H{"status": "created", "log": log})
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		ErrorInternal(c, "Content creation succeeded but revision could not be read")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"status":   "created",
+		"log":      log,
+		"revision": services.ArticleRevision(content),
+	})
 }
 
 func GetDiff(c *gin.Context) {
@@ -350,7 +388,8 @@ func DeleteArticle(c *gin.Context) {
 		return
 	}
 	var req struct {
-		Path string `json:"path"`
+		Path         string `json:"path"`
+		BaseRevision string `json:"base_revision"`
 	}
 	if err := c.BindJSON(&req); err != nil {
 		ErrorBadRequest(c, "Invalid JSON")
@@ -361,9 +400,28 @@ func DeleteArticle(c *gin.Context) {
 		ErrorBadRequest(c, "Invalid path")
 		return
 	}
+	fullPath := services.SafeJoin(runtime.RepoPath, runtime.ContentDir, req.Path)
+	if fullPath == "" {
+		ErrorBadRequest(c, "Invalid path")
+		return
+	}
 
 	unlock := services.LockRepositoryOperation()
 	defer unlock()
+
+	currentRevision, err := services.ArticleRevisionForPath(fullPath)
+	if err != nil {
+		ErrorInternal(c, "Failed to check article revision")
+		return
+	}
+	if currentRevision == "" {
+		ErrorNotFound(c, "File not found")
+		return
+	}
+	if currentRevision != req.BaseRevision {
+		respondArticleRevisionConflict(c, req.Path, currentRevision)
+		return
+	}
 
 	// Invalidate Eleventy metadata before deleting the shadow article. This
 	// makes URL resolution return a rebuilding state while the old file is
@@ -385,6 +443,16 @@ func DeleteArticle(c *gin.Context) {
 	// releasing the generator runtime for the next article.
 	syncLocalPreviewContentResource(runtime, filepath.ToSlash(filepath.Join(runtime.ContentDir, req.Path)), true, false)
 	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+}
+
+func respondArticleRevisionConflict(c *gin.Context, path, currentRevision string) {
+	c.JSON(http.StatusConflict, gin.H{
+		"status":           "error",
+		"code":             ErrCodeConflict,
+		"message":          "Article was changed externally; reload before saving",
+		"path":             path,
+		"current_revision": currentRevision,
+	})
 }
 
 func GetConfig(c *gin.Context) {

--- a/pkg/handlers/article_revision_test.go
+++ b/pkg/handlers/article_revision_test.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"hugo-cms/pkg/config"
+	"hugo-cms/pkg/models"
+	"hugo-cms/pkg/services"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func setupArticleRevisionTest(t *testing.T) string {
+	t.Helper()
+	restoreSiteScopeConfig(t)
+	repoPath := t.TempDir()
+	config.DefaultSiteID = "default"
+	config.Sites = nil
+	config.RepoPath = repoPath
+	config.ContentDir = "content"
+	contentPath := filepath.Join(repoPath, "content", "posts", "article.md")
+	if err := os.MkdirAll(filepath.Dir(contentPath), 0755); err != nil {
+		t.Fatalf("create content directory: %v", err)
+	}
+	if err := os.WriteFile(contentPath, []byte("original"), 0644); err != nil {
+		t.Fatalf("write article: %v", err)
+	}
+	return contentPath
+}
+
+func getArticleRevision(t *testing.T) string {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/api/article?path=posts/article.md", nil)
+	GetArticle(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GetArticle() status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var article models.Article
+	if err := json.Unmarshal(w.Body.Bytes(), &article); err != nil {
+		t.Fatalf("decode article: %v", err)
+	}
+	return article.Revision
+}
+
+func saveArticleForRevisionTest(t *testing.T, article models.Article) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(article)
+	if err != nil {
+		t.Fatalf("encode article: %v", err)
+	}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/api/article", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	SaveArticle(c)
+	return w
+}
+
+func TestArticleSaveRejectsStaleRevisionAndReturnsLatestRevision(t *testing.T) {
+	contentPath := setupArticleRevisionTest(t)
+	baseRevision := getArticleRevision(t)
+
+	if err := os.WriteFile(contentPath, []byte("remote update"), 0644); err != nil {
+		t.Fatalf("write remote update: %v", err)
+	}
+	staleResponse := saveArticleForRevisionTest(t, models.Article{
+		Path:         "posts/article.md",
+		Content:      "stale local update",
+		BaseRevision: baseRevision,
+	})
+	if staleResponse.Code != http.StatusConflict {
+		t.Fatalf("stale save status = %d, body = %s", staleResponse.Code, staleResponse.Body.String())
+	}
+	content, err := os.ReadFile(contentPath)
+	if err != nil {
+		t.Fatalf("read article after stale save: %v", err)
+	}
+	if string(content) != "remote update" {
+		t.Fatalf("stale save overwrote article with %q", content)
+	}
+
+	latestRevision := services.ArticleRevision([]byte("remote update"))
+	successResponse := saveArticleForRevisionTest(t, models.Article{
+		Path:         "posts/article.md",
+		Content:      "explicitly reloaded update",
+		BaseRevision: latestRevision,
+	})
+	if successResponse.Code != http.StatusOK {
+		t.Fatalf("current save status = %d, body = %s", successResponse.Code, successResponse.Body.String())
+	}
+	var response map[string]string
+	if err := json.Unmarshal(successResponse.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode save response: %v", err)
+	}
+	wantRevision := services.ArticleRevision([]byte("explicitly reloaded update"))
+	if response["revision"] != wantRevision {
+		t.Fatalf("save revision = %q, want %q", response["revision"], wantRevision)
+	}
+}
+
+func TestArticleRevisionIsScopedToEachArticle(t *testing.T) {
+	contentPath := setupArticleRevisionTest(t)
+	otherPath := filepath.Join(filepath.Dir(contentPath), "other.md")
+	if err := os.WriteFile(otherPath, []byte("other original"), 0644); err != nil {
+		t.Fatalf("write other article: %v", err)
+	}
+	baseRevision := getArticleRevision(t)
+	if err := os.WriteFile(otherPath, []byte("other remote update"), 0644); err != nil {
+		t.Fatalf("write other remote update: %v", err)
+	}
+
+	response := saveArticleForRevisionTest(t, models.Article{
+		Path:         "posts/article.md",
+		Content:      "article update",
+		BaseRevision: baseRevision,
+	})
+	if response.Code != http.StatusOK {
+		t.Fatalf("save after unrelated article update status = %d, body = %s", response.Code, response.Body.String())
+	}
+}
+
+func TestArticleDeleteRejectsStaleRevision(t *testing.T) {
+	contentPath := setupArticleRevisionTest(t)
+	baseRevision := getArticleRevision(t)
+	if err := os.WriteFile(contentPath, []byte("remote update"), 0644); err != nil {
+		t.Fatalf("write remote update: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"path":          "posts/article.md",
+		"base_revision": baseRevision,
+	})
+	if err != nil {
+		t.Fatalf("encode delete request: %v", err)
+	}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/api/delete", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	DeleteArticle(c)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("stale delete status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if _, err := os.Stat(contentPath); err != nil {
+		t.Fatalf("stale delete removed article: %v", err)
+	}
+}

--- a/pkg/models/article.go
+++ b/pkg/models/article.go
@@ -2,12 +2,14 @@ package models
 
 // Article represents a content file in the CMS.
 type Article struct {
-	Path        string                 `json:"path"`
-	Title       string                 `json:"title"`
-	Content     string                 `json:"content,omitempty"`     // Raw content (backward compatibility)
-	RawContent  string                 `json:"raw_content,omitempty"` // Original bytes for no-op preview synchronization
-	FrontMatter map[string]interface{} `json:"frontmatter,omitempty"`
-	Body        string                 `json:"body,omitempty"`
-	Format      string                 `json:"format,omitempty"` // yaml, toml, json
-	IsDirty     bool                   `json:"is_dirty"`
+	Path         string                 `json:"path"`
+	Title        string                 `json:"title"`
+	Content      string                 `json:"content,omitempty"`     // Raw content (backward compatibility)
+	RawContent   string                 `json:"raw_content,omitempty"` // Original bytes for no-op preview synchronization
+	FrontMatter  map[string]interface{} `json:"frontmatter,omitempty"`
+	Body         string                 `json:"body,omitempty"`
+	Format       string                 `json:"format,omitempty"` // yaml, toml, json
+	IsDirty      bool                   `json:"is_dirty"`
+	Revision     string                 `json:"revision,omitempty"`
+	BaseRevision string                 `json:"base_revision,omitempty"`
 }

--- a/pkg/services/article_revision.go
+++ b/pkg/services/article_revision.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+// ArticleRevision returns the stable, content-based revision used by the
+// production article optimistic-concurrency contract.
+func ArticleRevision(content []byte) string {
+	digest := sha256.Sum256(content)
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+// ArticleRevisionForPath returns an empty revision when the article does not
+// exist. This makes the empty revision the explicit "article absent" version
+// for create/delete conflict checks.
+func ArticleRevisionForPath(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return ArticleRevision(content), nil
+}

--- a/pkg/services/article_revision_test.go
+++ b/pkg/services/article_revision_test.go
@@ -1,0 +1,30 @@
+package services
+
+import (
+	"testing"
+)
+
+func TestArticleRevisionIsContentBased(t *testing.T) {
+	first := ArticleRevision([]byte("article"))
+	second := ArticleRevision([]byte("article"))
+	changed := ArticleRevision([]byte("article\n"))
+	if first != second {
+		t.Fatalf("same content revisions differ: %q != %q", first, second)
+	}
+	if first == changed {
+		t.Fatalf("different content revisions match: %q", first)
+	}
+	if len(first) != len("sha256:")+64 {
+		t.Fatalf("revision = %q, want sha256 prefix and 64 hex characters", first)
+	}
+}
+
+func TestArticleRevisionForPathReturnsEmptyForMissingArticle(t *testing.T) {
+	revision, err := ArticleRevisionForPath(t.TempDir() + "/missing.md")
+	if err != nil {
+		t.Fatalf("ArticleRevisionForPath() error = %v", err)
+	}
+	if revision != "" {
+		t.Fatalf("missing article revision = %q, want empty", revision)
+	}
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -73,16 +73,19 @@ async function fetchWithCSRF(url, options) {
 }
 
 async function responseError(res, fallback) {
-    let message = fallback;
-    try {
-        const data = await res.json();
-        message = data?.message || data?.error || fallback;
-    } catch (_) {
+	let message = fallback;
+	let data = null;
+	try {
+		data = await res.json();
+		message = data?.message || data?.error || fallback;
+	} catch (_) {
         // Keep the stable fallback when the server did not return JSON.
     }
-    const error = new Error(message);
-    error.status = res.status;
-    return error;
+	const error = new Error(message);
+	error.status = res.status;
+	error.code = data?.code || "";
+	error.currentRevision = data?.current_revision || "";
+	return error;
 }
 
 export async function fetchConfig(siteID = currentSite, signal) {
@@ -107,40 +110,31 @@ export async function fetchArticles(siteID = currentSite, signal) {
 }
 
 export async function fetchArticle(path, signal) {
-    const params = new URLSearchParams({ path });
-    const res = await fetch(withSite(`/admin/api/article?${params.toString()}`), { headers: siteHeaders(), signal });
-    if (!res.ok) throw new Error("Failed to load article");
-    return await res.json();
+	const params = new URLSearchParams({ path });
+	const res = await fetch(withSite(`/admin/api/article?${params.toString()}`), { headers: siteHeaders(), signal });
+	if (!res.ok) throw await responseError(res, "Failed to load article");
+	return await res.json();
 }
 
 export async function saveArticle(payload) {
-    await ensureCSRFToken();
-    const res = await fetch(withSite('/admin/api/article'), {
-        method: 'POST',
-        headers: {
+	const request = () => fetch(withSite('/admin/api/article'), {
+		method: 'POST',
+		headers: {
             'Content-Type': 'application/json',
             ...siteHeaders(),
             ...getCSRFHeaders()
-        },
-        body: JSON.stringify(payload)
-    });
-    if (res.status === 403) {
-        resetCSRFToken();
-        await ensureCSRFToken(true);
-        const retryRes = await fetch(withSite('/admin/api/article'), {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                ...siteHeaders(),
-                ...getCSRFHeaders()
-            },
-            body: JSON.stringify(payload)
-        });
-        if (!retryRes.ok) throw new Error("Save failed");
-        return await retryRes.json();
-    }
-    if (!res.ok) throw new Error("Save failed");
-    return await res.json();
+		},
+		body: JSON.stringify(payload)
+	});
+	await ensureCSRFToken();
+	let res = await request();
+	if (res.status === 403) {
+		resetCSRFToken();
+		await ensureCSRFToken(true);
+		res = await request();
+	}
+	if (!res.ok) throw await responseError(res, "Save failed");
+	return await res.json();
 }
 
 export async function createArticle(arg1, arg2) {
@@ -168,22 +162,19 @@ export async function createArticle(arg1, arg2) {
     return await res.json();
 }
 
-export async function deleteArticle(path) {
-    await ensureCSRFToken();
-    const res = await fetch(withSite('/admin/api/delete'), {
+export async function deleteArticle(path, baseRevision = "") {
+	await ensureCSRFToken();
+	const res = await fetch(withSite('/admin/api/delete'), {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             ...siteHeaders(),
             ...getCSRFHeaders()
         },
-        body: JSON.stringify({ path })
-    });
-    if (!res.ok) {
-        const data = await res.json();
-        throw new Error(data.message || data.error || "Delete failed");
-    }
-    return await res.json();
+		body: JSON.stringify({ path, base_revision: baseRevision })
+	});
+	if (!res.ok) throw await responseError(res, "Delete failed");
+	return await res.json();
 }
 
 export async function getDiff(payload) {

--- a/static/js/editor.js
+++ b/static/js/editor.js
@@ -17,11 +17,13 @@ let localPreviewRevision = 0;
 let articleLoadGeneration = 0;
 let articleLoadController = null;
 let gitSyncInProgress = false;
+let articleRevisionConflictPath = "";
 const localPreviewInflight = new Set();
 
 const PREVIEW_DEBOUNCE_MS = 180;
 const LOCAL_PREVIEW_DEBOUNCE_MS = 250;
 const GIT_SYNC_WRITE_PAUSED_MESSAGE = "Git Sync is in progress";
+const ARTICLE_REVISION_CONFLICT_MESSAGE = "この記事は別tabまたは外部で更新されました。ResetまたはDiffで確認してください。";
 const gitMutationInflight = new Set();
 
 export function getCurrentPath() {
@@ -30,7 +32,7 @@ export function getCurrentPath() {
 
 export function hasUnsavedChanges() {
     if (!currentPath || currentPath === deletingPath) return false;
-    return JSON.stringify(getPayload()) !== lastSavedPayload;
+    return serializePayload(getPayload()) !== lastSavedPayload;
 }
 
 function setEditorWritePaused(paused) {
@@ -163,6 +165,7 @@ export function clearEditor() {
     lastSavedPayload = "";
     lastQueuedPayload = "";
     deletingPath = "";
+    articleRevisionConflictPath = "";
 
     const display = document.getElementById('filename-display');
     if (display) display.textContent = "Select a file...";
@@ -209,6 +212,7 @@ function handleEditorChange() {
 function triggerAutoSave() {
     if (gitSyncInProgress || !currentPath) return;
     if (currentPath === deletingPath) return;
+    if (articleRevisionConflictPath === currentPath) return;
     clearAutoSaveTimer();
 
     // Debounce 3 seconds
@@ -239,6 +243,24 @@ function updateSaveStatus(msg, type) {
     }
     else if (type === 'error') el.style.color = '#d67a7a';
     else el.style.color = '#888';
+}
+
+function isArticleRevisionConflict(error) {
+    return error?.status === 409;
+}
+
+function markArticleRevisionConflict() {
+    if (!currentPath) return;
+    articleRevisionConflictPath = currentPath;
+    clearAutoSaveTimer();
+    updateSaveStatus("外部更新を検出", "error");
+    UI.showToast(ARTICLE_REVISION_CONFLICT_MESSAGE, "warning");
+}
+
+function serializePayload(payload) {
+    if (!payload) return "";
+    const { base_revision: _baseRevision, ...contentPayload } = payload;
+    return JSON.stringify(contentPayload);
 }
 
 function cancelMarkdownPreview() {
@@ -401,6 +423,7 @@ export async function flushLocalPreviewBeforeArticleSwitch(flush = refreshLocalL
 
 export async function execAutoSave() {
     if (gitSyncInProgress) return false;
+    if (articleRevisionConflictPath === currentPath) return false;
     return queueCurrentSave("Auto Saving...");
 }
 
@@ -416,7 +439,7 @@ async function queueCurrentSave(statusMessage) {
         }
 
         const payloadObj = getPayload();
-        const payloadStr = JSON.stringify(payloadObj);
+        const payloadStr = serializePayload(payloadObj);
 
         if (payloadStr === lastSavedPayload) {
             return false;
@@ -426,14 +449,23 @@ async function queueCurrentSave(statusMessage) {
         const operation = saveQueue.then(async () => {
             updateSaveStatus(statusMessage, "saving");
             try {
-                await API.saveArticle(payloadObj);
-                lastSavedPayload = payloadStr;
+                const response = await API.saveArticle(payloadObj);
+                if (currentData?.path === payloadObj.path && response?.revision) {
+                    currentData.revision = response.revision;
+                }
+                if (serializePayload(getPayload()) === payloadStr) {
+                    lastSavedPayload = serializePayload(getPayload());
+                }
                 console.log("[AutoSave] Saved:", payloadObj.path);
                 updateSaveStatus("Saved", "saved");
                 return true;
             } catch (e) {
                 console.error("[AutoSave] Failed:", e);
-                updateSaveStatus("Save Failed", "error");
+                if (isArticleRevisionConflict(e)) {
+                    markArticleRevisionConflict();
+                } else {
+                    updateSaveStatus("Save Failed", "error");
+                }
                 throw e;
             } finally {
                 if (lastQueuedPayload === payloadStr) {
@@ -504,13 +536,14 @@ export async function loadFile(path, { allowDuringGitSync = false } = {}) {
 
         currentPath = path;
         currentData = data;
+        articleRevisionConflictPath = "";
         resetLocalPreviewClientState();
         const display = document.getElementById('filename-display');
         if (display) display.textContent = path;
         UI.updateEditorContent(data, path, cmsConfig);
         setEditorWritePaused(gitSyncInProgress);
 
-        lastSavedPayload = JSON.stringify(getPayload());
+        lastSavedPayload = serializePayload(getPayload());
         lastQueuedPayload = "";
         await refreshMarkdownPreview({ allowDuringGitSync });
 
@@ -530,9 +563,16 @@ export async function loadFile(path, { allowDuringGitSync = false } = {}) {
 
 function getPayload() {
     if (currentData?.path === currentPath && typeof currentData.raw_content === 'string' && currentData.raw_content !== '') {
-        return { path: currentPath, content: currentData.raw_content };
+        return {
+            path: currentPath,
+            content: currentData.raw_content,
+            base_revision: currentData.revision || "",
+        };
     }
-    const payload = { path: currentPath };
+    const payload = {
+        path: currentPath,
+        base_revision: currentData?.path === currentPath ? currentData.revision || "" : "",
+    };
     const fm = UI.collectFrontMatter();
     if (fm) {
         payload.frontmatter = fm;
@@ -552,6 +592,9 @@ export async function saveFile() {
     if (currentPath === deletingPath) {
         return UI.showToast("Article deletion is in progress", "warning");
     }
+    if (articleRevisionConflictPath === currentPath) {
+        return UI.showToast(ARTICLE_REVISION_CONFLICT_MESSAGE, "warning");
+    }
 
     clearAutoSaveTimer();
 
@@ -559,7 +602,9 @@ export async function saveFile() {
         await queueCurrentSave("Saving...");
         UI.showToast("File saved successfully", "success");
     } catch (e) {
-        UI.showToast("Error saving: " + e.message, "error");
+        if (!isArticleRevisionConflict(e)) {
+            UI.showToast("Error saving: " + e.message, "error");
+        }
     }
 }
 
@@ -590,7 +635,7 @@ export async function deleteFile(refreshListCb) {
         // article in the resident workspace.
         await waitForLocalPreviewUpdates();
         assertGitSyncWritesAllowed();
-        await runGitMutation(() => API.deleteArticle(pathToDelete));
+        await runGitMutation(() => API.deleteArticle(pathToDelete, currentData?.revision || ""));
         // Production deletion is committed at this point. The server removes
         // the corresponding file from the site-scoped preview workspace while
         // keeping the generator runtime alive for the next article.
@@ -614,6 +659,8 @@ export async function deleteFile(refreshListCb) {
     } catch (e) {
         if (deleted) {
             UI.showToast("Article deleted, but refreshing the editor failed: " + e.message, "warning");
+        } else if (isArticleRevisionConflict(e)) {
+            markArticleRevisionConflict();
         } else {
             UI.showToast("Delete failed: " + e.message, "error");
         }

--- a/static/js/ui.test.mjs
+++ b/static/js/ui.test.mjs
@@ -42,6 +42,7 @@ const {
     flushPendingSave,
     getOrCreateDraftID,
     getCurrentPath,
+    hasUnsavedChanges,
     initAutoSave,
     isGitSyncInProgress,
     loadFile,
@@ -683,6 +684,34 @@ describe("Local Preview destructive operations", () => {
         }
     });
 
+    it("stops autosave after a production revision conflict without retrying", async () => {
+        const harness = createArticleSwitchHarness({
+            saveResponse: () => ({
+                ok: false,
+                status: 409,
+                json: async () => ({
+                    code: "CONFLICT",
+                    message: "Article was changed externally; reload before saving",
+                    current_revision: "sha256:remote",
+                }),
+            }),
+        });
+        try {
+            await loadFile("posts/a.md");
+            harness.calls.length = 0;
+            harness.editor.value = "stale editor content";
+
+            await assert.rejects(execAutoSave(), error => error.status === 409);
+            assert.equal(hasUnsavedChanges(), true);
+            assert.equal(harness.calls.filter(call => call.url.endsWith("/admin/api/article") && call.options.method === "POST").length, 1);
+
+            assert.equal(await execAutoSave(), false);
+            assert.equal(harness.calls.filter(call => call.url.endsWith("/admin/api/article") && call.options.method === "POST").length, 1);
+        } finally {
+            harness.restore();
+        }
+    });
+
     for (const staleResult of ["success", "failure"]) {
         it(`keeps the newest article when an older load finishes ${staleResult} later`, async () => {
             const bFetchStarted = deferred();
@@ -878,6 +907,29 @@ describe("Git Sync editor gate", () => {
 });
 
 describe("preview API contracts", () => {
+    it("sends the production base revision and preserves conflict details", async () => {
+        const calls = [];
+        globalThis.fetch = async (url, options = {}) => {
+            calls.push({ url, options });
+            return {
+                ok: false,
+                status: 409,
+                json: async () => ({
+                    code: "CONFLICT",
+                    message: "Article was changed externally; reload before saving",
+                    current_revision: "sha256:remote",
+                }),
+            };
+        };
+
+        API.setCurrentSite("site-a");
+        await assert.rejects(
+            API.saveArticle({ path: "posts/one.md", content: "stale", base_revision: "sha256:old" }),
+            error => error.status === 409 && error.code === "CONFLICT" && error.currentRevision === "sha256:remote",
+        );
+        assert.equal(JSON.parse(calls[0].options.body).base_revision, "sha256:old");
+    });
+
     it("pins site-scoped read requests to their explicit site id", async () => {
         const calls = [];
         globalThis.fetch = async (url, options = {}) => {


### PR DESCRIPTION
## 概要
Issue #81に対応し、記事単位のserver-side optimistic concurrencyを導入しました。

## 変更内容
- 記事GET時に内容SHA-256 revisionを返却
- save/delete時にbase_revisionを検証し、不一致はHTTP 409で拒否
- save/create成功時に新revisionを返却
- 409後はfrontendのAutoSaveを停止し、再読み込み/Diffを促す
- Local Preview shadow更新はproduction競合判定から分離
- revision競合、記事単位の独立性、AutoSave再試行停止のテストを追加
- API/アーキテクチャドキュメントを更新

## 検証
- go test ./...
- go vet ./...
- Node.js構文チェック
- Node.jsテスト: 53件中50件成功、3件スキップ

Closes #81